### PR TITLE
XREAD support for reading last message from stream

### DIFF
--- a/src/main/java/io/lettuce/core/XReadArgs.java
+++ b/src/main/java/io/lettuce/core/XReadArgs.java
@@ -1,10 +1,10 @@
 package io.lettuce.core;
 
-import java.time.Duration;
-
 import io.lettuce.core.internal.LettuceAssert;
 import io.lettuce.core.protocol.CommandArgs;
 import io.lettuce.core.protocol.CommandKeyword;
+
+import java.time.Duration;
 
 /**
  * Argument list builder for the Redis <a href="https://redis.io/commands/xread">XREAD</a> and {@literal XREADGROUP} commands.
@@ -171,7 +171,7 @@ public class XReadArgs implements CompositeArgument {
         }
 
         /**
-         * Read all new arriving elements from the stream identified by {@code name}.
+         * Read all new arriving elements from the stream identified by {@code name} excluding any elements before this call
          *
          * @param name must not be {@code null}.
          * @return the {@link StreamOffset} object without a specific offset.
@@ -181,6 +181,21 @@ public class XReadArgs implements CompositeArgument {
             LettuceAssert.notNull(name, "Stream must not be null");
 
             return new StreamOffset<>(name, "$");
+        }
+
+        /**
+         * Read all new arriving elements from the stream identified by {@code name} including the last element added before
+         * this call
+         *
+         * @param name must not be {@code null}.
+         * @return the {@link StreamOffset} object without a specific offset.
+         * @since 7.0
+         */
+        public static <K> StreamOffset<K> last(K name) {
+
+            LettuceAssert.notNull(name, "Stream must not be null");
+
+            return new StreamOffset<>(name, "+");
         }
 
         /**

--- a/src/test/java/io/lettuce/core/SocketOptionsIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/SocketOptionsIntegrationTests.java
@@ -1,16 +1,18 @@
 package io.lettuce.core;
 
-import io.lettuce.test.LettuceExtension;
-import io.netty.channel.ConnectTimeoutException;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
-import javax.inject.Inject;
 import java.net.SocketException;
 import java.util.concurrent.TimeUnit;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.lettuce.test.LettuceExtension;
+import io.netty.channel.ConnectTimeoutException;
 
 /**
  * @author Mark Paluch
@@ -48,29 +50,5 @@ class SocketOptionsIntegrationTests extends TestSupport {
             }
         }
     }
-
-//    @Test
-//    void testConnectTimeout() {
-//
-//        SocketOptions socketOptions = SocketOptions.builder().connectTimeout(100, TimeUnit.MILLISECONDS).build();
-//        client.setOptions(ClientOptions.builder().socketOptions(socketOptions).build());
-//
-//        try {
-//            client.connect(RedisURI.create("2:4:5:5::1", 60000));
-//            fail("Missing RedisConnectionException");
-//        } catch (RedisConnectionException e) {
-//
-//            if (e.getCause() instanceof ConnectTimeoutException) {
-//                assertThat(e).hasRootCauseInstanceOf(ConnectTimeoutException.class);
-//                assertThat(e.getCause()).hasMessageContaining("connection timed out");
-//                return;
-//            }
-//
-//            if (e.getCause() instanceof SocketException) {
-//                // Network is unreachable or No route to host are OK as well.
-//                return;
-//            }
-//        }
-//    }
 
 }

--- a/src/test/java/io/lettuce/core/SocketOptionsIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/SocketOptionsIntegrationTests.java
@@ -1,18 +1,16 @@
 package io.lettuce.core;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-
-import java.net.SocketException;
-import java.util.concurrent.TimeUnit;
-
-import javax.inject.Inject;
-
+import io.lettuce.test.LettuceExtension;
+import io.netty.channel.ConnectTimeoutException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import io.lettuce.test.LettuceExtension;
-import io.netty.channel.ConnectTimeoutException;
+import javax.inject.Inject;
+import java.net.SocketException;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Mark Paluch
@@ -50,5 +48,29 @@ class SocketOptionsIntegrationTests extends TestSupport {
             }
         }
     }
+
+//    @Test
+//    void testConnectTimeout() {
+//
+//        SocketOptions socketOptions = SocketOptions.builder().connectTimeout(100, TimeUnit.MILLISECONDS).build();
+//        client.setOptions(ClientOptions.builder().socketOptions(socketOptions).build());
+//
+//        try {
+//            client.connect(RedisURI.create("2:4:5:5::1", 60000));
+//            fail("Missing RedisConnectionException");
+//        } catch (RedisConnectionException e) {
+//
+//            if (e.getCause() instanceof ConnectTimeoutException) {
+//                assertThat(e).hasRootCauseInstanceOf(ConnectTimeoutException.class);
+//                assertThat(e.getCause()).hasMessageContaining("connection timed out");
+//                return;
+//            }
+//
+//            if (e.getCause() instanceof SocketException) {
+//                // Network is unreachable or No route to host are OK as well.
+//                return;
+//            }
+//        }
+//    }
 
 }


### PR DESCRIPTION
Closes #2861 

Added a convenience utility method to read the last message from a stream

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
