### PR TITLE
Replace reactor's deprecated API

### DIFF
--- a/src/main/java/io/lettuce/core/tracing/BraveTracing.java
+++ b/src/main/java/io/lettuce/core/tracing/BraveTracing.java
@@ -483,7 +483,7 @@ public class BraveTracing implements Tracing {
         @Override
         public Mono<TraceContext> getTraceContextLater() {
 
-            return Mono.subscriberContext()
+            return Mono.deferContextual(Mono::justOrEmpty)
                     .filter(it -> it.hasKey(Span.class) || it.hasKey(brave.propagation.TraceContext.class)).map(it -> {
 
                         if (it.hasKey(Span.class)) {

--- a/src/main/java/io/lettuce/core/tracing/Tracing.java
+++ b/src/main/java/io/lettuce/core/tracing/Tracing.java
@@ -81,7 +81,7 @@ public interface Tracing {
      * @return the {@link TraceContextProvider}.
      */
     static Mono<TraceContextProvider> getContext() {
-        return Mono.subscriberContext().filter(c -> c.hasKey(TraceContextProvider.class))
+        return Mono.deferContextual(Mono::justOrEmpty).filter(c -> c.hasKey(TraceContextProvider.class))
                 .map(c -> c.get(TraceContextProvider.class));
     }
 

--- a/src/test/java/io/lettuce/core/tracing/BraveTracingIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/tracing/BraveTracingIntegrationTests.java
@@ -178,7 +178,7 @@ class BraveTracingIntegrationTests extends TestSupport {
 
         StatefulRedisConnection<String, String> connect = client.connect();
         connect.reactive().ping() //
-                .subscriberContext(it -> it.put(TraceContext.class, trace.context())) //
+                .contextWrite(it -> it.put(TraceContext.class, trace.context())) //
                 .as(StepVerifier::create) //
                 .expectNext("PONG").verifyComplete();
 
@@ -200,7 +200,7 @@ class BraveTracingIntegrationTests extends TestSupport {
         StatefulRedisConnection<String, String> connect = client.connect();
         connect.reactive().set("foo", "bar") //
                 .then(connect.reactive().get("foo")) //
-                .subscriberContext(it -> it.put(TraceContext.class, trace.context())) //
+                .contextWrite(it -> it.put(TraceContext.class, trace.context())) //
                 .as(StepVerifier::create) //
                 .expectNext("bar").verifyComplete();
 
@@ -224,8 +224,7 @@ class BraveTracingIntegrationTests extends TestSupport {
 
         StatefulRedisConnection<String, String> connect = client.connect();
         connect.reactive().set("foo", "bar").then(connect.reactive().get("foo"))
-                .subscriberContext(io.lettuce.core.tracing.Tracing
-                        .withTraceContextProvider(() -> BraveTracing.BraveTraceContext.create(trace.context()))) //
+                .contextWrite(io.lettuce.core.tracing.Tracing.withTraceContextProvider(() -> BraveTracing.BraveTraceContext.create(trace.context()))) //
                 .as(StepVerifier::create) //
                 .expectNext("bar").verifyComplete();
 


### PR DESCRIPTION
Replace deprecated `subscriberContext()` with either `deferContextual` or `contextWrite`

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
