### PR TITLE
Add defensive copy for Futures allOf() method

### DIFF
--- a/src/main/java/io/lettuce/core/internal/Futures.java
+++ b/src/main/java/io/lettuce/core/internal/Futures.java
@@ -21,7 +21,7 @@ public abstract class Futures {
     }
 
     /**
-     * Create a composite {@link CompletableFuture} is composed from the given {@code stages}.
+     * Create a composite {@link CompletableFuture} that is composed of the given {@code stages}.
      *
      * @param stages must not be {@code null}.
      * @return the composed {@link CompletableFuture}.
@@ -32,10 +32,11 @@ public abstract class Futures {
 
         LettuceAssert.notNull(stages, "Futures must not be null");
 
-        CompletableFuture[] futures = new CompletableFuture[stages.size()];
+        CompletionStage[] copies = stages.toArray(new CompletionStage[0]);
+        CompletableFuture[] futures = new CompletableFuture[copies.length];
 
         int index = 0;
-        for (CompletionStage<?> stage : stages) {
+        for (CompletionStage<?> stage : copies) {
             futures[index++] = stage.toCompletableFuture();
         }
 

--- a/src/main/java/io/lettuce/core/internal/Futures.java
+++ b/src/main/java/io/lettuce/core/internal/Futures.java
@@ -12,6 +12,7 @@ import io.netty.channel.ChannelFuture;
  * without further notice.
  *
  * @author Mark Paluch
+ * @author jinkshower
  * @since 5.1
  */
 public abstract class Futures {

--- a/src/test/java/io/lettuce/core/internal/FuturesUnitTests.java
+++ b/src/test/java/io/lettuce/core/internal/FuturesUnitTests.java
@@ -83,7 +83,8 @@ class FuturesUnitTests {
                     issues.add(e);
                 } finally {
                     latch.countDown();
-                } });
+                }
+            });
         }
 
         // wait for all threads to complete


### PR DESCRIPTION
Closes #2935

I've added defensive copy for the method so that external modification could not affect stages during iteration.

As for test, I can't come up with any better idea so just used two Threads each calling allOf() and modifying stages simultaneously.

Thank you.

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
