### PR TITLE
Initial commit for dual publishing TopologyRefreshEvent to EventBus

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/event/TopologyRefreshEvent.java
+++ b/src/main/java/io/lettuce/core/cluster/event/TopologyRefreshEvent.java
@@ -4,6 +4,10 @@ import java.util.List;
 
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.event.Event;
+import io.lettuce.core.event.DurationalEvent;
+
+import static io.lettuce.core.event.DurationalEvent.EventStatus.COMPLETED;
+import static io.lettuce.core.event.DurationalEvent.EventStatus.IN_PROGRESS;
 
 /**
  * Event for initiating a topology refresh.
@@ -11,16 +15,27 @@ import io.lettuce.core.event.Event;
  * @author Mark Paluch
  * @since 6.1
  */
-public class TopologyRefreshEvent implements Event {
+public class TopologyRefreshEvent implements DurationalEvent, Event {
 
     private final List<RedisURI> topologyRefreshSource;
+    private EventStatus status;
 
     public TopologyRefreshEvent(List<RedisURI> topologyRefreshSource) {
         this.topologyRefreshSource = topologyRefreshSource;
+        this.status = IN_PROGRESS;
     }
 
     public List<RedisURI> getTopologyRefreshSource() {
         return topologyRefreshSource;
     }
 
+    @Override
+    public void completeEvent() {
+        this.status = COMPLETED;
+    }
+
+    @Override
+    public DurationalEvent.EventStatus getEventStatus() {
+        return status;
+    }
 }

--- a/src/main/java/io/lettuce/core/event/DurationalEvent.java
+++ b/src/main/java/io/lettuce/core/event/DurationalEvent.java
@@ -1,0 +1,18 @@
+package io.lettuce.core.event;
+
+
+public interface DurationalEvent {
+    enum EventStatus {
+        /**
+         * An IN_PROGRESS event indicates the start of series actions and might have future event indicating the completion.
+         */
+        IN_PROGRESS,
+        /**
+         * A COMPLETED event is in its final status and indicates the completion of previous event
+         * and will not have future event indicating status change.
+         */
+        COMPLETED
+    }
+    void completeEvent();
+    EventStatus getEventStatus();
+}

--- a/src/main/java/io/lettuce/core/event/jfr/EventRecorder.java
+++ b/src/main/java/io/lettuce/core/event/jfr/EventRecorder.java
@@ -1,10 +1,14 @@
 package io.lettuce.core.event.jfr;
 
+import io.lettuce.core.event.DurationalEvent;
 import io.lettuce.core.event.Event;
+import io.lettuce.core.event.EventBus;
+import io.lettuce.core.event.RecordableEvent;
 
 /**
  * Event recorder that can delegate events from the {@link io.lettuce.core.event.EventBus} into a recording facility such as
- * JFR. Transforming an {@link Event} into a recordable event is subject to the actual {@link EventRecorder} implementation.
+ * JFR and make dual publishing for {@link io.lettuce.core.event.DurationalEvent} to {@link io.lettuce.core.event.EventBus}.
+ * Transforming an {@link Event} into a recordable event is subject to the actual {@link EventRecorder} implementation.
  * <p>
  * You can record data by launching the application with recording enabled:
  * {@code java -XX:StartFlightRecording:filename=recording.jfr,duration=10s -jar app.jar}.
@@ -31,12 +35,29 @@ public interface EventRecorder {
     void record(Event event);
 
     /**
+     * Record an event and publish an {@link DurationalEvent.EventStatus#COMPLETED} event to bus.
+     *
+     * @param event the event to record, must not be {@code null}.
+     * @param eventBus the event bus for dual publishing, must not be {@code null}.
+     */
+    <T extends DurationalEvent & Event> void record(T event, EventBus eventBus);
+
+    /**
      * Start recording an event. This method returns a {@link RecordableEvent} that can be recorded by calling
      * {@link RecordableEvent#record()}. These events can be used to measure time between start and record.
      *
      * @param event the event to record, must not be {@code null}.
      */
     RecordableEvent start(Event event);
+
+    /**
+     * Start recording an event and publish an {@link DurationalEvent.EventStatus#IN_PROGRESS} event to bus. This method returns a {@link RecordableEvent} that can be recorded by calling
+     * {@link RecordableEvent#record()}. These events can be used to measure time between start and record.
+     *
+     * @param event the event to record, must not be {@code null}.
+     * @param eventBus the event bus for dual publishing, must not be {@code null}.
+     */
+    <T extends DurationalEvent & Event> RecordableEvent start(T event, EventBus eventBus);
 
     /**
      * Interface defining a recordable event that is recorded on calling {@link #record()}.


### PR DESCRIPTION
[Publish TopologyRefreshEvent to event bus #2809](https://github.com/redis/lettuce/discussions/2809)

Update: 2024-04-07 

Only include interface change to get a sense of direction before larger change.

Some reasoning:
1. Creating a new interface called `DurationalEvent` to capture the traits of event thats not ephemeral or instantaneous.
I didn't reuse the Event interface because most of events that implements it are instantaneous and I don't want them to
carry traits that could indicate anything that's related to *duration*.
2. Adding new methods in `EventRecorder` to explicitly handle dual publishing (recording with recorder and publishing with event bus or only recording). This seems to be the most straight forward and I am also open to creating a new wrapper class for dual publishing only.
3. Reusing `TopologyRefreshEvent` as I suspect there are many people subscribing to it from EventBus already. I am also open to create new events class dedicated for the start and end for topology refresh operation.




<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
