### PR TITLE
Add a `evalReadOnly` overload that accepts the script as a `String`

### DIFF
--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -742,6 +742,12 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
     }
 
     @Override
+    @SuppressWarnings("unchecked")
+    public <T> RedisFuture<T> evalReadOnly(String script, ScriptOutputType type, K[] keys, V... values) {
+        return evalReadOnly(encodeScript(script), type, keys, values);
+    }
+
+    @Override
     public <T> RedisFuture<T> evalReadOnly(byte[] script, ScriptOutputType type, K[] keys, V... values) {
         return (RedisFuture<T>) dispatch(commandBuilder.eval(script, type, true, keys, values));
     }

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -798,6 +798,12 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
+    @SuppressWarnings("unchecked")
+    public <T> Flux<T> evalReadOnly(String script, ScriptOutputType type, K[] keys, V... values) {
+        return evalReadOnly(encodeScript(script), type, keys, values);
+    }
+
+    @Override
     public <T> Flux<T> evalReadOnly(byte[] script, ScriptOutputType type, K[] keys, V... values) {
         return createFlux(() -> commandBuilder.eval(script, type, true, keys, values));
     }

--- a/src/main/java/io/lettuce/core/api/async/RedisScriptingAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisScriptingAsyncCommands.java
@@ -94,7 +94,7 @@ public interface RedisScriptingAsyncCommands<K, V> {
      * @param values the values.
      * @param <T> expected return type.
      * @return script result.
-     * @since 6.4
+     * @since 7.0
      */
     <T> RedisFuture<T> evalReadOnly(String script, ScriptOutputType type, K[] keys, V... values);
 

--- a/src/main/java/io/lettuce/core/api/async/RedisScriptingAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisScriptingAsyncCommands.java
@@ -94,6 +94,19 @@ public interface RedisScriptingAsyncCommands<K, V> {
      * @param values the values.
      * @param <T> expected return type.
      * @return script result.
+     * @since 6.4
+     */
+    <T> RedisFuture<T> evalReadOnly(String script, ScriptOutputType type, K[] keys, V... values);
+
+    /**
+     * This is a read-only variant of the EVAL command that cannot execute commands that modify data.
+     *
+     * @param script Lua 5.1 script.
+     * @param type the type.
+     * @param keys the keys.
+     * @param values the values.
+     * @param <T> expected return type.
+     * @return script result.
      * @since 6.2
      */
     <T> RedisFuture<T> evalReadOnly(byte[] script, ScriptOutputType type, K[] keys, V... values);

--- a/src/main/java/io/lettuce/core/api/reactive/RedisScriptingReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisScriptingReactiveCommands.java
@@ -93,7 +93,7 @@ public interface RedisScriptingReactiveCommands<K, V> {
      * @param values the values.
      * @param <T> expected return type.
      * @return script result.
-     * @since 6.4
+     * @since 7.0
      */
     <T> Flux<T> evalReadOnly(String script, ScriptOutputType type, K[] keys, V... values);
 

--- a/src/main/java/io/lettuce/core/api/reactive/RedisScriptingReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisScriptingReactiveCommands.java
@@ -93,6 +93,19 @@ public interface RedisScriptingReactiveCommands<K, V> {
      * @param values the values.
      * @param <T> expected return type.
      * @return script result.
+     * @since 6.4
+     */
+    <T> Flux<T> evalReadOnly(String script, ScriptOutputType type, K[] keys, V... values);
+
+    /**
+     * This is a read-only variant of the EVAL command that cannot execute commands that modify data.
+     *
+     * @param script Lua 5.1 script.
+     * @param type the type.
+     * @param keys the keys.
+     * @param values the values.
+     * @param <T> expected return type.
+     * @return script result.
      * @since 6.2
      */
     <T> Flux<T> evalReadOnly(byte[] script, ScriptOutputType type, K[] keys, V... values);

--- a/src/main/java/io/lettuce/core/api/sync/RedisScriptingCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisScriptingCommands.java
@@ -93,6 +93,19 @@ public interface RedisScriptingCommands<K, V> {
      * @param values the values.
      * @param <T> expected return type.
      * @return script result.
+     * @since 6.4
+     */
+    <T> T evalReadOnly(String script, ScriptOutputType type, K[] keys, V... values);
+
+    /**
+     * This is a read-only variant of the EVAL command that cannot execute commands that modify data.
+     *
+     * @param script Lua 5.1 script.
+     * @param type output type.
+     * @param keys the keys.
+     * @param values the values.
+     * @param <T> expected return type.
+     * @return script result.
      * @since 6.2
      */
     <T> T evalReadOnly(byte[] script, ScriptOutputType type, K[] keys, V... values);

--- a/src/main/java/io/lettuce/core/api/sync/RedisScriptingCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisScriptingCommands.java
@@ -93,7 +93,7 @@ public interface RedisScriptingCommands<K, V> {
      * @param values the values.
      * @param <T> expected return type.
      * @return script result.
-     * @since 6.4
+     * @since 7.0
      */
     <T> T evalReadOnly(String script, ScriptOutputType type, K[] keys, V... values);
 

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionScriptingAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionScriptingAsyncCommands.java
@@ -93,6 +93,19 @@ public interface NodeSelectionScriptingAsyncCommands<K, V> {
      * @param values the values.
      * @param <T> expected return type.
      * @return script result.
+     * @since 6.4
+     */
+    <T> AsyncExecutions<T> evalReadOnly(String script, ScriptOutputType type, K[] keys, V... values);
+
+    /**
+     * This is a read-only variant of the EVAL command that cannot execute commands that modify data.
+     *
+     * @param script Lua 5.1 script.
+     * @param type the type.
+     * @param keys the keys.
+     * @param values the values.
+     * @param <T> expected return type.
+     * @return script result.
      * @since 6.2
      */
     <T> AsyncExecutions<T> evalReadOnly(byte[] script, ScriptOutputType type, K[] keys, V... values);

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionScriptingAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionScriptingAsyncCommands.java
@@ -93,7 +93,7 @@ public interface NodeSelectionScriptingAsyncCommands<K, V> {
      * @param values the values.
      * @param <T> expected return type.
      * @return script result.
-     * @since 6.4
+     * @since 7.0
      */
     <T> AsyncExecutions<T> evalReadOnly(String script, ScriptOutputType type, K[] keys, V... values);
 

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionScriptingCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionScriptingCommands.java
@@ -93,7 +93,7 @@ public interface NodeSelectionScriptingCommands<K, V> {
      * @param values the values.
      * @param <T> expected return type.
      * @return script result.
-     * @since 6.4
+     * @since 7.0
      */
     <T> Executions<T> evalReadOnly(String script, ScriptOutputType type, K[] keys, V... values);
 

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionScriptingCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionScriptingCommands.java
@@ -93,6 +93,19 @@ public interface NodeSelectionScriptingCommands<K, V> {
      * @param values the values.
      * @param <T> expected return type.
      * @return script result.
+     * @since 6.4
+     */
+    <T> Executions<T> evalReadOnly(String script, ScriptOutputType type, K[] keys, V... values);
+
+    /**
+     * This is a read-only variant of the EVAL command that cannot execute commands that modify data.
+     *
+     * @param script Lua 5.1 script.
+     * @param type the type.
+     * @param keys the keys.
+     * @param values the values.
+     * @param <T> expected return type.
+     * @return script result.
      * @since 6.2
      */
     <T> Executions<T> evalReadOnly(byte[] script, ScriptOutputType type, K[] keys, V... values);

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisScriptingCoroutinesCommands.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisScriptingCoroutinesCommands.kt
@@ -94,6 +94,24 @@ interface RedisScriptingCoroutinesCommands<K : Any, V : Any> {
      * @param values the values.
      * @param <T> expected return type.
      * @return script result.
+     * @since 6.4
+     */
+    suspend fun <T> evalReadOnly(
+        script: String,
+        type: ScriptOutputType,
+        keys: Array<K>,
+        vararg values: V
+    ): T?
+
+    /**
+     * This is a read-only variant of the EVAL command that cannot execute commands that modify data.
+     *
+     * @param script Lua 5.1 script.
+     * @param type the type.
+     * @param keys the keys.
+     * @param values the values.
+     * @param <T> expected return type.
+     * @return script result.
      * @since 6.2
      */
     suspend fun <T> evalReadOnly(
@@ -214,4 +232,3 @@ interface RedisScriptingCoroutinesCommands<K : Any, V : Any> {
     suspend fun digest(script: ByteArray): String?
 
 }
-

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisScriptingCoroutinesCommands.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisScriptingCoroutinesCommands.kt
@@ -94,7 +94,7 @@ interface RedisScriptingCoroutinesCommands<K : Any, V : Any> {
      * @param values the values.
      * @param <T> expected return type.
      * @return script result.
-     * @since 6.4
+     * @since 7.0
      */
     suspend fun <T> evalReadOnly(
         script: String,

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisScriptingCoroutinesCommandsImpl.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisScriptingCoroutinesCommandsImpl.kt
@@ -52,6 +52,13 @@ internal class RedisScriptingCoroutinesCommandsImpl<K : Any, V : Any>(internal v
     override suspend fun <T> eval(script: ByteArray, type: ScriptOutputType, keys: Array<K>, vararg values: V): T? = ops.eval<T>(script, type, keys, *values).awaitFirstOrNull()
 
     override suspend fun <T> evalReadOnly(
+        script: String,
+        type: ScriptOutputType,
+        keys: Array<K>,
+        vararg values: V
+    ): T? = ops.evalReadOnly<T>(script, type, keys, *values).awaitFirstOrNull()
+
+    override suspend fun <T> evalReadOnly(
         script: ByteArray,
         type: ScriptOutputType,
         keys: Array<K>,
@@ -86,4 +93,3 @@ internal class RedisScriptingCoroutinesCommandsImpl<K : Any, V : Any>(internal v
     override suspend fun digest(script: ByteArray): String = ops.digest(script)
 
 }
-

--- a/src/main/templates/io/lettuce/core/api/RedisScriptingCommands.java
+++ b/src/main/templates/io/lettuce/core/api/RedisScriptingCommands.java
@@ -92,7 +92,7 @@ public interface RedisScriptingCommands<K, V> {
      * @param values the values.
      * @param <T> expected return type.
      * @return script result.
-     * @since 6.4
+     * @since 7.0
      */
     <T> T evalReadOnly(String script, ScriptOutputType type, K[] keys, V... values);
 

--- a/src/main/templates/io/lettuce/core/api/RedisScriptingCommands.java
+++ b/src/main/templates/io/lettuce/core/api/RedisScriptingCommands.java
@@ -92,6 +92,19 @@ public interface RedisScriptingCommands<K, V> {
      * @param values the values.
      * @param <T> expected return type.
      * @return script result.
+     * @since 6.4
+     */
+    <T> T evalReadOnly(String script, ScriptOutputType type, K[] keys, V... values);
+
+    /**
+     * This is a read-only variant of the EVAL command that cannot execute commands that modify data.
+     *
+     * @param script Lua 5.1 script.
+     * @param type the type.
+     * @param keys the keys.
+     * @param values the values.
+     * @param <T> expected return type.
+     * @return script result.
      * @since 6.2
      */
     <T> T evalReadOnly(byte[] script, ScriptOutputType type, K[] keys, V... values);

--- a/src/test/java/io/lettuce/core/commands/ScriptingCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/ScriptingCommandIntegrationTests.java
@@ -134,7 +134,7 @@ public class ScriptingCommandIntegrationTests extends TestSupport {
     @EnabledOnCommand("EVAL_RO") // Redis 7.0
     void evalReadOnly() {
         String[] keys = new String[] { "key1" };
-        assertThat((String) redis.evalReadOnly("return KEYS[1]".getBytes(), STATUS, keys, "a")).isEqualTo("key1");
+        assertThat((String) redis.evalReadOnly("return KEYS[1]", STATUS, keys, "a")).isEqualTo("key1");
     }
 
     @Test


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

-----

I am assuming the only reason why this method is missing is just an oversight, please let me know if there is anything else I should have considered.

-----

Related to #1987 
