### PR TITLE
fix:deadlock when reentrant exclusive lock #2905 #2879

### DIFF
--- a/src/main/java/io/lettuce/core/protocol/SharedLock.java
+++ b/src/main/java/io/lettuce/core/protocol/SharedLock.java
@@ -146,9 +146,13 @@ class SharedLock {
     private void unlockWritersExclusive() {
 
         if (exclusiveLockOwner == Thread.currentThread()) {
+            // check exclusive look not reentrant first
             if (WRITERS.compareAndSet(this, -1, sharedCnt.get())) {
                 exclusiveLockOwner = null;
+                return;
             }
+            // otherwise unlock until no more reentrant left
+            WRITERS.incrementAndGet(this);
         }
     }
 

--- a/src/test/java/io/lettuce/core/protocol/SharedLockTest.java
+++ b/src/test/java/io/lettuce/core/protocol/SharedLockTest.java
@@ -1,0 +1,42 @@
+package io.lettuce.core.protocol;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class SharedLockTest {
+
+    @Test
+    public void safety_on_reentrant_lock_exclusive_on_writers() throws InterruptedException {
+        final SharedLock sharedLock = new SharedLock();
+        CountDownLatch cnt = new CountDownLatch(1);
+        try {
+            sharedLock.incrementWriters();
+
+            String result = sharedLock.doExclusive(() -> {
+                return sharedLock.doExclusive(() -> {
+                    return "ok";
+                });
+            });
+            if ("ok".equals(result)) {
+                cnt.countDown();
+            }
+        } finally {
+            sharedLock.decrementWriters();
+        }
+
+        cnt.await(1, TimeUnit.SECONDS);
+
+        // verify writers won't be negative after finally decrementWriters
+        String result = sharedLock.doExclusive(() -> {
+            return sharedLock.doExclusive(() -> {
+                return "ok";
+            });
+        });
+
+        Assertions.assertEquals("ok", result);
+    }
+
+}


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
## Motivation

Resolves: #2905 #2879

## Investigation

Both of issues point to this stack trace. I have reproduced this with the sample in #2905.

After some investigation, I figured why, because the thread that holds the shared lock also requires exclusive lock in the same time.(I think it happened on error handling, or the channel was disactive when writer was writing).



```log
      at io.lettuce.core.protocol.Sharedlock.lockWritersExclusive(SharedLock.java:139)
      at io.lettuce.core.protocol.SharedLock.doexclusive(SharedLock.java:114)
      at io.lettuce.core.protocol.DefaultEndpoint.doExclusive(DefaultEndpoint.java:741)
```




Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
