### PR TITLE
Add hasNoSlots() method to RedisClusterNode

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/models/partitions/RedisClusterNode.java
+++ b/src/main/java/io/lettuce/core/cluster/models/partitions/RedisClusterNode.java
@@ -45,6 +45,7 @@ import io.lettuce.core.models.role.RedisNodeDescription;
  *
  * @author Mark Paluch
  * @author Alessandro Simi
+ * @author Tony Zhang
  * @since 3.0
  */
 @SuppressWarnings("serial")
@@ -292,6 +293,15 @@ public class RedisClusterNode implements Serializable, RedisNodeDescription {
         }
 
         return slots;
+    }
+
+    /**
+     * Checks if the node has no slots assigned.
+     *
+     * @return {@code true} if the slots field is null or empty, {@code false} otherwise.
+     */
+    public boolean hasNoSlots() {
+        return slots == null || slots.isEmpty();
     }
 
     /**

--- a/src/test/java/io/lettuce/core/cluster/models/partitions/RedisClusterNodeUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/models/partitions/RedisClusterNodeUnitTests.java
@@ -140,4 +140,35 @@ class RedisClusterNodeUnitTests {
         assertThat(node.toString()).contains(RedisClusterNode.class.getSimpleName());
     }
 
+    @Test
+    void shouldReturnTrueWhenSlotsAreNull() {
+
+        BitSet emptySlots = null;
+        RedisClusterNode node = new RedisClusterNode(RedisURI.create("localhost", 6379), "1", true, null, 0, 0, 0, emptySlots,
+                Collections.emptySet());
+
+        assertThat(node.hasNoSlots()).isTrue();
+    }
+
+    @Test
+    void shouldReturnTrueWhenSlotsAreEmpty() {
+
+        BitSet emptySlots = new BitSet(); // Empty BitSet
+        RedisClusterNode node = new RedisClusterNode(RedisURI.create("localhost", 6379), "1", true, null, 0, 0, 0, emptySlots,
+                Collections.emptySet());
+
+        assertThat(node.hasNoSlots()).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenSlotsAreAssigned() {
+
+        BitSet slots = new BitSet();
+        slots.set(1); // Assign a slot
+        RedisClusterNode node = new RedisClusterNode(RedisURI.create("localhost", 6379), "1", true, null, 0, 0, 0, slots,
+                Collections.emptySet());
+
+        assertThat(node.hasNoSlots()).isFalse();
+    }
+
 }


### PR DESCRIPTION
Closes #3014 

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

Pull Request: Add hasNoSlots() Method to RedisClusterNode

#### Feature Request:

This pull request addresses feature request [#3014](https://github.com/redis/lettuce/issues/3014) and is related to the bug report [#2769](https://github.com/redis/lettuce/issues/2769).

#### Problem:

Currently, checking if a RedisClusterNode has no assigned slots involves accessing the private slots field or using getSlots(), which generates unnecessary objects and adds overhead.

#### Solution:

This PR introduces a new method, hasNoSlots(), in the RedisClusterNode class. This method encapsulates the logic for checking if the slots field is either null or empty, improving performance and code readability.

#### Changes:

	•	Added the method public boolean hasNoSlots() to the RedisClusterNode class.
	•	Added unit tests to validate the behavior of this method.

#### Testing:

	•	All existing tests pass.
	•	New unit tests were added to ensure correct behavior when:
	•	Slots are null.
	•	Slots are empty.
	•	Slots are assigned.
