### PR TITLE
ScanIterator.scan.stream().toList() causes "java.lang.IllegalStateException: Accept exceeded fixed size of 0" on Java 16+ (#3002)

### DIFF
--- a/src/main/java/io/lettuce/core/ScanIterator.java
+++ b/src/main/java/io/lettuce/core/ScanIterator.java
@@ -341,7 +341,7 @@ public abstract class ScanIterator<T> implements Iterator<T> {
      * @return a {@link Stream} for this {@link ScanIterator}.
      */
     public Stream<T> stream() {
-        return StreamSupport.stream(Spliterators.spliterator(this, 0, 0), false);
+        return StreamSupport.stream(Spliterators.spliterator(this, -1, 0), false);
     }
 
     /**


### PR DESCRIPTION
Closes #3002

Applied the same solution as the one in the spring tracker.
Currently the infrastructure does not allow us to add a test for this, as we are using Java 8 on the pipeline.
(verified locally - of course - with Java 17 and Java 21)

Will add another issue to consider enabling the infra to at least run the tests with newer versions of Java.

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
