### PR TITLE
OpsForGeo producing "READONLY You can't write against a read only replica " on READS... 

### DIFF
--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -58,8 +58,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static io.lettuce.core.protocol.CommandType.EXEC;
-import static io.lettuce.core.protocol.CommandType.GEORADIUS;
-import static io.lettuce.core.protocol.CommandType.GEORADIUSBYMEMBER;
 import static io.lettuce.core.protocol.CommandType.GEORADIUSBYMEMBER_RO;
 import static io.lettuce.core.protocol.CommandType.GEORADIUS_RO;
 
@@ -1140,13 +1138,13 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
 
     @Override
     public RedisFuture<Set<V>> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit) {
-        return dispatch(commandBuilder.georadius(GEORADIUS, key, longitude, latitude, distance, unit.name()));
+        return georadius_ro(key, longitude, latitude, distance, unit);
     }
 
     @Override
     public RedisFuture<List<GeoWithin<V>>> georadius(K key, double longitude, double latitude, double distance,
             GeoArgs.Unit unit, GeoArgs geoArgs) {
-        return dispatch(commandBuilder.georadius(GEORADIUS, key, longitude, latitude, distance, unit.name(), geoArgs));
+        return georadius_ro(key, longitude, latitude, distance, unit, geoArgs);
     }
 
     @Override
@@ -1166,13 +1164,13 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
 
     @Override
     public RedisFuture<Set<V>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit) {
-        return dispatch(commandBuilder.georadiusbymember(GEORADIUSBYMEMBER, key, member, distance, unit.name()));
+        return georadiusbymember_ro(key, member, distance, unit);
     }
 
     @Override
     public RedisFuture<List<GeoWithin<V>>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit,
             GeoArgs geoArgs) {
-        return dispatch(commandBuilder.georadiusbymember(GEORADIUSBYMEMBER, key, member, distance, unit.name(), geoArgs));
+        return georadiusbymember_ro(key, member, distance, unit, geoArgs);
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -66,8 +66,6 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 import static io.lettuce.core.protocol.CommandType.EXEC;
-import static io.lettuce.core.protocol.CommandType.GEORADIUS;
-import static io.lettuce.core.protocol.CommandType.GEORADIUSBYMEMBER;
 import static io.lettuce.core.protocol.CommandType.GEORADIUSBYMEMBER_RO;
 import static io.lettuce.core.protocol.CommandType.GEORADIUS_RO;
 
@@ -1203,14 +1201,14 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
-    public Flux<V> georadius(K key, double longitude, double latitude, double distance, Unit unit) {
-        return createDissolvingFlux(() -> commandBuilder.georadius(GEORADIUS, key, longitude, latitude, distance, unit.name()));
+    public Flux<V> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit) {
+        return georadius_ro(key, longitude, latitude, distance, unit);
     }
 
     @Override
-    public Flux<GeoWithin<V>> georadius(K key, double longitude, double latitude, double distance, Unit unit, GeoArgs geoArgs) {
-        return createDissolvingFlux(
-                () -> commandBuilder.georadius(GEORADIUS, key, longitude, latitude, distance, unit.name(), geoArgs));
+    public Flux<GeoWithin<V>> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit,
+            GeoArgs geoArgs) {
+        return georadius_ro(key, longitude, latitude, distance, unit, geoArgs);
     }
 
     @Override
@@ -1231,15 +1229,13 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
-    public Flux<V> georadiusbymember(K key, V member, double distance, Unit unit) {
-        return createDissolvingFlux(
-                () -> commandBuilder.georadiusbymember(GEORADIUSBYMEMBER, key, member, distance, unit.name()));
+    public Flux<V> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit) {
+        return georadiusbymember_ro(key, member, distance, unit);
     }
 
     @Override
-    public Flux<GeoWithin<V>> georadiusbymember(K key, V member, double distance, Unit unit, GeoArgs geoArgs) {
-        return createDissolvingFlux(
-                () -> commandBuilder.georadiusbymember(GEORADIUSBYMEMBER, key, member, distance, unit.name(), geoArgs));
+    public Flux<GeoWithin<V>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit, GeoArgs geoArgs) {
+        return georadiusbymember_ro(key, member, distance, unit, geoArgs);
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterAsyncCommandsImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterAsyncCommandsImpl.java
@@ -250,28 +250,6 @@ public class RedisAdvancedClusterAsyncCommandsImpl<K, V> extends AbstractRedisAs
     }
 
     @Override
-    public RedisFuture<Set<V>> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit) {
-        return super.georadius_ro(key, longitude, latitude, distance, unit);
-    }
-
-    @Override
-    public RedisFuture<List<GeoWithin<V>>> georadius(K key, double longitude, double latitude, double distance,
-            GeoArgs.Unit unit, GeoArgs geoArgs) {
-        return super.georadius_ro(key, longitude, latitude, distance, unit, geoArgs);
-    }
-
-    @Override
-    public RedisFuture<Set<V>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit) {
-        return super.georadiusbymember_ro(key, member, distance, unit);
-    }
-
-    @Override
-    public RedisFuture<List<GeoWithin<V>>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit,
-            GeoArgs geoArgs) {
-        return super.georadiusbymember_ro(key, member, distance, unit, geoArgs);
-    }
-
-    @Override
     public RedisFuture<List<K>> keys(K pattern) {
 
         Map<String, CompletableFuture<List<K>>> executions = executeOnUpstream(commands -> commands.keys(pattern));

--- a/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImpl.java
@@ -236,27 +236,6 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
     }
 
     @Override
-    public Flux<V> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit) {
-        return super.georadius_ro(key, longitude, latitude, distance, unit);
-    }
-
-    @Override
-    public Flux<GeoWithin<V>> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit,
-            GeoArgs geoArgs) {
-        return super.georadius_ro(key, longitude, latitude, distance, unit, geoArgs);
-    }
-
-    @Override
-    public Flux<V> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit) {
-        return super.georadiusbymember_ro(key, member, distance, unit);
-    }
-
-    @Override
-    public Flux<GeoWithin<V>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit, GeoArgs geoArgs) {
-        return super.georadiusbymember_ro(key, member, distance, unit, geoArgs);
-    }
-
-    @Override
     public Flux<K> keys(K pattern) {
 
         Map<String, Publisher<K>> publishers = executeOnUpstream(commands -> commands.keys(pattern));

--- a/src/main/java/io/lettuce/core/cluster/RedisClusterPubSubAsyncCommandsImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisClusterPubSubAsyncCommandsImpl.java
@@ -66,28 +66,6 @@ public class RedisClusterPubSubAsyncCommandsImpl<K, V> extends RedisPubSubAsyncC
     }
 
     @Override
-    public RedisFuture<Set<V>> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit) {
-        return super.georadius_ro(key, longitude, latitude, distance, unit);
-    }
-
-    @Override
-    public RedisFuture<List<GeoWithin<V>>> georadius(K key, double longitude, double latitude, double distance,
-            GeoArgs.Unit unit, GeoArgs geoArgs) {
-        return super.georadius_ro(key, longitude, latitude, distance, unit, geoArgs);
-    }
-
-    @Override
-    public RedisFuture<Set<V>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit) {
-        return super.georadiusbymember_ro(key, member, distance, unit);
-    }
-
-    @Override
-    public RedisFuture<List<GeoWithin<V>>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit,
-            GeoArgs geoArgs) {
-        return super.georadiusbymember_ro(key, member, distance, unit, geoArgs);
-    }
-
-    @Override
     public StatefulRedisClusterPubSubConnectionImpl<K, V> getStatefulConnection() {
         return (StatefulRedisClusterPubSubConnectionImpl<K, V>) super.getStatefulConnection();
     }

--- a/src/test/java/io/lettuce/core/commands/GeoMasterReplicaIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/GeoMasterReplicaIntegrationTests.java
@@ -114,12 +114,4 @@ public class GeoMasterReplicaIntegrationTests extends AbstractRedisClientTest {
         redis.geoadd(key, 8.3796281, 48.9978127, "EFS9", 8.665351, 49.553302, "Bahn");
     }
 
-    private static double getY(List<GeoWithin<String>> georadius, int i) {
-        return georadius.get(i).getCoordinates().getY().doubleValue();
-    }
-
-    private static double getX(List<GeoWithin<String>> georadius, int i) {
-        return georadius.get(i).getCoordinates().getX().doubleValue();
-    }
-
 }

--- a/src/test/java/io/lettuce/core/commands/GeoMasterReplicaIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/GeoMasterReplicaIntegrationTests.java
@@ -1,0 +1,122 @@
+package io.lettuce.core.commands;
+
+import io.lettuce.core.*;
+import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.masterreplica.MasterReplica;
+import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection;
+import io.lettuce.core.models.role.RedisInstance;
+import io.lettuce.core.models.role.RoleParser;
+import io.lettuce.test.LettuceExtension;
+import io.lettuce.test.condition.EnabledOnCommand;
+import io.lettuce.test.settings.TestSettings;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import static io.lettuce.TestTags.INTEGRATION_TEST;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * @author Mark Paluch
+ */
+@Tag(INTEGRATION_TEST)
+@ExtendWith(LettuceExtension.class)
+@EnabledOnCommand("GEOADD")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class GeoMasterReplicaIntegrationTests extends AbstractRedisClientTest {
+
+    private StatefulRedisMasterReplicaConnection<String, String> masterReplica;
+
+    private RedisCommands<String, String> upstream;
+
+    private RedisCommands<String, String> connection1;
+
+    private RedisCommands<String, String> connection2;
+
+    @BeforeEach
+    void before() {
+
+        RedisURI node1 = RedisURI.Builder.redis(host, TestSettings.port(3)).withDatabase(2).build();
+        RedisURI node2 = RedisURI.Builder.redis(host, TestSettings.port(4)).withDatabase(2).build();
+
+        connection1 = client.connect(node1).sync();
+        connection2 = client.connect(node2).sync();
+
+        RedisInstance node1Instance = RoleParser.parse(this.connection1.role());
+        RedisInstance node2Instance = RoleParser.parse(this.connection2.role());
+
+        if (node1Instance.getRole().isUpstream() && node2Instance.getRole().isReplica()) {
+            upstream = connection1;
+        } else if (node2Instance.getRole().isUpstream() && node1Instance.getRole().isReplica()) {
+            upstream = connection2;
+        } else {
+            assumeTrue(false,
+                    String.format("Cannot run the test because I don't have a distinct master and replica but %s and %s",
+                            node1Instance, node2Instance));
+        }
+
+        masterReplica = MasterReplica.connect(client, StringCodec.UTF8, Arrays.asList(node1, node2));
+        masterReplica.setReadFrom(ReadFrom.REPLICA);
+    }
+
+    @AfterEach
+    void after() {
+
+        if (connection1 != null) {
+            connection1.getStatefulConnection().close();
+        }
+
+        if (connection2 != null) {
+            connection2.getStatefulConnection().close();
+        }
+
+        if (masterReplica != null) {
+            masterReplica.close();
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        this.redis.flushall();
+    }
+
+    @Test
+    void georadiusReadFromReplica() {
+
+        prepareGeo(upstream);
+
+        upstream.waitForReplication(1, 1000);
+
+        Set<String> georadius = masterReplica.sync().georadius(key, 8.6582861, 49.5285695, 1, GeoArgs.Unit.km);
+        assertThat(georadius).hasSize(1).contains("Weinheim");
+    }
+
+    @Test
+    void georadiusbymemberReadFromReplica() {
+
+        prepareGeo(upstream);
+        upstream.waitForReplication(1, 100);
+
+        Set<String> empty = masterReplica.sync().georadiusbymember(key, "Bahn", 1, GeoArgs.Unit.km);
+        assertThat(empty).hasSize(1).contains("Bahn");
+    }
+
+    protected void prepareGeo(RedisCommands<String, String> redis) {
+        redis.geoadd(key, 8.6638775, 49.5282537, "Weinheim");
+        redis.geoadd(key, 8.3796281, 48.9978127, "EFS9", 8.665351, 49.553302, "Bahn");
+    }
+
+    private static double getY(List<GeoWithin<String>> georadius, int i) {
+        return georadius.get(i).getCoordinates().getY().doubleValue();
+    }
+
+    private static double getX(List<GeoWithin<String>> georadius, int i) {
+        return georadius.get(i).getCoordinates().getX().doubleValue();
+    }
+
+}

--- a/src/test/java/io/lettuce/core/commands/GeoMasterReplicaIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/GeoMasterReplicaIntegrationTests.java
@@ -47,6 +47,9 @@ public class GeoMasterReplicaIntegrationTests extends AbstractRedisClientTest {
         connection1 = client.connect(node1).sync();
         connection2 = client.connect(node2).sync();
 
+        connection1.flushall();
+        connection2.flushall();
+
         RedisInstance node1Instance = RoleParser.parse(this.connection1.role());
         RedisInstance node2Instance = RoleParser.parse(this.connection2.role());
 


### PR DESCRIPTION
only if master & replica configured 

Divert pure read intentions of **georadius** and **georadiusbymember** commands (variants that do not use STORE/STOREDIST) to GEORADIUS_RO/GEORADIUSBYMEMBER_RO This will unify the behavior between Cluster and Redis Standalone/Replica arrangements

Relates to  issues #1481 #2568 #2871

Closes #1813

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [+] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [+] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [+] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [+] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
