### PR TITLE
Propagate handshake failures to Handshake future

### DIFF
--- a/src/main/java/io/lettuce/core/RedisHandshake.java
+++ b/src/main/java/io/lettuce/core/RedisHandshake.java
@@ -134,8 +134,12 @@ class RedisHandshake implements ConnectionInitializer {
                     handshake.completeExceptionally(throwable);
                 }
             } else {
-                onHelloResponse(settings);
-                handshake.complete(null);
+                try {
+                    onHelloResponse(settings);
+                    handshake.complete(null);
+                } catch (RuntimeException e) {
+                    handshake.completeExceptionally(e);
+                }
             }
         });
 


### PR DESCRIPTION
We now complete the handshake future exceptionally if handshake settings do not match our expectations. This can happen if e.g. the connection id is being sent as String instead of an integer.

See also:

* https://github.com/Prompt-oven/auth-service/issues/16
* https://github.com/microsoft/garnet/issues/811
