### PR TITLE
refactor mget method improved readability and efficiency

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -76,7 +76,7 @@ jobs:
           gh-repository: 'github.com/redis/lettuce'
           gh-pages-branch: 'benchmarks'
           benchmark-data-dir-path: './'
-          output-file-path: benchmark.log
+          output-file-path: benchmarks.json
           fail-on-alert: false
           alert-threshold: '200%'
           alert-comment-cc-users: '@tishun'

--- a/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImpl.java
@@ -264,37 +264,25 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
             return super.mget(keyList);
         }
 
-        List<Publisher<KeyValue<K, V>>> publishers = new ArrayList<>();
+        List<Publisher<KeyValue<K, V>>> publishers = partitioned.values().stream().map(super::mget)
+                .collect(Collectors.toList());
 
-        for (Map.Entry<Integer, List<K>> entry : partitioned.entrySet()) {
-            publishers.add(super.mget(entry.getValue()));
-        }
-
-        Flux<KeyValue<K, V>> fluxes = Flux.mergeSequential(publishers);
-
-        Mono<List<KeyValue<K, V>>> map = fluxes.collectList().map(vs -> {
-
-            KeyValue<K, V>[] values = new KeyValue[vs.size()];
+        return Flux.mergeSequential(publishers).collectList().map(results -> {
+            KeyValue<K, V>[] values = new KeyValue[keyList.size()];
             int offset = 0;
-            for (Map.Entry<Integer, List<K>> entry : partitioned.entrySet()) {
 
+            for (List<K> partitionKeys : partitioned.values()) {
                 for (int i = 0; i < keyList.size(); i++) {
-
-                    int index = entry.getValue().indexOf(keyList.get(i));
-                    if (index == -1) {
-                        continue;
+                    int index = partitionKeys.indexOf(keyList.get(i));
+                    if (index != -1) {
+                        values[i] = results.get(offset + index);
                     }
-
-                    values[i] = vs.get(offset + index);
                 }
-
-                offset += entry.getValue().size();
+                offset += partitionKeys.size();
             }
 
             return Arrays.asList(values);
-        });
-
-        return map.flatMapIterable(keyValues -> keyValues);
+        }).flatMapMany(Flux::fromIterable);
     }
 
     @Override


### PR DESCRIPTION
## Related Feature Request
Relates to feature request: [Improve mget method implementation using Java 8 Streams]

## Description
This PR refactors the `mget` method in `RedisAdvancedClusterReactiveCommandsImpl.java` to improve code readability and maintainability by utilizing Java 8 Streams and reactive programming patterns.

### Current Implementation Issues
- Uses manual for loops to build publisher list
- Complex nested iteration structure
- Less readable code for handling partitioned data
- Uses `flatMapIterable` instead of more idiomatic reactive approach

### Proposed Changes
- Replaced manual publisher list creation with Stream API
- Simplified partition handling using functional approach
- Improved reactive chain using `flatMapMany(Flux::fromIterable)`
- Maintained same functionality with cleaner implementation

## Implementation Details
- Replaced `for` loop with `partitioned.values().stream().map(super::mget)`
- Streamlined result processing using reactive chain
- Maintained backward compatibility with existing API
- No changes to public interfaces

---

closes #3060 