### PR TITLE
Lettuce EntraID integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,12 +189,6 @@
             <version>0.1.1-beta1</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.github.cdimascio</groupId>
-            <artifactId>dotenv-java</artifactId>
-            <version>2.2.0</version>
-            <scope>test</scope>
-        </dependency>
         <!-- Start of core dependencies -->
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1044,6 +1044,38 @@
         <profile>
             <id>ci</id>
         </profile>
+        <profile>
+            <id>entraid-it</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                           <skipTests>true</skipTests>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <groups>entraid</groups>
+                            <skipITs>false</skipITs>
+                            <includes>
+                                <include>**/*IntegrationTests</include>
+                            </includes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 
         <profile>
 

--- a/src/test/java/io/lettuce/TestTags.java
+++ b/src/test/java/io/lettuce/TestTags.java
@@ -29,4 +29,9 @@ public class TestTags {
      */
     public static final String API_GENERATOR = "api_generator";
 
+    /**
+     * Tag for EntraId integration tests (require a running environment with configured microsoft EntraId authentication)
+     */
+    public static final String ENTRA_ID = "entraid";
+
 }

--- a/src/test/java/io/lettuce/authx/EntraIdClusterIntegrationTests.java
+++ b/src/test/java/io/lettuce/authx/EntraIdClusterIntegrationTests.java
@@ -1,0 +1,111 @@
+package io.lettuce.authx;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisFuture;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.SocketOptions;
+import io.lettuce.core.TimeoutOptions;
+import io.lettuce.core.TransactionResult;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.async.RedisAsyncCommands;
+import io.lettuce.core.cluster.ClusterClientOptions;
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
+import io.lettuce.core.resource.ClientResources;
+import io.lettuce.core.resource.DnsResolver;
+import io.lettuce.core.support.PubSubTestListener;
+import io.lettuce.test.Wait;
+import io.lettuce.test.env.Endpoints;
+import io.lettuce.test.env.Endpoints.Endpoint;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import redis.clients.authentication.core.TokenAuthConfig;
+import redis.clients.authentication.entraid.EntraIDTokenAuthConfigBuilder;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.lettuce.TestTags.ENTRA_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+@Tag(ENTRA_ID)
+public class EntraIdClusterIntegrationTests {
+
+    private static final EntraIdTestContext testCtx = EntraIdTestContext.DEFAULT;
+
+    private static TokenBasedRedisCredentialsProvider credentialsProvider;
+
+    private static RedisClusterClient clusterClient;
+
+    private static ClientResources resources;
+
+    private static Endpoint cluster;
+
+    @BeforeAll
+    public static void setup() {
+        cluster = Endpoints.DEFAULT.getEndpoint("cluster-entraid-acl");
+        if (cluster != null) {
+            Assumptions.assumeTrue(testCtx.getClientId() != null && testCtx.getClientSecret() != null,
+                    "Skipping EntraID tests. Azure AD credentials not provided!");
+            // Configure timeout options to assure fast test failover
+            ClusterClientOptions clientOptions = ClusterClientOptions.builder()
+                    .socketOptions(SocketOptions.builder().connectTimeout(Duration.ofSeconds(1)).build())
+                    .timeoutOptions(TimeoutOptions.enabled(Duration.ofSeconds(1)))
+                    // enable re-authentication
+                    .reauthenticateBehavior(ClientOptions.ReauthenticateBehavior.ON_NEW_CREDENTIALS).build();
+
+            TokenAuthConfig tokenAuthConfig = EntraIDTokenAuthConfigBuilder.builder().clientId(testCtx.getClientId())
+                    .secret(testCtx.getClientSecret()).authority(testCtx.getAuthority()).scopes(testCtx.getRedisScopes())
+                    .expirationRefreshRatio(0.0000001F).build();
+
+            credentialsProvider = TokenBasedRedisCredentialsProvider.create(tokenAuthConfig);
+
+            resources = ClientResources.builder().dnsResolver(DnsResolver.jvmDefault()).build();
+
+            RedisURI clusterUri = RedisURI.create(cluster.getEndpoints().get(0));
+            clusterUri.setCredentialsProvider(credentialsProvider);
+            clusterClient = RedisClusterClient.create(resources, clusterUri);
+            clusterClient.setOptions(clientOptions);
+        }
+    }
+
+    @AfterAll
+    public static void cleanup() {
+        if (credentialsProvider != null) {
+            credentialsProvider.close();
+        }
+        if (resources != null) {
+            resources.shutdown();
+        }
+    }
+
+    // T.1.1
+    // Verify authentication using Azure AD with service principals using Redis Cluster Client
+    @Test
+    public void clusterWithSecret_azureServicePrincipalIntegrationTest() throws ExecutionException, InterruptedException {
+        assumeTrue(cluster != null, "Skipping EntraID tests. Redis host with enabled EntraId not provided!");
+
+        try (StatefulRedisClusterConnection<String, String> connection = clusterClient.connect()) {
+            assertThat(connection.sync().aclWhoami()).isEqualTo(cluster.getUsername());
+            assertThat(connection.async().aclWhoami().get()).isEqualTo(cluster.getUsername());
+            assertThat(connection.reactive().aclWhoami().block()).isEqualTo(cluster.getUsername());
+
+            connection.getPartitions().forEach((partition) -> {
+                try (StatefulRedisConnection<?, ?> nodeConnection = connection.getConnection(partition.getNodeId())) {
+                    assertThat(nodeConnection.sync().aclWhoami()).isEqualTo(cluster.getUsername());
+                }
+            });
+        }
+    }
+
+}

--- a/src/test/java/io/lettuce/authx/EntraIdIntegrationTests.java
+++ b/src/test/java/io/lettuce/authx/EntraIdIntegrationTests.java
@@ -12,8 +12,6 @@ import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.cluster.ClusterClientOptions;
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
-import io.lettuce.core.resource.ClientResources;
-import io.lettuce.core.resource.DnsResolver;
 import io.lettuce.core.support.PubSubTestListener;
 import io.lettuce.test.Wait;
 import io.lettuce.test.env.Endpoints;
@@ -47,8 +45,6 @@ public class EntraIdIntegrationTests {
 
     private static RedisClient client;
 
-    private static ClientResources resources;
-
     private static Endpoint standalone;
 
     @BeforeAll
@@ -70,13 +66,9 @@ public class EntraIdIntegrationTests {
 
             credentialsProvider = TokenBasedRedisCredentialsProvider.create(tokenAuthConfig);
 
-            resources = ClientResources.builder()
-                    // .dnsResolver(DnsResolver.jvmDefault())
-                    .build();
-
             RedisURI uri = RedisURI.create((standalone.getEndpoints().get(0)));
             uri.setCredentialsProvider(credentialsProvider);
-            client = RedisClient.create(resources, uri);
+            client = RedisClient.create(uri);
             client.setOptions(clientOptions);
 
         }
@@ -86,9 +78,6 @@ public class EntraIdIntegrationTests {
     public static void cleanup() {
         if (credentialsProvider != null) {
             credentialsProvider.close();
-        }
-        if (resources != null) {
-            resources.shutdown();
         }
     }
 

--- a/src/test/java/io/lettuce/authx/EntraIdIntegrationTests.java
+++ b/src/test/java/io/lettuce/authx/EntraIdIntegrationTests.java
@@ -10,8 +10,6 @@ import io.lettuce.core.TransactionResult;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.cluster.ClusterClientOptions;
-import io.lettuce.core.cluster.RedisClusterClient;
-import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 import io.lettuce.core.resource.ClientResources;
 import io.lettuce.core.resource.DnsResolver;
@@ -22,7 +20,6 @@ import io.lettuce.test.env.Endpoints.Endpoint;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import redis.clients.authentication.core.TokenAuthConfig;
@@ -73,12 +70,11 @@ public class EntraIdIntegrationTests {
 
             resources = ClientResources.builder().dnsResolver(DnsResolver.jvmDefault()).build();
 
-            if (standalone != null) {
-                RedisURI uri = RedisURI.create((standalone.getEndpoints().get(0)));
-                uri.setCredentialsProvider(credentialsProvider);
-                client = RedisClient.create(resources, uri);
-                client.setOptions(clientOptions);
-            }
+            RedisURI uri = RedisURI.create((standalone.getEndpoints().get(0)));
+            uri.setCredentialsProvider(credentialsProvider);
+            client = RedisClient.create(resources, uri);
+            client.setOptions(clientOptions);
+
         }
     }
 

--- a/src/test/java/io/lettuce/authx/EntraIdIntegrationTests.java
+++ b/src/test/java/io/lettuce/authx/EntraIdIntegrationTests.java
@@ -70,7 +70,9 @@ public class EntraIdIntegrationTests {
 
             credentialsProvider = TokenBasedRedisCredentialsProvider.create(tokenAuthConfig);
 
-            resources = ClientResources.builder().dnsResolver(DnsResolver.jvmDefault()).build();
+            resources = ClientResources.builder()
+                    // .dnsResolver(DnsResolver.jvmDefault())
+                    .build();
 
             RedisURI uri = RedisURI.create((standalone.getEndpoints().get(0)));
             uri.setCredentialsProvider(credentialsProvider);

--- a/src/test/java/io/lettuce/authx/EntraIdManagedIdentityIntegrationTests.java
+++ b/src/test/java/io/lettuce/authx/EntraIdManagedIdentityIntegrationTests.java
@@ -1,0 +1,105 @@
+package io.lettuce.authx;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.core.cluster.ClusterClientOptions;
+import io.lettuce.test.env.Endpoints;
+import io.lettuce.test.env.Endpoints.Endpoint;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import redis.clients.authentication.core.TokenAuthConfig;
+import redis.clients.authentication.entraid.EntraIDTokenAuthConfigBuilder;
+import redis.clients.authentication.entraid.ManagedIdentityInfo;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import static io.lettuce.TestTags.ENTRA_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+@Tag(ENTRA_ID)
+public class EntraIdManagedIdentityIntegrationTests {
+
+    private static final EntraIdTestContext testCtx = EntraIdTestContext.DEFAULT;
+
+    private static RedisClient client;
+
+    private static Endpoint standalone;
+
+    private static Set<String> managedIdentityAudience = Collections.singleton("https://redis.azure.com");
+
+    @BeforeAll
+    public static void setup() {
+        standalone = Endpoints.DEFAULT.getEndpoint("standalone-entraid-acl");
+        assumeTrue(standalone != null, "Skipping test because no Redis endpoint is configured!");
+    }
+
+    @Test
+    public void withUserAssignedId_azureManagedIdentityIntegrationTest() throws ExecutionException, InterruptedException {
+
+        // enable re-authentication
+        ClusterClientOptions clientOptions = ClusterClientOptions.builder()
+                .reauthenticateBehavior(ClientOptions.ReauthenticateBehavior.ON_NEW_CREDENTIALS).build();
+
+        TokenAuthConfig tokenAuthConfig = EntraIDTokenAuthConfigBuilder.builder()
+                .userAssignedManagedIdentity(ManagedIdentityInfo.UserManagedIdentityType.OBJECT_ID,
+                        testCtx.getUserAssignedManagedIdentity())
+                .scopes(managedIdentityAudience).build();
+
+        try (TokenBasedRedisCredentialsProvider credentialsProvider = TokenBasedRedisCredentialsProvider
+                .create(tokenAuthConfig)) {
+
+            RedisURI uri = RedisURI.create((standalone.getEndpoints().get(0)));
+            uri.setCredentialsProvider(credentialsProvider);
+            client = RedisClient.create(uri);
+            client.setOptions(clientOptions);
+
+            try (StatefulRedisConnection<String, String> connection = client.connect()) {
+                RedisCommands<String, String> sync = connection.sync();
+                String key = UUID.randomUUID().toString();
+                sync.set(key, "value");
+                assertThat(connection.sync().get(key)).isEqualTo("value");
+                assertThat(connection.async().get(key).get()).isEqualTo("value");
+                assertThat(connection.reactive().get(key).block()).isEqualTo("value");
+                sync.del(key);
+            }
+        }
+    }
+
+    @Test
+    public void withSystemAssignedId_azureManagedIdentityIntegrationTest() throws ExecutionException, InterruptedException {
+        // enable re-authentication
+        ClusterClientOptions clientOptions = ClusterClientOptions.builder()
+                .reauthenticateBehavior(ClientOptions.ReauthenticateBehavior.ON_NEW_CREDENTIALS).build();
+
+        TokenAuthConfig tokenAuthConfig = EntraIDTokenAuthConfigBuilder.builder().systemAssignedManagedIdentity()
+                .scopes(managedIdentityAudience).build();
+
+        try (TokenBasedRedisCredentialsProvider credentialsProvider = TokenBasedRedisCredentialsProvider
+                .create(tokenAuthConfig)) {
+
+            RedisURI uri = RedisURI.create((standalone.getEndpoints().get(0)));
+            uri.setCredentialsProvider(credentialsProvider);
+            client = RedisClient.create(uri);
+            client.setOptions(clientOptions);
+
+            try (StatefulRedisConnection<String, String> connection = client.connect()) {
+                RedisCommands<String, String> sync = connection.sync();
+                String key = UUID.randomUUID().toString();
+                sync.set(key, "value");
+                assertThat(connection.sync().get(key)).isEqualTo("value");
+                assertThat(connection.async().get(key).get()).isEqualTo("value");
+                assertThat(connection.reactive().get(key).block()).isEqualTo("value");
+                sync.del(key);
+            }
+        }
+    }
+
+}

--- a/src/test/java/io/lettuce/authx/EntraIdTestContext.java
+++ b/src/test/java/io/lettuce/authx/EntraIdTestContext.java
@@ -14,6 +14,8 @@ public class EntraIdTestContext {
 
     private static final String AZURE_REDIS_SCOPES = "AZURE_REDIS_SCOPES";
 
+    private static final String AZURE_USER_ASSIGNED_MANAGED_ID = "AZURE_USER_ASSIGNED_MANAGED_ID";
+
     private final String clientId;
 
     private final String authority;
@@ -22,12 +24,15 @@ public class EntraIdTestContext {
 
     private Set<String> redisScopes;
 
+    private String userAssignedManagedIdentity;
+
     public static final EntraIdTestContext DEFAULT = new EntraIdTestContext();
 
     private EntraIdTestContext() {
         clientId = System.getenv(AZURE_CLIENT_ID);
         authority = System.getenv(AZURE_AUTHORITY);
         clientSecret = System.getenv(AZURE_CLIENT_SECRET);
+        this.userAssignedManagedIdentity = System.getenv(AZURE_USER_ASSIGNED_MANAGED_ID);
     }
 
     public EntraIdTestContext(String clientId, String authority, String clientSecret, Set<String> redisScopes,
@@ -36,6 +41,7 @@ public class EntraIdTestContext {
         this.authority = authority;
         this.clientSecret = clientSecret;
         this.redisScopes = redisScopes;
+        this.userAssignedManagedIdentity = userAssignedManagedIdentity;
     }
 
     public String getClientId() {
@@ -56,6 +62,10 @@ public class EntraIdTestContext {
             this.redisScopes = new HashSet<>(Arrays.asList(redisScopesEnv.split(";")));
         }
         return redisScopes;
+    }
+
+    public String getUserAssignedManagedIdentity() {
+        return userAssignedManagedIdentity;
     }
 
 }

--- a/src/test/java/io/lettuce/authx/EntraIdTestContext.java
+++ b/src/test/java/io/lettuce/authx/EntraIdTestContext.java
@@ -13,21 +13,9 @@ public class EntraIdTestContext {
 
     private static final String AZURE_CLIENT_SECRET = "AZURE_CLIENT_SECRET";
 
-    private static final String AZURE_SP_OID = "AZURE_SP_OID";
-
     private static final String AZURE_AUTHORITY = "AZURE_AUTHORITY";
 
     private static final String AZURE_REDIS_SCOPES = "AZURE_REDIS_SCOPES";
-
-    private static final String REDIS_AZURE_HOST = "REDIS_AZURE_HOST";
-
-    private static final String REDIS_AZURE_PORT = "REDIS_AZURE_PORT";
-
-    private static final String REDIS_AZURE_CLUSTER_HOST = "REDIS_AZURE_CLUSTER_HOST";
-
-    private static final String REDIS_AZURE_CLUSTER_PORT = "REDIS_AZURE_CLUSTER_PORT";
-
-    private static final String REDIS_AZURE_DB = "REDIS_AZURE_DB";
 
     private final String clientId;
 
@@ -35,35 +23,19 @@ public class EntraIdTestContext {
 
     private final String clientSecret;
 
-    private final String spOID;
-
     private final Set<String> redisScopes;
-
-    private final String redisHost;
-
-    private final int redisPort;
-
-    private final List<String> redisClusterHost;
-
-    private final int redisClusterPort;
 
     private static Dotenv dotenv;
     static {
-        dotenv = Dotenv.configure().directory("src/test/resources").filename(".env.entraid").load();
+        dotenv = Dotenv.configure().directory("src/test/resources").filename(".env.entraid.local").load();
     }
 
     public static final EntraIdTestContext DEFAULT = new EntraIdTestContext();
 
     private EntraIdTestContext() {
-        // Using Dotenv directly here
         clientId = dotenv.get(AZURE_CLIENT_ID, "<client-id>");
         clientSecret = dotenv.get(AZURE_CLIENT_SECRET, "<client-secret>");
-        spOID = dotenv.get(AZURE_SP_OID, "<service-provider-oid>");
         authority = dotenv.get(AZURE_AUTHORITY, "https://login.microsoftonline.com/your-tenant-id");
-        redisHost = dotenv.get(REDIS_AZURE_HOST);
-        redisPort = Integer.parseInt(dotenv.get(REDIS_AZURE_PORT, "6379"));
-        redisClusterHost = Arrays.asList(dotenv.get(REDIS_AZURE_CLUSTER_HOST, "").split(","));
-        redisClusterPort = Integer.parseInt(dotenv.get(REDIS_AZURE_CLUSTER_PORT, "6379"));
         String redisScopesEnv = dotenv.get(AZURE_REDIS_SCOPES, "https://redis.azure.com/.default");
         if (redisScopesEnv != null && !redisScopesEnv.isEmpty()) {
             this.redisScopes = new HashSet<>(Arrays.asList(redisScopesEnv.split(";")));
@@ -72,28 +44,8 @@ public class EntraIdTestContext {
         }
     }
 
-    public String host() {
-        return redisHost;
-    }
-
-    public int port() {
-        return redisPort;
-    }
-
-    public List<String> clusterHost() {
-        return redisClusterHost;
-    }
-
-    public int clusterPort() {
-        return redisClusterPort;
-    }
-
     public String getClientId() {
         return clientId;
-    }
-
-    public String getSpOID() {
-        return spOID;
     }
 
     public String getAuthority() {

--- a/src/test/java/io/lettuce/authx/EntraIdTestContext.java
+++ b/src/test/java/io/lettuce/authx/EntraIdTestContext.java
@@ -1,10 +1,7 @@
 package io.lettuce.authx;
 
-import io.github.cdimascio.dotenv.Dotenv;
-
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 public class EntraIdTestContext {
@@ -23,25 +20,22 @@ public class EntraIdTestContext {
 
     private final String clientSecret;
 
-    private final Set<String> redisScopes;
-
-    private static Dotenv dotenv;
-    static {
-        dotenv = Dotenv.configure().directory("src/test/resources").filename(".env.entraid.local").load();
-    }
+    private Set<String> redisScopes;
 
     public static final EntraIdTestContext DEFAULT = new EntraIdTestContext();
 
     private EntraIdTestContext() {
-        clientId = dotenv.get(AZURE_CLIENT_ID, "<client-id>");
-        clientSecret = dotenv.get(AZURE_CLIENT_SECRET, "<client-secret>");
-        authority = dotenv.get(AZURE_AUTHORITY, "https://login.microsoftonline.com/your-tenant-id");
-        String redisScopesEnv = dotenv.get(AZURE_REDIS_SCOPES, "https://redis.azure.com/.default");
-        if (redisScopesEnv != null && !redisScopesEnv.isEmpty()) {
-            this.redisScopes = new HashSet<>(Arrays.asList(redisScopesEnv.split(";")));
-        } else {
-            this.redisScopes = new HashSet<>();
-        }
+        clientId = System.getenv(AZURE_CLIENT_ID);
+        authority = System.getenv(AZURE_AUTHORITY);
+        clientSecret = System.getenv(AZURE_CLIENT_SECRET);
+    }
+
+    public EntraIdTestContext(String clientId, String authority, String clientSecret, Set<String> redisScopes,
+            String userAssignedManagedIdentity) {
+        this.clientId = clientId;
+        this.authority = authority;
+        this.clientSecret = clientSecret;
+        this.redisScopes = redisScopes;
     }
 
     public String getClientId() {
@@ -57,6 +51,10 @@ public class EntraIdTestContext {
     }
 
     public Set<String> getRedisScopes() {
+        if (redisScopes == null) {
+            String redisScopesEnv = System.getenv(AZURE_REDIS_SCOPES);
+            this.redisScopes = new HashSet<>(Arrays.asList(redisScopesEnv.split(";")));
+        }
         return redisScopes;
     }
 

--- a/src/test/java/io/lettuce/test/env/Endpoints.java
+++ b/src/test/java/io/lettuce/test/env/Endpoints.java
@@ -1,0 +1,235 @@
+package io.lettuce.test.env;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+
+public class Endpoints {
+
+    private static final Logger log = LoggerFactory.getLogger(Endpoints.class);
+
+    private Map<String, Endpoint> endpoints;
+
+    public static final Endpoints DEFAULT;
+
+    static {
+        String filePath = System.getenv("REDIS_ENDPOINTS_CONFIG_PATH");
+        if (filePath == null || filePath.isEmpty()) {
+            log.info("REDIS_ENDPOINTS_CONFIG_PATH environment variable is not set. No Endpoints configuration will be loaded.");
+            DEFAULT = new Endpoints(Collections.emptyMap());
+        } else {
+            DEFAULT = fromFile(filePath);
+        }
+    }
+
+    private Endpoints(Map<String, Endpoint> endpoints) {
+        this.endpoints = endpoints;
+    }
+
+    /**
+     * Factory method to create an Endpoints instance from a file.
+     *
+     * @param filePath Path to the JSON file.
+     * @return Populated Endpoints instance.
+     */
+    public static Endpoints fromFile(String filePath) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            File file = new File(filePath);
+
+            HashMap<String, Endpoint> endpoints = objectMapper.readValue(file,
+                    objectMapper.getTypeFactory().constructMapType(HashMap.class, String.class, Endpoint.class));
+            return new Endpoints(endpoints);
+
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load Endpoints from file: " + filePath, e);
+        }
+    }
+
+    /**
+     * Get an endpoint by name.
+     *
+     * @param name the name of the endpoint.
+     * @return the corresponding Endpoint or {@code null} if not found.
+     */
+    public Endpoint getEndpoint(String name) {
+        return endpoints != null ? endpoints.get(name) : null;
+    }
+
+    public Map<String, Endpoint> getEndpoints() {
+        return endpoints;
+    }
+
+    public void setEndpoints(Map<String, Endpoint> endpoints) {
+        this.endpoints = endpoints;
+    }
+
+    // Inner classes for Endpoint and RawEndpoint
+    public static class Endpoint {
+
+        @JsonProperty("bdb_id")
+        private int bdbId;
+
+        private String username;
+
+        private String password;
+
+        private boolean tls;
+
+        @JsonProperty("raw_endpoints")
+        private List<RawEndpoint> rawEndpoints;
+
+        private List<String> endpoints;
+
+        // Getters and Setters
+        public int getBdbId() {
+            return bdbId;
+        }
+
+        public void setBdbId(int bdbId) {
+            this.bdbId = bdbId;
+        }
+
+        public String getUsername() {
+            return username;
+        }
+
+        public void setUsername(String username) {
+            this.username = username;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String password) {
+            this.password = password;
+        }
+
+        public boolean isTls() {
+            return tls;
+        }
+
+        public void setTls(boolean tls) {
+            this.tls = tls;
+        }
+
+        public List<RawEndpoint> getRawEndpoints() {
+            return rawEndpoints;
+        }
+
+        public void setRawEndpoints(List<RawEndpoint> rawEndpoints) {
+            this.rawEndpoints = rawEndpoints;
+        }
+
+        public List<String> getEndpoints() {
+            return endpoints;
+        }
+
+        public void setEndpoints(List<String> endpoints) {
+            this.endpoints = endpoints;
+        }
+
+    }
+
+    public static class RawEndpoint {
+
+        private List<String> addr;
+
+        @JsonProperty("addr_type")
+        private String addrType;
+
+        @JsonProperty("dns_name")
+        private String dnsName;
+
+        @JsonProperty("oss_cluster_api_preferred_endpoint_type")
+        private String preferredEndpointType;
+
+        @JsonProperty("oss_cluster_api_preferred_ip_type")
+        private String preferredIpType;
+
+        private int port;
+
+        @JsonProperty("proxy_policy")
+        private String proxyPolicy;
+
+        private String uid;
+
+        // Getters and Setters
+        public List<String> getAddr() {
+            return addr;
+        }
+
+        public void setAddr(List<String> addr) {
+            this.addr = addr;
+        }
+
+        public String getAddrType() {
+            return addrType;
+        }
+
+        public void setAddrType(String addrType) {
+            this.addrType = addrType;
+        }
+
+        public String getDnsName() {
+            return dnsName;
+        }
+
+        public void setDnsName(String dnsName) {
+            this.dnsName = dnsName;
+        }
+
+        public String getPreferredEndpointType() {
+            return preferredEndpointType;
+        }
+
+        public void setPreferredEndpointType(String preferredEndpointType) {
+            this.preferredEndpointType = preferredEndpointType;
+        }
+
+        public String getPreferredIpType() {
+            return preferredIpType;
+        }
+
+        public void setPreferredIpType(String preferredIpType) {
+            this.preferredIpType = preferredIpType;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        public void setPort(int port) {
+            this.port = port;
+        }
+
+        public String getProxyPolicy() {
+            return proxyPolicy;
+        }
+
+        public void setProxyPolicy(String proxyPolicy) {
+            this.proxyPolicy = proxyPolicy;
+        }
+
+        public String getUid() {
+            return uid;
+        }
+
+        public void setUid(String uid) {
+            this.uid = uid;
+        }
+
+    }
+
+}


### PR DESCRIPTION
Prepare EntraId integration tests for inclusion in EntraId nightly tests

Changes introduced with this review:
- Separated EntraID standalone & cluster tests (`EntraIdIntegrationTests.java`, `EntraIdClusterIntegrationTests.java`)
- Added EntraID managed identity integration test - `EntraIdManagedIdentityIntegrationTests.java`
- Read EntraID test env settings from `endpoints.json`
- get rid of `dotenv-java`
- EntraID related tests marked with `entraid` tag

To run entraId-related tests you use:
`mvn  integration-test -Pentraid-it`

Prerequisites: 
- Redis server configured with enabled EntraID authentication
- Provide required info in EntraIdTestContext.


Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
