### PR TITLE
fix: prevent blocking event loop thread by replacing ArrayDeque with HashIndexedQueue

### DIFF
--- a/src/main/java/io/lettuce/core/ClientOptions.java
+++ b/src/main/java/io/lettuce/core/ClientOptions.java
@@ -85,6 +85,8 @@ public class ClientOptions implements Serializable {
 
     public static final TimeoutOptions DEFAULT_TIMEOUT_OPTIONS = TimeoutOptions.enabled();
 
+    public static final boolean DEFAULT_USE_HASH_INDEX_QUEUE = false;
+
     private final boolean autoReconnect;
 
     private final boolean cancelCommandsOnReconnectFailure;
@@ -115,6 +117,8 @@ public class ClientOptions implements Serializable {
 
     private final TimeoutOptions timeoutOptions;
 
+    private final boolean useHashIndexedQueue;
+
     protected ClientOptions(Builder builder) {
         this.autoReconnect = builder.autoReconnect;
         this.cancelCommandsOnReconnectFailure = builder.cancelCommandsOnReconnectFailure;
@@ -131,6 +135,7 @@ public class ClientOptions implements Serializable {
         this.sslOptions = builder.sslOptions;
         this.suspendReconnectOnProtocolFailure = builder.suspendReconnectOnProtocolFailure;
         this.timeoutOptions = builder.timeoutOptions;
+        this.useHashIndexedQueue = builder.useHashIndexedQueue;
     }
 
     protected ClientOptions(ClientOptions original) {
@@ -149,6 +154,7 @@ public class ClientOptions implements Serializable {
         this.sslOptions = original.getSslOptions();
         this.suspendReconnectOnProtocolFailure = original.isSuspendReconnectOnProtocolFailure();
         this.timeoutOptions = original.getTimeoutOptions();
+        this.useHashIndexedQueue = original.isUseHashIndexedQueue();
     }
 
     /**
@@ -214,6 +220,8 @@ public class ClientOptions implements Serializable {
 
         private TimeoutOptions timeoutOptions = DEFAULT_TIMEOUT_OPTIONS;
 
+        private boolean useHashIndexedQueue = DEFAULT_USE_HASH_INDEX_QUEUE;
+
         protected Builder() {
         }
 
@@ -269,8 +277,8 @@ public class ClientOptions implements Serializable {
          *
          * @param policy the policy to use in {@link io.lettuce.core.protocol.CommandHandler}
          * @return {@code this}
-         * @since 6.0
          * @see DecodeBufferPolicies
+         * @since 6.0
          */
         public Builder decodeBufferPolicy(DecodeBufferPolicy policy) {
 
@@ -317,8 +325,8 @@ public class ClientOptions implements Serializable {
          *
          * @param protocolVersion version to use.
          * @return {@code this}
-         * @since 6.0
          * @see ProtocolVersion#newestSupported()
+         * @since 6.0
          */
         public Builder protocolVersion(ProtocolVersion protocolVersion) {
 
@@ -337,9 +345,9 @@ public class ClientOptions implements Serializable {
          *
          * @param publishOnScheduler true/false
          * @return {@code this}
-         * @since 5.2
          * @see org.reactivestreams.Subscriber#onNext(Object)
          * @see ClientResources#eventExecutorGroup()
+         * @since 5.2
          */
         public Builder publishOnScheduler(boolean publishOnScheduler) {
             this.publishOnScheduler = publishOnScheduler;
@@ -460,6 +468,20 @@ public class ClientOptions implements Serializable {
         }
 
         /**
+         * Use hash indexed queue which provides O(1) remove(Object) thus won't cause blocking issues.
+         *
+         * @param useHashIndexedQueue true/false
+         * @return {@code this}
+         * @see io.lettuce.core.protocol.CommandHandler.AddToStack
+         * @since 5.1
+         */
+        @SuppressWarnings("JavadocReference")
+        public Builder useHashIndexQueue(boolean useHashIndexedQueue) {
+            this.useHashIndexedQueue = useHashIndexedQueue;
+            return this;
+        }
+
+        /**
          * Create a new instance of {@link ClientOptions}.
          *
          * @return new instance of {@link ClientOptions}
@@ -476,7 +498,6 @@ public class ClientOptions implements Serializable {
      *
      * @return a {@link ClientOptions.Builder} to create new {@link ClientOptions} whose settings are replicated from the
      *         current {@link ClientOptions}.
-     *
      * @since 5.1
      */
     public ClientOptions.Builder mutate() {
@@ -535,7 +556,6 @@ public class ClientOptions implements Serializable {
      *
      * @return zero.
      * @since 5.2
-     *
      * @deprecated since 6.0 in favor of {@link DecodeBufferPolicy}.
      */
     @Deprecated
@@ -682,6 +702,15 @@ public class ClientOptions implements Serializable {
      */
     public TimeoutOptions getTimeoutOptions() {
         return timeoutOptions;
+    }
+
+    /**
+     * Whether we should use hash indexed queue, which provides O(1) remove(Object)
+     *
+     * @return if hash indexed queue should be used
+     */
+    public boolean isUseHashIndexedQueue() {
+        return useHashIndexedQueue;
     }
 
     /**

--- a/src/main/java/io/lettuce/core/ClientOptions.java
+++ b/src/main/java/io/lettuce/core/ClientOptions.java
@@ -85,7 +85,7 @@ public class ClientOptions implements Serializable {
 
     public static final TimeoutOptions DEFAULT_TIMEOUT_OPTIONS = TimeoutOptions.enabled();
 
-    public static final boolean DEFAULT_USE_HASH_INDEX_QUEUE = false;
+    public static final boolean DEFAULT_USE_HASH_INDEX_QUEUE = true;
 
     private final boolean autoReconnect;
 
@@ -468,12 +468,12 @@ public class ClientOptions implements Serializable {
         }
 
         /**
-         * Use hash indexed queue which provides O(1) remove(Object) thus won't cause blocking issues.
+         * Use hash indexed queue, which provides O(1) remove(Object) thus won't cause blocking issues.
          *
          * @param useHashIndexedQueue true/false
          * @return {@code this}
          * @see io.lettuce.core.protocol.CommandHandler.AddToStack
-         * @since 5.1
+         * @since 6.6
          */
         @SuppressWarnings("JavadocReference")
         public Builder useHashIndexQueue(boolean useHashIndexedQueue) {

--- a/src/main/java/io/lettuce/core/datastructure/queue/HashIndexedQueue.java
+++ b/src/main/java/io/lettuce/core/datastructure/queue/HashIndexedQueue.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2011-Present, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ */
 package io.lettuce.core.datastructure.queue;
 
 import java.util.AbstractQueue;
@@ -7,11 +13,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Queue;
 
 import io.lettuce.core.internal.LettuceAssert;
+import org.jetbrains.annotations.NotNull;
 
 /**
+ * A queue implementation that supports O(1) removal of elements. The queue is backed by a hash map and a doubly linked list.
  * @author chenxiaofan
  */
 @SuppressWarnings("unchecked")
@@ -39,6 +46,9 @@ public class HashIndexedQueue<E> extends AbstractQueue<E> {
 
     }
 
+    /**
+     * Create a new instance of the {@link HashIndexedQueue}.
+     */
     public HashIndexedQueue() {
         map = new HashMap<>();
         size = 0;
@@ -157,6 +167,7 @@ public class HashIndexedQueue<E> extends AbstractQueue<E> {
 
     }
 
+    @NotNull
     @Override
     public Iterator iterator() {
         return new Iterator();
@@ -181,20 +192,20 @@ public class HashIndexedQueue<E> extends AbstractQueue<E> {
         size = 0;
     }
 
-    private boolean removeFirstOccurrence(Object o) {
-        Object current = map.get(o);
+    private boolean removeFirstOccurrence(Object element) {
+        Object current = map.get(element);
         if (current == null) {
             return false;
         }
         if (current instanceof Node) {
             Node<E> node = (Node<E>) current;
             removeNode(node);
-            map.remove(o);
+            map.remove(element);
         } else {
             List<Node<E>> nodes = (List<Node<E>>) current;
             Node<E> node = nodes.remove(0);
             if (nodes.isEmpty()) {
-                map.remove(o);
+                map.remove(element);
             }
             removeNode(node);
         }
@@ -202,8 +213,8 @@ public class HashIndexedQueue<E> extends AbstractQueue<E> {
         return true;
     }
 
-    private boolean removeAllOccurrences(Object o) {
-        Object current = map.get(o);
+    private boolean removeAllOccurrences(Object element) {
+        Object current = map.get(element);
         if (current == null) {
             return false;
         }
@@ -218,7 +229,7 @@ public class HashIndexedQueue<E> extends AbstractQueue<E> {
                 size--;
             }
         }
-        map.remove(o);
+        map.remove(element);
         return true;
     }
 

--- a/src/main/java/io/lettuce/core/datastructure/queue/HashIndexedQueue.java
+++ b/src/main/java/io/lettuce/core/datastructure/queue/HashIndexedQueue.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * A queue implementation that supports O(1) removal of elements. The queue is backed by a hash map and a doubly linked list.
+ * 
  * @author chenxiaofan
  */
 @SuppressWarnings("unchecked")

--- a/src/main/java/io/lettuce/core/datastructure/queue/HashIndexedQueue.java
+++ b/src/main/java/io/lettuce/core/datastructure/queue/HashIndexedQueue.java
@@ -1,0 +1,254 @@
+package io.lettuce.core.datastructure.queue;
+
+import java.util.AbstractQueue;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+
+import io.lettuce.core.internal.LettuceAssert;
+
+/**
+ * @author chenxiaofan
+ */
+@SuppressWarnings("unchecked")
+public class HashIndexedQueue<E> extends AbstractQueue<E> {
+
+    private final Map<E, Object> map; // Object can be Node<E> or List<Node<E>>
+
+    private Node<E> head;
+
+    private Node<E> tail;
+
+    private int size;
+
+    private static class Node<E> {
+
+        E value;
+
+        Node<E> next;
+
+        Node<E> prev;
+
+        Node(E value) {
+            this.value = value;
+        }
+
+    }
+
+    public HashIndexedQueue() {
+        map = new HashMap<>();
+        size = 0;
+    }
+
+    @Override
+    public boolean add(E e) {
+        return offer(e);
+    }
+
+    @Override
+    public boolean offer(E e) {
+        final Node<E> newNode = new Node<>(e);
+        if (tail == null) {
+            head = tail = newNode;
+        } else {
+            tail.next = newNode;
+            newNode.prev = tail;
+            tail = newNode;
+        }
+
+        if (!map.containsKey(e)) {
+            map.put(e, newNode);
+        } else {
+            Object current = map.get(e);
+            if (current instanceof Node) {
+                List<Node<E>> nodes = new ArrayList<>();
+                nodes.add((Node<E>) current);
+                nodes.add(newNode);
+                map.put(e, nodes);
+            } else {
+                ((List<Node<E>>) current).add(newNode);
+            }
+        }
+        size++;
+        return true;
+    }
+
+    @Override
+    public E poll() {
+        if (head == null) {
+            return null;
+        }
+        E value = head.value;
+        removeNodeFromMap(head);
+        head = head.next;
+        if (head == null) {
+            tail = null;
+        } else {
+            head.prev = null;
+        }
+        size--;
+        return value;
+    }
+
+    @Override
+    public E peek() {
+        if (head == null) {
+            return null;
+        }
+        return head.value;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return removeFirstOccurrence(o);
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return map.containsKey(o);
+    }
+
+    public class Iterator implements java.util.Iterator<E> {
+
+        private Node<E> current;
+
+        private Node<E> prev;
+
+        private Iterator() {
+            current = HashIndexedQueue.this.head;
+            prev = null;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return current != null;
+        }
+
+        @Override
+        public E next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            E value = current.value;
+            prev = current;
+            current = current.next;
+            return value;
+        }
+
+        @Override
+        public void remove() {
+            if (prev != null) {
+                removeNodeFromMap(prev);
+                removeNode(prev);
+                size--;
+                // remove once
+                prev = null;
+            }
+        }
+
+    }
+
+    @Override
+    public Iterator iterator() {
+        return new Iterator();
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        boolean modified = false;
+        for (Object e : c) {
+            if (removeAllOccurrences(e)) {
+                modified = true;
+            }
+        }
+        return modified;
+    }
+
+    @Override
+    public void clear() {
+        head = null;
+        tail = null;
+        map.clear();
+        size = 0;
+    }
+
+    private boolean removeFirstOccurrence(Object o) {
+        Object current = map.get(o);
+        if (current == null) {
+            return false;
+        }
+        if (current instanceof Node) {
+            Node<E> node = (Node<E>) current;
+            removeNode(node);
+            map.remove(o);
+        } else {
+            List<Node<E>> nodes = (List<Node<E>>) current;
+            Node<E> node = nodes.remove(0);
+            if (nodes.isEmpty()) {
+                map.remove(o);
+            }
+            removeNode(node);
+        }
+        size--;
+        return true;
+    }
+
+    private boolean removeAllOccurrences(Object o) {
+        Object current = map.get(o);
+        if (current == null) {
+            return false;
+        }
+        if (current instanceof Node) {
+            final Node<E> node = (Node<E>) current;
+            removeNode(node);
+            size--;
+        } else {
+            final List<Node<E>> nodes = (List<Node<E>>) current;
+            for (Node<E> node : nodes) {
+                removeNode(node);
+                size--;
+            }
+        }
+        map.remove(o);
+        return true;
+    }
+
+    private void removeNode(Node<E> node) {
+        if (node.prev != null) {
+            node.prev.next = node.next;
+        } else {
+            head = node.next;
+        }
+        if (node.next != null) {
+            node.next.prev = node.prev;
+        } else {
+            tail = node.prev;
+        }
+    }
+
+    private void removeNodeFromMap(Node<E> node) {
+        E value = node.value;
+        Object current = map.get(value);
+        if (current instanceof Node) {
+            LettuceAssert.assertState(current == node, "current != node");
+            map.remove(value);
+        } else {
+            List<Node<E>> nodes = (List<Node<E>>) current;
+            final boolean removed = nodes.remove(node);
+            LettuceAssert.assertState(removed, "!nodes.remove(node)");
+            if (nodes.isEmpty()) {
+                map.remove(value);
+            }
+        }
+    }
+
+}

--- a/src/main/java/io/lettuce/core/protocol/CommandHandler.java
+++ b/src/main/java/io/lettuce/core/protocol/CommandHandler.java
@@ -43,6 +43,7 @@ import io.lettuce.core.RedisException;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.push.PushListener;
 import io.lettuce.core.api.push.PushMessage;
+import io.lettuce.core.datastructure.queue.HashIndexedQueue;
 import io.lettuce.core.internal.LettuceAssert;
 import io.lettuce.core.internal.LettuceSets;
 import io.lettuce.core.metrics.CommandLatencyRecorder;
@@ -98,7 +99,7 @@ public class CommandHandler extends ChannelDuplexHandler implements HasQueuedCom
 
     private final Endpoint endpoint;
 
-    private final ArrayDeque<RedisCommand<?, ?, ?>> stack = new ArrayDeque<>();
+    private final Queue<RedisCommand<?, ?, ?>> stack;
 
     private final long commandHandlerId = COMMAND_HANDLER_COUNTER.incrementAndGet();
 
@@ -157,6 +158,7 @@ public class CommandHandler extends ChannelDuplexHandler implements HasQueuedCom
         this.commandLatencyRecorder = clientResources.commandLatencyRecorder();
         this.latencyMetricsEnabled = commandLatencyRecorder.isEnabled();
         this.boundedQueues = clientOptions.getRequestQueueSize() != Integer.MAX_VALUE;
+        this.stack = clientOptions.isUseHashIndexedQueue() ? new HashIndexedQueue<>() : new ArrayDeque<>();
 
         Tracing tracing = clientResources.tracing();
 
@@ -1041,7 +1043,7 @@ public class CommandHandler extends ChannelDuplexHandler implements HasQueuedCom
 
         private final Recycler.Handle<AddToStack> handle;
 
-        private ArrayDeque<Object> stack;
+        private Queue<RedisCommand<?, ?, ?>> stack;
 
         private RedisCommand<?, ?, ?> command;
 
@@ -1057,11 +1059,11 @@ public class CommandHandler extends ChannelDuplexHandler implements HasQueuedCom
          * @return
          */
         @SuppressWarnings("unchecked")
-        static AddToStack newInstance(ArrayDeque<?> stack, RedisCommand<?, ?, ?> command) {
+        static AddToStack newInstance(Queue<RedisCommand<?, ?, ?>> stack, RedisCommand<?, ?, ?> command) {
 
             AddToStack entry = RECYCLER.get();
 
-            entry.stack = (ArrayDeque<Object>) stack;
+            entry.stack = stack;
             entry.command = command;
 
             return entry;

--- a/src/test/java/io/lettuce/core/datastructure/queue/HashIndexedQueueTests.java
+++ b/src/test/java/io/lettuce/core/datastructure/queue/HashIndexedQueueTests.java
@@ -1,0 +1,185 @@
+package io.lettuce.core.datastructure.queue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.NoSuchElementException;
+
+import io.lettuce.test.LettuceExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("ConstantValue")
+@ExtendWith(LettuceExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HashIndexedQueueTests {
+
+    private HashIndexedQueue<Integer> queue;
+
+    @BeforeEach
+    void setUp() {
+        queue = new HashIndexedQueue<>();
+    }
+
+    @Test
+    void testInitialization() {
+        assertTrue(queue.isEmpty());
+        assertEquals(0, queue.size());
+    }
+
+    @Test
+    void testAddAndOffer() {
+        assertTrue(queue.add(1));
+        assertTrue(queue.offer(2));
+        assertEquals(2, queue.size());
+        assertTrue(queue.contains(1));
+        assertTrue(queue.contains(2));
+    }
+
+    @Test
+    void testRemoveAndPoll() {
+        queue.add(1);
+        queue.add(2);
+        assertEquals(1, queue.remove());
+        assertEquals(1, queue.size());
+        assertEquals(2, queue.poll());
+        assertTrue(queue.isEmpty());
+    }
+
+    @Test
+    void testPeekAndElement() {
+        queue.add(1);
+        queue.add(2);
+        assertEquals(1, queue.peek());
+        assertEquals(1, queue.element());
+        queue.remove();
+        assertEquals(2, queue.peek());
+        assertEquals(2, queue.element());
+    }
+
+    @Test
+    void testContains() {
+        queue.add(1);
+        assertTrue(queue.contains(1));
+        assertFalse(queue.contains(2));
+    }
+
+    @Test
+    void testSizeAndIsEmpty() {
+        assertTrue(queue.isEmpty());
+        queue.add(1);
+        assertFalse(queue.isEmpty());
+        assertEquals(1, queue.size());
+    }
+
+    @Test
+    void testClear() {
+        queue.add(1);
+        queue.add(2);
+        queue.clear();
+        assertTrue(queue.isEmpty());
+        assertEquals(0, queue.size());
+    }
+
+    @Test
+    void testRemove() {
+        queue.add(1);
+        queue.add(1);
+        queue.add(2);
+        queue.add(1);
+        assertTrue(queue.remove(1));
+        assertEquals(3, queue.size());
+        assertTrue(queue.contains(1));
+        assertTrue(queue.contains(2));
+        assertTrue(queue.remove(1));
+        assertEquals(2, queue.size());
+        assertTrue(queue.remove(1));
+        assertEquals(1, queue.size());
+        assertTrue(queue.contains(2));
+    }
+
+    @Test
+    void testRemoveAll() {
+        queue.add(1);
+        queue.add(1);
+        queue.add(2);
+        queue.add(1);
+        assertTrue(queue.removeAll(Collections.singletonList(1)));
+        assertEquals(1, queue.size());
+        assertTrue(queue.contains(2));
+    }
+
+    @Test
+    void testRemoveAll2() {
+        queue.add(1);
+        queue.add(1);
+        queue.add(1);
+        queue.add(1);
+        assertTrue(queue.removeAll(Collections.singletonList(1)));
+        assertEquals(0, queue.size());
+    }
+
+    @Test
+    void testRemoveAllAndRetainAll() {
+        queue.addAll(Arrays.asList(1, 2, 3, 4));
+        queue.removeAll(Arrays.asList(1, 2));
+        assertEquals(2, queue.size());
+        assertFalse(queue.contains(1));
+        assertFalse(queue.contains(2));
+        queue.retainAll(Collections.singletonList(3));
+        assertEquals(1, queue.size());
+        assertTrue(queue.contains(3));
+        assertFalse(queue.contains(4));
+    }
+
+    @Test
+    void testRetainAll() {
+        queue.addAll(Arrays.asList(1, 2, 3, 4, 1, 2, 3, 4));
+        queue.retainAll(Arrays.asList(1, 2));
+        assertEquals(4, queue.size());
+        HashIndexedQueue<Integer>.Iterator iterator = queue.iterator();
+        iterator.remove();
+        assertEquals(1, iterator.next());
+        assertEquals(2, iterator.next());
+        assertEquals(1, iterator.next());
+        assertEquals(2, iterator.next());
+        iterator.remove();
+        // no effect
+        iterator.remove();
+        iterator.remove();
+
+        iterator = queue.iterator();
+        assertEquals(1, iterator.next());
+        assertEquals(2, iterator.next());
+        assertEquals(1, iterator.next());
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    void testRemoveNonExistentElement() {
+        assertThrows(NoSuchElementException.class, () -> queue.remove());
+    }
+
+    @Test
+    void testPollEmptyQueue() {
+        assertNull(queue.poll());
+    }
+
+    @Test
+    void testElementEmptyQueue() {
+        assertThrows(NoSuchElementException.class, () -> queue.element());
+    }
+
+    @Test
+    void testPeekEmptyQueue() {
+        assertNull(queue.peek());
+    }
+
+}


### PR DESCRIPTION
Closes #2937

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
