### PR TITLE
Adjusting disconnectedBehavior Option to Prevent Timeout During Redis Shutdown #2866

### DIFF
--- a/src/main/java/io/lettuce/core/protocol/DefaultEndpoint.java
+++ b/src/main/java/io/lettuce/core/protocol/DefaultEndpoint.java
@@ -678,7 +678,7 @@ public class DefaultEndpoint implements RedisChannelWriter, Endpoint, PushHandle
             cancelCommands("Connection closed", queuedCommands.drainQueue(), it -> it.completeExceptionally(lazy.get()));
             cancelCommands("Connection closed", drainCommands(), it -> it.completeExceptionally(lazy.get()));
             return;
-        } else if (reliability == Reliability.AT_MOST_ONCE && rejectCommandsWhileDisconnected) {
+        } else if (rejectCommandsWhileDisconnected) {
 
             Lazy<RedisException> lazy = Lazy.of(() -> new RedisException("Connection disconnected"));
             cancelCommands("Connection disconnected", queuedCommands.drainQueue(), it -> it.completeExceptionally(lazy.get()));


### PR DESCRIPTION
The purpose of this PR is to adjust the disconnectedBehavior option to prevent timeouts when Redis is shutdown, addressing issue #2866.

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/lettuce-io/lettuce-core/blob/main/formatting.xml) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
