### PR TITLE
Test failures not reported because step is skipped

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -59,6 +59,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test failure reports to Codecov
         uses: codecov/test-results-action@v1
+        if: always() # always upload test results to include test failures
         with:
           fail_ci_if_error: false
           files: ./target/surefire-reports/TEST*,./target/failsafe-reports/TEST*

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,13 +1,6 @@
 name: Release Drafter
 
-on:
-  push:
-    # branches to consider in the event; optional, defaults to all
-    branches:
-      - '[0-9].*'
-  # pull_request event is required only for autolabeler
-  pull_request:
-    types: [opened, reopened, synchronize]
+on: workflow_dispatch
 
 permissions:
   contents: read


### PR DESCRIPTION
Make sure we execute the step to report test execution to catch failed tests
(additionally) disable ReleaseDrafter as it is not helping, leaving it as manual step

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
