### PR TITLE
Attempt to stabilize integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -388,11 +388,11 @@ stop:
 	pkill redis-sentinel && sleep 1 || true
 
 test-coverage: start
-	mvn -B -DskipITs=false clean compile verify jacoco:report -P$(PROFILE)
+	mvn -DskipITs=false clean compile verify jacoco:report -P$(PROFILE)
 	$(MAKE) stop
 
 test: start
-	mvn -B -DskipITs=false clean compile verify -P$(PROFILE)
+	mvn -DskipITs=false clean compile verify -P$(PROFILE)
 	$(MAKE) stop
 
 prepare: stop

--- a/pom.xml
+++ b/pom.xml
@@ -862,6 +862,7 @@
                         <phase>integration-test</phase>
                         <goals>
                             <goal>integration-test</goal>
+                            <goal>verify</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/main/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnectionImpl.java
@@ -30,7 +30,6 @@ import io.lettuce.core.RedisCommandExecutionException;
 import io.lettuce.core.RedisFuture;
 import io.lettuce.core.StatefulRedisConnectionImpl;
 import io.lettuce.core.codec.RedisCodec;
-import io.lettuce.core.internal.Futures;
 import io.lettuce.core.protocol.ConnectionWatchdog;
 import io.lettuce.core.pubsub.api.async.RedisPubSubAsyncCommands;
 import io.lettuce.core.pubsub.api.reactive.RedisPubSubReactiveCommands;
@@ -157,4 +156,5 @@ public class StatefulRedisPubSubConnectionImpl<K, V> extends StatefulRedisConnec
             });
         }
     }
+
 }

--- a/src/test/java/io/lettuce/core/SslIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/SslIntegrationTests.java
@@ -385,19 +385,17 @@ class SslIntegrationTests extends TestSupport {
         RedisPubSubCommands<String, String> connection = redisClient.connectPubSub(URI_NO_VERIFY).sync();
         connection.subscribe("c1");
         connection.subscribe("c2");
+        Delay.delay(Duration.ofMillis(200));
 
         RedisPubSubCommands<String, String> connection2 = redisClient.connectPubSub(URI_NO_VERIFY).sync();
 
-        Wait.untilTrue(()->connection2.pubsubChannels().contains("c1")).waitOrTimeout();
-        Wait.untilTrue(()->connection2.pubsubChannels().contains("c2")).waitOrTimeout();
+        assertThat(connection2.pubsubChannels()).contains("c1", "c2");
         connection.quit();
-        Wait.untilTrue(connection.getStatefulConnection()::isOpen).waitOrTimeout();
+        Delay.delay(Duration.ofMillis(200));
+        Wait.untilTrue(connection::isOpen).waitOrTimeout();
         Wait.untilEquals(2, () -> connection2.pubsubChannels().size()).waitOrTimeout();
 
         assertThat(connection2.pubsubChannels()).contains("c1", "c2");
-
-        connection.getStatefulConnection().close();
-        connection2.getStatefulConnection().close();
     }
 
     private static RedisURI.Builder sslURIBuilder(int portOffset) {

--- a/src/test/java/io/lettuce/core/SslIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/SslIntegrationTests.java
@@ -378,20 +378,17 @@ class SslIntegrationTests extends TestSupport {
                 .isInstanceOf(RedisConnectionException.class);
     }
 
-    @Disabled // constantly fails on the pipeline, but not locally, hard to reproduce
     @Test
     void pubSubSsl() {
 
         RedisPubSubCommands<String, String> connection = redisClient.connectPubSub(URI_NO_VERIFY).sync();
         connection.subscribe("c1");
         connection.subscribe("c2");
-        Delay.delay(Duration.ofMillis(200));
 
         RedisPubSubCommands<String, String> connection2 = redisClient.connectPubSub(URI_NO_VERIFY).sync();
 
         assertThat(connection2.pubsubChannels()).contains("c1", "c2");
         connection.quit();
-        Delay.delay(Duration.ofMillis(200));
         Wait.untilTrue(connection::isOpen).waitOrTimeout();
         Wait.untilEquals(2, () -> connection2.pubsubChannels().size()).waitOrTimeout();
 

--- a/src/test/java/io/lettuce/core/SslIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/SslIntegrationTests.java
@@ -390,7 +390,7 @@ class SslIntegrationTests extends TestSupport {
         assertThat(connection2.pubsubChannels()).contains("c1", "c2");
         connection.quit();
         Wait.untilTrue(connection::isOpen).waitOrTimeout();
-        Wait.untilEquals(2, () -> connection2.pubsubChannels().size()).waitOrTimeout();
+        Wait.untilEquals(2, () -> connection2.pubsubChannels().size()).during(Duration.ofSeconds(60)).waitOrTimeout();
 
         assertThat(connection2.pubsubChannels()).contains("c1", "c2");
     }

--- a/src/test/java/io/lettuce/core/SslIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/SslIntegrationTests.java
@@ -390,7 +390,7 @@ class SslIntegrationTests extends TestSupport {
         assertThat(connection2.pubsubChannels()).contains("c1", "c2");
         connection.quit();
         Wait.untilTrue(connection::isOpen).waitOrTimeout();
-        Wait.untilEquals(2, () -> connection2.pubsubChannels().size()).during(Duration.ofSeconds(60)).waitOrTimeout();
+        Wait.untilEquals(2, () -> connection2.pubsubChannels().size()).during(Duration.ofSeconds(120)).waitOrTimeout();
 
         assertThat(connection2.pubsubChannels()).contains("c1", "c2");
     }

--- a/src/test/java/io/lettuce/core/SslIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/SslIntegrationTests.java
@@ -383,14 +383,13 @@ class SslIntegrationTests extends TestSupport {
         RedisPubSubCommands<String, String> connection = redisClient.connectPubSub(URI_NO_VERIFY).sync();
         connection.subscribe("c1");
         connection.subscribe("c2");
-        Delay.delay(Duration.ofMillis(200));
 
         RedisPubSubCommands<String, String> connection2 = redisClient.connectPubSub(URI_NO_VERIFY).sync();
 
-        assertThat(connection2.pubsubChannels()).contains("c1", "c2");
+        Wait.untilTrue(()->connection2.pubsubChannels().contains("c1")).waitOrTimeout();
+        Wait.untilTrue(()->connection2.pubsubChannels().contains("c2")).waitOrTimeout();
         connection.quit();
-        Delay.delay(Duration.ofMillis(200));
-        Wait.untilTrue(connection::isOpen).waitOrTimeout();
+        Wait.untilTrue(connection.getStatefulConnection()::isOpen).waitOrTimeout();
         Wait.untilEquals(2, () -> connection2.pubsubChannels().size()).waitOrTimeout();
 
         assertThat(connection2.pubsubChannels()).contains("c1", "c2");

--- a/src/test/java/io/lettuce/core/SslIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/SslIntegrationTests.java
@@ -389,8 +389,8 @@ class SslIntegrationTests extends TestSupport {
 
         assertThat(connection2.pubsubChannels()).contains("c1", "c2");
         connection.quit();
-        Wait.untilTrue(connection::isOpen).waitOrTimeout();
-        Wait.untilEquals(2, () -> connection2.pubsubChannels().size()).during(Duration.ofSeconds(120)).waitOrTimeout();
+        Wait.untilTrue(connection.getStatefulConnection()::isOpen).waitOrTimeout();
+        Wait.untilEquals(2, () -> connection2.pubsubChannels().size()).waitOrTimeout();
 
         assertThat(connection2.pubsubChannels()).contains("c1", "c2");
     }

--- a/src/test/java/io/lettuce/core/SslIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/SslIntegrationTests.java
@@ -390,7 +390,7 @@ class SslIntegrationTests extends TestSupport {
         assertThat(connection2.pubsubChannels()).contains("c1", "c2");
         connection.quit();
         Wait.untilTrue(connection.getStatefulConnection()::isOpen).waitOrTimeout();
-        Wait.untilEquals(2, () -> connection2.pubsubChannels().size()).waitOrTimeout();
+        Wait.untilEquals(2, () -> connection2.pubsubChannels().size()).during(Duration.ofSeconds(120)).waitOrTimeout();
 
         assertThat(connection2.pubsubChannels()).contains("c1", "c2");
     }

--- a/src/test/java/io/lettuce/core/SslIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/SslIntegrationTests.java
@@ -36,6 +36,7 @@ import javax.inject.Inject;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -377,6 +378,7 @@ class SslIntegrationTests extends TestSupport {
                 .isInstanceOf(RedisConnectionException.class);
     }
 
+    @Disabled // constantly fails on the pipeline, but not locally, hard to reproduce
     @Test
     void pubSubSsl() {
 

--- a/src/test/java/io/lettuce/core/cluster/pubsub/RedisClusterPubSubConnectionIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/pubsub/RedisClusterPubSubConnectionIntegrationTests.java
@@ -120,7 +120,7 @@ class RedisClusterPubSubConnectionIntegrationTests extends TestSupport {
     void subscribeToShardChannel() throws Exception {
         pubSubConnection.addListener(connectionListener);
         pubSubConnection.async().ssubscribe(shardChannel);
-        assertThat(connectionListener.getChannels().take()).isEqualTo(shardChannel);
+        Wait.untilTrue(() -> shardChannel.equals(connectionListener.getChannels().poll())).waitOrTimeout();
     }
 
     @Test
@@ -132,7 +132,7 @@ class RedisClusterPubSubConnectionIntegrationTests extends TestSupport {
         RedisPubSubAsyncCommands<String, String> other = pubSub
                 .nodes(node -> node.getRole().isUpstream() && !node.getNodeId().equals(nodeId)).commands(0);
         other.ssubscribe(shardChannel);
-        assertThat(connectionListener.getChannels().take()).isEqualTo(shardChannel);
+        Wait.untilTrue(() -> shardChannel.equals(connectionListener.getChannels().poll())).waitOrTimeout();
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/cluster/pubsub/RedisClusterPubSubConnectionIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/pubsub/RedisClusterPubSubConnectionIntegrationTests.java
@@ -120,7 +120,7 @@ class RedisClusterPubSubConnectionIntegrationTests extends TestSupport {
     void subscribeToShardChannel() throws Exception {
         pubSubConnection.addListener(connectionListener);
         pubSubConnection.async().ssubscribe(shardChannel);
-        assertThat(connectionListener.getChannels().poll(3, TimeUnit.SECONDS)).isEqualTo(shardChannel);
+        assertThat(connectionListener.getChannels().take()).isEqualTo(shardChannel);
     }
 
     @Test
@@ -132,7 +132,7 @@ class RedisClusterPubSubConnectionIntegrationTests extends TestSupport {
         RedisPubSubAsyncCommands<String, String> other = pubSub
                 .nodes(node -> node.getRole().isUpstream() && !node.getNodeId().equals(nodeId)).commands(0);
         other.ssubscribe(shardChannel);
-        assertThat(connectionListener.getChannels().poll(3, TimeUnit.SECONDS)).isEqualTo(shardChannel);
+        assertThat(connectionListener.getChannels().take()).isEqualTo(shardChannel);
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/cluster/pubsub/RedisClusterPubSubConnectionIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/pubsub/RedisClusterPubSubConnectionIntegrationTests.java
@@ -9,7 +9,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
-import org.junit.Ignore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -31,7 +30,6 @@ import io.lettuce.core.cluster.pubsub.api.sync.NodeSelectionPubSubCommands;
 import io.lettuce.core.cluster.pubsub.api.sync.PubSubNodeSelection;
 import io.lettuce.core.event.command.CommandFailedEvent;
 import io.lettuce.core.event.command.CommandListener;
-import io.lettuce.core.internal.LettuceFactories;
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 import io.lettuce.core.pubsub.api.async.RedisPubSubAsyncCommands;
 import io.lettuce.core.support.PubSubTestListener;

--- a/src/test/java/io/lettuce/core/support/PubSubTestListener.java
+++ b/src/test/java/io/lettuce/core/support/PubSubTestListener.java
@@ -33,6 +33,8 @@ public class PubSubTestListener implements RedisPubSubListener<String, String> {
     private BlockingQueue<String> patterns = LettuceFactories.newBlockingQueue();
     private BlockingQueue<String> messages = LettuceFactories.newBlockingQueue();
     private BlockingQueue<Long> counts = LettuceFactories.newBlockingQueue();
+    private BlockingQueue<String> shardChannels = LettuceFactories.newBlockingQueue();
+    private BlockingQueue<Long> shardCounts = LettuceFactories.newBlockingQueue();
 
     // RedisPubSubListener implementation
 
@@ -53,6 +55,12 @@ public class PubSubTestListener implements RedisPubSubListener<String, String> {
     public void subscribed(String channel, long count) {
         channels.add(channel);
         counts.add(count);
+    }
+
+    @Override
+    public void ssubscribed(String shardChannel, long count) {
+        shardChannels.add(shardChannel);
+        shardCounts.add(count);
     }
 
     @Override
@@ -77,6 +85,10 @@ public class PubSubTestListener implements RedisPubSubListener<String, String> {
         return channels;
     }
 
+    public BlockingQueue<String> getShardChannels() {
+        return shardChannels;
+    }
+
     public BlockingQueue<String> getPatterns() {
         return patterns;
     }
@@ -89,13 +101,19 @@ public class PubSubTestListener implements RedisPubSubListener<String, String> {
         return counts;
     }
 
+    public BlockingQueue<Long> getShardCounts() {
+        return shardCounts;
+    }
+
     /**
      * Clear listener state (i.e. channels, patterns, messages, counts).
      */
     public void clear() {
         channels.clear();
+        shardChannels.clear();
         patterns.clear();
         messages.clear();
         counts.clear();
+        shardCounts.clear();
     }
 }


### PR DESCRIPTION
Addressing several stability issues with the pipeline:

1. Failing Integration tests would not fail the pipeline checks - this resulted in several tests constantly failing, and the number was rising. To address this I've added the `failsafe` plugin to the `verify` step, as suggested by the Maven best manual
2. Removed the `-B` option in the `Makefile` to improve readability in the logs
3. Modified the `io.lettuce.core.SslIntegrationTests.pubSubSsl` to attempt to verify the re-subscription process for a longer period of time, as it seems on the runners it takes more than 10 seconds (more than 60 seconds really)
4. Modified the `io.lettuce.core.cluster.pubsub.RedisClusterPubSubConnectionIntegrationTests.subscribeToShardChannelViaOtherEndpoint` to instead test replica scenario, see discussion below
5. Finished and enabled the `testRegularClientPubSubShardChannels` test 

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
