### PR TITLE
Extending recording/publishing infra

### DIFF
--- a/src/main/java/io/lettuce/core/AbstractRedisClient.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisClient.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import reactor.core.publisher.Mono;
+import io.lettuce.core.event.RecordableEvent;
 import io.lettuce.core.event.command.CommandListener;
 import io.lettuce.core.event.connection.ConnectEvent;
 import io.lettuce.core.event.connection.ConnectionCreatedEvent;
@@ -400,7 +401,7 @@ public abstract class AbstractRedisClient implements AutoCloseable {
         String uriString = connectionBuilder.getRedisURI().toString();
 
         EventRecorder.getInstance().record(new ConnectionCreatedEvent(uriString, connectionBuilder.endpoint().getId()));
-        EventRecorder.RecordableEvent event = EventRecorder.getInstance()
+        RecordableEvent event = EventRecorder.getInstance()
                 .start(new ConnectEvent(uriString, connectionBuilder.endpoint().getId()));
 
         channelReadyFuture.whenComplete((channel, throwable) -> {

--- a/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
@@ -54,6 +54,7 @@ import io.lettuce.core.cluster.topology.NodeConnectionFactory;
 import io.lettuce.core.cluster.topology.TopologyComparators;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.event.RecordableEvent;
 import io.lettuce.core.event.jfr.EventRecorder;
 import io.lettuce.core.internal.Exceptions;
 import io.lettuce.core.internal.Futures;
@@ -886,7 +887,7 @@ public class RedisClusterClient extends AbstractRedisClient {
             sources.add(redisURI);
         }
 
-        EventRecorder.RecordableEvent event = EventRecorder.getInstance().start(new TopologyRefreshEvent(sources));
+        RecordableEvent event = EventRecorder.getInstance().start(new TopologyRefreshEvent(sources));
 
         if (partitions == null) {
             return initializePartitions().thenAccept(Partitions::updateCache)

--- a/src/main/java/io/lettuce/core/event/DefaultEventBus.java
+++ b/src/main/java/io/lettuce/core/event/DefaultEventBus.java
@@ -33,7 +33,7 @@ public class DefaultEventBus implements EventBus {
     @Override
     public void publish(Event event) {
 
-        recorder.record(event);
+        recorder.publish(event);
 
         Sinks.EmitResult emitResult;
 

--- a/src/main/java/io/lettuce/core/event/RecordableEvent.java
+++ b/src/main/java/io/lettuce/core/event/RecordableEvent.java
@@ -1,0 +1,18 @@
+package io.lettuce.core.event;
+
+/**
+ * Interface defining a recordable event that is recorded on calling {@link #record()}.
+ */
+public interface RecordableEvent extends Event {
+
+    /**
+     * Complete the event recording.
+     */
+    void record();
+
+    /**
+     * Get the source event.
+     */
+    Event getSource();
+
+}

--- a/src/main/java/io/lettuce/core/event/jfr/EventRecorder.java
+++ b/src/main/java/io/lettuce/core/event/jfr/EventRecorder.java
@@ -1,6 +1,7 @@
 package io.lettuce.core.event.jfr;
 
 import io.lettuce.core.event.Event;
+import io.lettuce.core.event.RecordableEvent;
 
 /**
  * Event recorder that can delegate events from the {@link io.lettuce.core.event.EventBus} into a recording facility such as
@@ -38,16 +39,6 @@ public interface EventRecorder {
      */
     RecordableEvent start(Event event);
 
-    /**
-     * Interface defining a recordable event that is recorded on calling {@link #record()}.
-     */
-    interface RecordableEvent {
-
-        /**
-         * Complete the event recording.
-         */
-        void record();
-
-    }
+    void publish(Event event);
 
 }

--- a/src/main/java/io/lettuce/core/event/jfr/NoOpEventRecorder.java
+++ b/src/main/java/io/lettuce/core/event/jfr/NoOpEventRecorder.java
@@ -1,6 +1,7 @@
 package io.lettuce.core.event.jfr;
 
 import io.lettuce.core.event.Event;
+import io.lettuce.core.event.RecordableEvent;
 
 /**
  * No-op implementation.
@@ -8,9 +9,18 @@ import io.lettuce.core.event.Event;
  * @author Mark Paluch
  * @since 6.1
  */
-enum NoOpEventRecorder implements EventRecorder, EventRecorder.RecordableEvent {
+public final class NoOpEventRecorder implements EventRecorder, RecordableEvent {
 
-    INSTANCE;
+    public final static NoOpEventRecorder INSTANCE = new NoOpEventRecorder();
+
+    private Event originalEvent = null;
+
+    private NoOpEventRecorder() {
+    }
+
+    public NoOpEventRecorder(Event event) {
+        this.originalEvent = event;
+    }
 
     @Override
     public void record(Event event) {
@@ -23,8 +33,17 @@ enum NoOpEventRecorder implements EventRecorder, EventRecorder.RecordableEvent {
     }
 
     @Override
-    public void record() {
+    public void publish(Event event) {
 
+    }
+
+    @Override
+    public void record() {
+    }
+
+    @Override
+    public Event getSource() {
+        return originalEvent;
     }
 
 }


### PR DESCRIPTION
Seems I messed up the PR a bit. I have linked the previous one.

This PR is to fulfill this https://github.com/redis/lettuce/discussions/2809#discussioncomment-9055302 and address [comments from https://github.com/redis/lettuce/pull/2819](https://github.com/redis/lettuce/pull/2819#issuecomment-2044326923)

> Extending individual events requires duplicating a lot of the functionality within the individual events and it makes these mutable.
> 
> I was looking more for an approach where we extend the recording/publishing infrastructure. In particular:
> 
> * Add `Event getSource()` to `RecordableEvent` and make `RecordableEvent extends Event`
> * Capture the original event in `JfrRecordableEvent` and rework `NoOpEventRecorder` to create an event instance
> * Long-lived events would be published to `EventBus` (e.g. `EventRecorder.RecordableEvent event = …;` later: `eventBus.publish(event)`.
> * Adopt `JfrEventRecorder.publish(…)` to check whether the given event is `EventRecorder.RecordableEvent`. If so, then we call `record(…)` on the event instead of `jdk.jfr.Event jfrEvent = createEvent(…);`
> * Retrofit `DefaultEventBus` to unwrap `EventRecorder.RecordableEvent` before emitting the event




---

* Add publish interface in EventRecorder
* Allow DefaultEventBus to publish event through EventRecorder
* Wrap source Event in JfrRecordableEvent

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [X] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [X] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [X] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
