### PR TITLE
Should not update Known nodes when refreshed topology is empty

### DIFF
--- a/src/main/java/io/lettuce/core/masterreplica/SentinelConnector.java
+++ b/src/main/java/io/lettuce/core/masterreplica/SentinelConnector.java
@@ -120,7 +120,8 @@ class SentinelConnector<K, V> implements MasterReplicaConnector<K, V> {
                     EventRecorder.getInstance().record(new MasterReplicaTopologyChangedEvent(redisURI, nodes));
 
                     if (nodes.isEmpty()) {
-                        LOG.warn("Topology refresh returned no nodes from {}", redisURI);
+                        LOG.warn("Topology refresh returned no nodes from {}, skip refresh Known nodes", redisURI);
+                        return;
                     }
 
                     LOG.debug("New topology: {}", nodes);


### PR DESCRIPTION
Closes #3017


