### PR TITLE
[#2341] Initialize slots with empty BitSet in RedisClusterNode's constructors

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/models/partitions/RedisClusterNode.java
+++ b/src/main/java/io/lettuce/core/cluster/models/partitions/RedisClusterNode.java
@@ -103,7 +103,11 @@ public class RedisClusterNode implements Serializable, RedisNodeDescription {
         this.configEpoch = configEpoch;
         this.replOffset = -1;
 
-        this.slots = slots != null ? slots : new BitSet(0);
+        this.slots = new BitSet(SlotHash.SLOT_COUNT);
+
+        if (slots != null) {
+            this.slots.or(slots);
+        }
 
         setFlags(flags);
     }
@@ -122,7 +126,7 @@ public class RedisClusterNode implements Serializable, RedisNodeDescription {
         this.replOffset = redisClusterNode.replOffset;
         this.aliases.addAll(redisClusterNode.aliases);
 
-        this.slots = redisClusterNode.slots != null ? new BitSet(SlotHash.SLOT_COUNT) : new BitSet(0);
+        this.slots = new BitSet(SlotHash.SLOT_COUNT);
 
         if (redisClusterNode.slots != null) {
             this.slots.or(redisClusterNode.slots);

--- a/src/main/java/io/lettuce/core/cluster/models/partitions/RedisClusterNode.java
+++ b/src/main/java/io/lettuce/core/cluster/models/partitions/RedisClusterNode.java
@@ -103,8 +103,7 @@ public class RedisClusterNode implements Serializable, RedisNodeDescription {
         this.configEpoch = configEpoch;
         this.replOffset = -1;
 
-        this.slots = new BitSet(slots.length());
-        this.slots.or(slots);
+        this.slots = slots != null ? slots : new BitSet(0);
 
         setFlags(flags);
     }
@@ -123,8 +122,9 @@ public class RedisClusterNode implements Serializable, RedisNodeDescription {
         this.replOffset = redisClusterNode.replOffset;
         this.aliases.addAll(redisClusterNode.aliases);
 
-        if (redisClusterNode.slots != null && !redisClusterNode.slots.isEmpty()) {
-            this.slots = new BitSet(SlotHash.SLOT_COUNT);
+        this.slots = redisClusterNode.slots != null ? new BitSet(SlotHash.SLOT_COUNT) : new BitSet(0);
+
+        if (redisClusterNode.slots != null) {
             this.slots.or(redisClusterNode.slots);
         }
 

--- a/src/test/java/io/lettuce/core/cluster/models/partitions/RedisClusterNodeUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/models/partitions/RedisClusterNodeUnitTests.java
@@ -24,6 +24,7 @@ class RedisClusterNodeUnitTests {
         BitSet slots = new BitSet();
         RedisClusterNode node = new RedisClusterNode(RedisURI.create("localhost", 6379), "1", true, null, 0, 0, 0, slots,
                 Collections.emptySet());
+
         assertThat(node.getSlots()).isEmpty();
         assertThat(node.getSlots()).isNotNull();
     }

--- a/src/test/java/io/lettuce/core/cluster/models/partitions/RedisClusterNodeUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/models/partitions/RedisClusterNodeUnitTests.java
@@ -3,6 +3,8 @@ package io.lettuce.core.cluster.models.partitions;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
@@ -15,6 +17,55 @@ import io.lettuce.core.cluster.SlotHash;
  * @author Mark Paluch
  */
 class RedisClusterNodeUnitTests {
+
+    @Test
+    void shouldCreateNodeWithEmptySlots() {
+
+        BitSet slots = new BitSet();
+        RedisClusterNode node = new RedisClusterNode(RedisURI.create("localhost", 6379), "1", true, null, 0, 0, 0, slots,
+                Collections.emptySet());
+        assertThat(node.getSlots()).isEmpty();
+        assertThat(node.getSlots()).isNotNull();
+    }
+
+    @Test
+    void shouldCreateNodeWithNonEmptySlots() {
+
+        BitSet slots = new BitSet();
+        slots.set(1);
+        slots.set(2);
+        RedisClusterNode node = new RedisClusterNode(RedisURI.create("localhost", 6379), "1", true, null, 0, 0, 0, slots,
+                Collections.emptySet());
+
+        assertThat(node.getSlots()).containsExactly(1, 2);
+    }
+
+    @Test
+    void shouldCopyNodeWithEmptySlots() {
+
+        BitSet slots = new BitSet();
+        RedisClusterNode originalNode = new RedisClusterNode(RedisURI.create("localhost", 6379), "1", true, null, 0, 0, 0,
+                slots, Collections.emptySet());
+
+        RedisClusterNode copiedNode = new RedisClusterNode(originalNode);
+
+        assertThat(copiedNode.getSlots()).isEmpty();
+        assertThat(copiedNode.getSlots()).isNotNull();
+    }
+
+    @Test
+    void shouldCopyNodeWithNonEmptySlots() {
+
+        BitSet slots = new BitSet();
+        slots.set(1);
+        slots.set(2);
+        RedisClusterNode originalNode = new RedisClusterNode(RedisURI.create("localhost", 6379), "1", true, null, 0, 0, 0,
+                slots, Collections.emptySet());
+
+        RedisClusterNode copiedNode = new RedisClusterNode(originalNode);
+
+        assertThat(copiedNode.getSlots()).containsExactly(1, 2);
+    }
 
     @Test
     void shouldCopyNode() {

--- a/src/test/java/io/lettuce/core/cluster/models/partitions/RedisClusterNodeUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/models/partitions/RedisClusterNodeUnitTests.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collections;
+import java.util.HashSet;
 
 import org.junit.jupiter.api.Test;
 
@@ -66,6 +67,42 @@ class RedisClusterNodeUnitTests {
         RedisClusterNode copiedNode = new RedisClusterNode(originalNode);
 
         assertThat(copiedNode.getSlots()).containsExactly(1, 2);
+    }
+
+    @Test
+    public void testHasSameSlotsAs() {
+
+        BitSet slots1 = new BitSet(SlotHash.SLOT_COUNT);
+        slots1.set(1);
+        slots1.set(2);
+
+        BitSet slots2 = new BitSet(SlotHash.SLOT_COUNT);
+        slots2.set(1);
+        slots2.set(2);
+
+        RedisClusterNode node1 = new RedisClusterNode(RedisURI.create("localhost", 6379), "nodeId1", true, "slaveOf", 0L, 0L,
+                0L, slots1, new HashSet<>());
+        RedisClusterNode node2 = new RedisClusterNode(RedisURI.create("localhost", 6379), "nodeId2", true, "slaveOf", 0L, 0L,
+                0L, slots2, new HashSet<>());
+
+        assertThat(node1.hasSameSlotsAs(node2)).isTrue();
+    }
+
+    @Test
+    public void testHasDifferentSlotsAs() {
+
+        BitSet slots1 = new BitSet(SlotHash.SLOT_COUNT);
+        slots1.set(1);
+
+        BitSet slots2 = new BitSet(SlotHash.SLOT_COUNT);
+        slots2.set(2);
+
+        RedisClusterNode node1 = new RedisClusterNode(RedisURI.create("localhost", 6379), "nodeId1", true, "slaveOf", 0L, 0L,
+                0L, slots1, new HashSet<>());
+        RedisClusterNode node2 = new RedisClusterNode(RedisURI.create("localhost", 6379), "nodeId2", true, "slaveOf", 0L, 0L,
+                0L, slots2, new HashSet<>());
+
+        assertThat(node1.hasSameSlotsAs(node2)).isFalse();
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/cluster/models/partitions/RedisClusterNodeUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/models/partitions/RedisClusterNodeUnitTests.java
@@ -72,18 +72,14 @@ class RedisClusterNodeUnitTests {
     @Test
     public void testHasSameSlotsAs() {
 
-        BitSet slots1 = new BitSet(SlotHash.SLOT_COUNT);
-        slots1.set(1);
-        slots1.set(2);
-
-        BitSet slots2 = new BitSet(SlotHash.SLOT_COUNT);
-        slots2.set(1);
-        slots2.set(2);
+        BitSet emptySlots = new BitSet(SlotHash.SLOT_COUNT);
+        emptySlots.set(1);
+        emptySlots.set(2);
 
         RedisClusterNode node1 = new RedisClusterNode(RedisURI.create("localhost", 6379), "nodeId1", true, "slaveOf", 0L, 0L,
-                0L, slots1, new HashSet<>());
-        RedisClusterNode node2 = new RedisClusterNode(RedisURI.create("localhost", 6379), "nodeId2", true, "slaveOf", 0L, 0L,
-                0L, slots2, new HashSet<>());
+                0L, emptySlots, new HashSet<>());
+
+        RedisClusterNode node2 = new RedisClusterNode(node1);
 
         assertThat(node1.hasSameSlotsAs(node2)).isTrue();
     }


### PR DESCRIPTION
**Issue: #2341** 
This PR supersedes the previously closed PR #2798

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
