### PR TITLE
Add the github repo url to the doc config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: Lettuce Reference Guide
+repo_url: https://github.com/redis/lettuce
 theme:
   name: material
   logo: static/logo-redis.svg


### PR DESCRIPTION
This adds the lettuce GitHub repo link/information to the top right corner of the docs, handy for getting back to the repo from any documentation page.

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
