### PR TITLE
Send the CLIENT SETINFO command in a fire-and-forget way

### DIFF
--- a/src/test/java/io/lettuce/core/RedisHandshakeUnitTests.java
+++ b/src/test/java/io/lettuce/core/RedisHandshakeUnitTests.java
@@ -3,7 +3,9 @@ package io.lettuce.core;
 import static org.assertj.core.api.Assertions.*;
 
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletionStage;
 
 import org.junit.jupiter.api.Test;
 
@@ -18,6 +20,8 @@ import io.netty.channel.embedded.EmbeddedChannel;
  * @author Mark Paluch
  */
 class RedisHandshakeUnitTests {
+
+    public static final String ERR_UNKNOWN_COMMAND = "ERR unknown command 'CLIENT', with args beginning with: 'SETINFO' 'lib-name' 'Lettuce'";
 
     @Test
     void handshakeWithResp3ShouldPass() {
@@ -69,6 +73,34 @@ class RedisHandshakeUnitTests {
         hello.complete();
 
         assertThat(state.getNegotiatedProtocolVersion()).isEqualTo(ProtocolVersion.RESP2);
+    }
+
+    @Test
+    void handshakeFireAndForgetPostHandshake() {
+
+        EmbeddedChannel channel = new EmbeddedChannel(true, false);
+
+        ConnectionMetadata connectionMetdata = new ConnectionMetadata();
+        connectionMetdata.setLibraryName("library-name");
+        connectionMetdata.setLibraryVersion("library-version");
+
+        ConnectionState state = new ConnectionState();
+        state.setCredentialsProvider(new StaticCredentialsProvider(null, null));
+        state.apply(connectionMetdata);
+        RedisHandshake handshake = new RedisHandshake(null, false, state);
+        CompletionStage<Void> handshakeInit = handshake.initialize(channel);
+
+        AsyncCommand<String, String, Map<String, String>> hello = channel.readOutbound();
+        helloResponse(hello.getOutput());
+        hello.complete();
+
+        List<AsyncCommand<String, String, Map<String, String>>> postHandshake = channel.readOutbound();
+        postHandshake.get(0).getOutput().setError(ERR_UNKNOWN_COMMAND);
+        postHandshake.get(0).completeExceptionally(new RedisException(ERR_UNKNOWN_COMMAND));
+        postHandshake.get(0).complete();
+
+        assertThat(postHandshake.size()).isEqualTo(2);
+        assertThat(handshakeInit.toCompletableFuture().isCompletedExceptionally()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
Closes #2817 

This solution aims to bring consistency between the Lettuce driver and most other drivers maintained by the Redis team.
The current approach is - instead of probing for the version of the remote server and deciding based on that wether or not to send the CLIENT SETINFO command - to always send it and ignore the server response. There are two main reasons behind this: different flavors of the Redis server handle this in different versions and also the information sent is not critical to the operation of the driver, so failures should not necessary terminate the connection.

1. Tested against Redis 6.0 - verified no connection failures are shown
2. Tested against Redis  (unstable) - verified no connection failures are shown; and that CLIENT LIST contains the expected data on the `lib-name` and `lib-ver` are set properly.
3. Added unit tests

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
