### PR TITLE
fix: Lcs response parse

### DIFF
--- a/src/main/java/io/lettuce/core/RedisCommandBuilder.java
+++ b/src/main/java/io/lettuce/core/RedisCommandBuilder.java
@@ -2919,7 +2919,7 @@ class RedisCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
 
         CommandArgs<K, V> args = new CommandArgs<>(codec);
         strAlgoArgs.build(args);
-        return createCommand(STRALGO, new StringMatchResultOutput<>(codec, strAlgoArgs.isWithIdx()), args);
+        return createCommand(STRALGO, new StringMatchResultOutput<>(codec), args);
     }
 
     Command<K, V, Set<V>> sunion(K... keys) {

--- a/src/main/java/io/lettuce/core/dynamic/output/OutputRegistry.java
+++ b/src/main/java/io/lettuce/core/dynamic/output/OutputRegistry.java
@@ -56,6 +56,8 @@ public class OutputRegistry {
         register(registry, StringListOutput.class, StringListOutput::new);
         register(registry, VoidOutput.class, VoidOutput::new);
 
+        register(registry, StringMatchResultOutput.class, StringMatchResultOutput::new);
+
         BUILTIN.putAll(registry);
     }
 

--- a/src/main/java/io/lettuce/core/output/StringMatchResultOutput.java
+++ b/src/main/java/io/lettuce/core/output/StringMatchResultOutput.java
@@ -19,16 +19,16 @@
  */
 package io.lettuce.core.output;
 
-import static io.lettuce.core.StringMatchResult.MatchedPosition;
-import static io.lettuce.core.StringMatchResult.Position;
+import io.lettuce.core.StringMatchResult;
+import io.lettuce.core.codec.RedisCodec;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.lettuce.core.StringMatchResult;
-import io.lettuce.core.codec.RedisCodec;
+import static io.lettuce.core.StringMatchResult.MatchedPosition;
+import static io.lettuce.core.StringMatchResult.Position;
 
 /**
  * Command output for {@code STRALGO} returning {@link StringMatchResult}.
@@ -40,8 +40,6 @@ public class StringMatchResultOutput<K, V> extends CommandOutput<K, V, StringMat
 
     private static final ByteBuffer LEN = StandardCharsets.US_ASCII.encode("len");
 
-    private final boolean withIdx;
-
     private String matchString;
 
     private int len;
@@ -52,24 +50,18 @@ public class StringMatchResultOutput<K, V> extends CommandOutput<K, V, StringMat
 
     private final List<MatchedPosition> matchedPositions = new ArrayList<>();
 
-    public StringMatchResultOutput(RedisCodec<K, V> codec, boolean withIdx) {
+    public StringMatchResultOutput(RedisCodec<K, V> codec) {
         super(codec, null);
-        this.withIdx = withIdx;
     }
 
     @Override
     public void set(ByteBuffer bytes) {
-
-        if (!withIdx && matchString == null) {
-            matchString = (String) codec.decodeKey(bytes);
-        } else {
-            readingLen = LEN.equals(bytes);
-        }
+        matchString = (String) codec.decodeKey(bytes);
+        readingLen = LEN.equals(bytes);
     }
 
     @Override
     public void set(long integer) {
-
         if (readingLen) {
             this.len = (int) integer;
         } else {
@@ -78,7 +70,7 @@ public class StringMatchResultOutput<K, V> extends CommandOutput<K, V, StringMat
             }
             positions.add(integer);
         }
-
+        matchString = null;
     }
 
     @Override

--- a/src/test/java/io/lettuce/core/output/StringMatchResultOutputUnitTests.java
+++ b/src/test/java/io/lettuce/core/output/StringMatchResultOutputUnitTests.java
@@ -1,18 +1,97 @@
 package io.lettuce.core.output;
 
-import io.lettuce.core.StringMatchResult;
-import io.lettuce.core.codec.StringCodec;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+
+import io.lettuce.core.StringMatchResult;
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.protocol.ProtocolVersion;
+import io.lettuce.core.protocol.RedisStateMachine;
 
 public class StringMatchResultOutputUnitTests {
 
     @Test
-    void parseLenAndMatches() {
-        StringMatchResultOutput<String, String> output = new StringMatchResultOutput<>(new StringCodec(), false);
+    void parseManually() {
+        byte[] rawOne = "%2\r\n$7\r\nmatches\r\n*1\r\n*3\r\n*2\r\n:4\r\n:7\r\n*2\r\n:5\r\n:8\r\n:4\r\n$3\r\nlen\r\n:6\r\n"
+                .getBytes(StandardCharsets.US_ASCII);
+        byte[] rawTwo = "%2\r\n$3\r\nlen\r\n:6\r\n$7\r\nmatches\r\n*1\r\n*3\r\n*2\r\n:4\r\n:7\r\n*2\r\n:5\r\n:8\r\n:4\r\n"
+                .getBytes(StandardCharsets.US_ASCII);
+        RedisStateMachine rsm = new RedisStateMachine();
+        rsm.setProtocolVersion(ProtocolVersion.RESP3);
+
+        StringMatchResultOutput<String, String> o1 = new StringMatchResultOutput<>(StringCodec.ASCII);
+        assertThat(rsm.decode(Unpooled.wrappedBuffer(rawOne), o1)).isTrue();
+
+        StringMatchResultOutput<String, String> o2 = new StringMatchResultOutput<>(StringCodec.ASCII);
+        assertThat(rsm.decode(Unpooled.wrappedBuffer(rawTwo), o2)).isTrue();
+
+        Map<String, Object> res1 = transform(o1.get());
+        Map<String, Object> res2 = transform(o2.get());
+
+        assertThat(res1).isEqualTo(res2);
+    }
+
+    private Map<String, Object> transform(StringMatchResult result) {
+        Map<String, Object> obj = new HashMap<>();
+        List<Object> matches = new ArrayList<>();
+        for (StringMatchResult.MatchedPosition match : result.getMatches()) {
+            Map<String, Object> intra = new HashMap<>();
+            Map<String, Object> a = new HashMap<>();
+            Map<String, Object> b = new HashMap<>();
+            a.put("start", match.getA().getStart());
+            a.put("end", match.getA().getEnd());
+
+            b.put("start", match.getB().getStart());
+            b.put("end", match.getB().getEnd());
+            intra.put("a", a);
+            intra.put("b", b);
+            intra.put("matchLen", match.getMatchLen());
+            matches.add(intra);
+        }
+        obj.put("matches", matches);
+        obj.put("len", result.getLen());
+        return obj;
+    }
+
+    @Test
+    void parseOnlyStringMatch() {
+        StringMatchResultOutput<String, String> output = new StringMatchResultOutput<>(StringCodec.ASCII);
+
+        String matchString = "some-string";
+        output.set(ByteBuffer.wrap(matchString.getBytes()));
+        output.complete(0);
+
+        StringMatchResult result = output.get();
+        assertThat(result.getMatchString()).isEqualTo(matchString);
+        assertThat(result.getMatches()).isEmpty();
+        assertThat(result.getLen()).isZero();
+    }
+
+    @Test
+    void parseOnlyLen() {
+        StringMatchResultOutput<String, String> output = new StringMatchResultOutput<>(StringCodec.ASCII);
+
+        output.set(42);
+        output.complete(0);
+
+        StringMatchResult result = output.get();
+        assertThat(result.getMatchString()).isNull();
+        assertThat(result.getMatches()).isEmpty();
+        assertThat(result.getLen()).isEqualTo(42);
+    }
+
+    @Test
+    void parseLenAndMatchesWithIdx() {
+        StringMatchResultOutput<String, String> output = new StringMatchResultOutput<>(StringCodec.ASCII);
 
         output.set(ByteBuffer.wrap("len".getBytes()));
         output.set(42);
@@ -28,8 +107,8 @@ public class StringMatchResultOutputUnitTests {
 
         StringMatchResult result = output.get();
 
+        assertThat(result.getMatchString()).isNull();
         assertThat(result.getLen()).isEqualTo(42);
-
         assertThat(result.getMatches()).hasSize(1).satisfies(m -> assertMatchedPositions(m.get(0), 0, 5, 10, 15));
     }
 

--- a/src/test/java/io/lettuce/core/output/StringMatchResultOutputUnitTests.java
+++ b/src/test/java/io/lettuce/core/output/StringMatchResultOutputUnitTests.java
@@ -1,0 +1,43 @@
+package io.lettuce.core.output;
+
+import io.lettuce.core.StringMatchResult;
+import io.lettuce.core.codec.StringCodec;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StringMatchResultOutputUnitTests {
+
+    @Test
+    void parseLenAndMatches() {
+        StringMatchResultOutput<String, String> output = new StringMatchResultOutput<>(new StringCodec(), false);
+
+        output.set(ByteBuffer.wrap("len".getBytes()));
+        output.set(42);
+
+        output.set(ByteBuffer.wrap("matches".getBytes()));
+        output.set(0);
+        output.set(5);
+        output.set(10);
+        output.set(15);
+
+        output.complete(2);
+        output.complete(0);
+
+        StringMatchResult result = output.get();
+
+        assertThat(result.getLen()).isEqualTo(42);
+
+        assertThat(result.getMatches()).hasSize(1).satisfies(m -> assertMatchedPositions(m.get(0), 0, 5, 10, 15));
+    }
+
+    private void assertMatchedPositions(StringMatchResult.MatchedPosition match, int... expected) {
+        assertThat(match.getA().getStart()).isEqualTo(expected[0]);
+        assertThat(match.getA().getEnd()).isEqualTo(expected[1]);
+        assertThat(match.getB().getStart()).isEqualTo(expected[2]);
+        assertThat(match.getB().getEnd()).isEqualTo(expected[3]);
+    }
+
+}


### PR DESCRIPTION
Originally, the LCS response parsing depended on the order of the returned map. The `len` field updates when adding the values to the `matches` values. Just a simple fix to verify first which key was read in the `#set(ByteBuffer)` method.