### PR TITLE
Add custom connection validation to ConnectionPoolSupport #3081

### DIFF
--- a/src/main/java/io/lettuce/core/support/ConnectionPoolSupport.java
+++ b/src/main/java/io/lettuce/core/support/ConnectionPoolSupport.java
@@ -71,7 +71,8 @@ public abstract class ConnectionPoolSupport {
 
     /**
      * Creates a new {@link GenericObjectPool} using the {@link Supplier}. Allocated instances are wrapped and must not be
-     * returned with {@link ObjectPool#returnObject(Object)}.
+     * returned with {@link ObjectPool#returnObject(Object)}. By default, connections are validated by checking their
+     * {@link StatefulConnection#isOpen()} method.
      *
      * @param connectionSupplier must not be {@code null}.
      * @param config must not be {@code null}.
@@ -79,8 +80,41 @@ public abstract class ConnectionPoolSupport {
      * @return the connection pool.
      */
     public static <T extends StatefulConnection<?, ?>> GenericObjectPool<T> createGenericObjectPool(
-            Supplier<T> connectionSupplier, GenericObjectPoolConfig<T> config, Predicate<T> connectionValidator) {
-        return createGenericObjectPool(connectionSupplier, config, true, connectionValidator);
+            Supplier<T> connectionSupplier, GenericObjectPoolConfig<T> config) {
+        return createGenericObjectPool(connectionSupplier, config, true, (c) -> c.isOpen());
+    }
+
+    /**
+     * Creates a new {@link GenericObjectPool} using the {@link Supplier}. Allocated instances are wrapped and must not be
+     * returned with {@link ObjectPool#returnObject(Object)}.
+     *
+     * @param connectionSupplier must not be {@code null}.
+     * @param config must not be {@code null}.
+     * @param validationPredicate a {@link Predicate} to help validate connections
+     * @param <T> connection type.
+     * @return the connection pool.
+     */
+    public static <T extends StatefulConnection<?, ?>> GenericObjectPool<T> createGenericObjectPool(
+            Supplier<T> connectionSupplier, GenericObjectPoolConfig<T> config, Predicate<T> validationPredicate) {
+        return createGenericObjectPool(connectionSupplier, config, true, validationPredicate);
+    }
+
+    /**
+     * Creates a new {@link GenericObjectPool} using the {@link Supplier}. By default, connections are validated by checking
+     * their {@link StatefulConnection#isOpen()} method.
+     *
+     * @param connectionSupplier must not be {@code null}.
+     * @param config must not be {@code null}.
+     * @param wrapConnections {@code false} to return direct connections that need to be returned to the pool using
+     *        {@link ObjectPool#returnObject(Object)}. {@code true} to return wrapped connections that are returned to the pool
+     *        when invoking {@link StatefulConnection#close()}.
+     * @param <T> connection type.
+     * @return the connection pool.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T extends StatefulConnection<?, ?>> GenericObjectPool<T> createGenericObjectPool(
+            Supplier<T> connectionSupplier, GenericObjectPoolConfig<T> config, boolean wrapConnections) {
+        return createGenericObjectPool(connectionSupplier, config, wrapConnections, (c) -> c.isOpen());
     }
 
     /**
@@ -89,24 +123,25 @@ public abstract class ConnectionPoolSupport {
      * @param connectionSupplier must not be {@code null}.
      * @param config must not be {@code null}.
      * @param wrapConnections {@code false} to return direct connections that need to be returned to the pool using
-     *        {@link ObjectPool#returnObject(Object)}. {@code true} to return wrapped connection that are returned to the pool
+     *        {@link ObjectPool#returnObject(Object)}. {@code true} to return wrapped connections that are returned to the pool
      *        when invoking {@link StatefulConnection#close()}.
+     * @param validationPredicate a {@link Predicate} to help validate connections
      * @param <T> connection type.
      * @return the connection pool.
      */
     @SuppressWarnings("unchecked")
     public static <T extends StatefulConnection<?, ?>> GenericObjectPool<T> createGenericObjectPool(
             Supplier<T> connectionSupplier, GenericObjectPoolConfig<T> config, boolean wrapConnections,
-            Predicate<T> connectionValidator) {
+            Predicate<T> validationPredicate) {
 
         LettuceAssert.notNull(connectionSupplier, "Connection supplier must not be null");
         LettuceAssert.notNull(config, "GenericObjectPoolConfig must not be null");
-        LettuceAssert.notNull(connectionValidator, "Connection validator must not be null");
+        LettuceAssert.notNull(validationPredicate, "Connection validator must not be null");
 
         AtomicReference<Origin<T>> poolRef = new AtomicReference<>();
 
         GenericObjectPool<T> pool = new GenericObjectPool<T>(
-                new EnhancedRedisPooledObjectFactory<T>(connectionSupplier, connectionValidator), config) {
+                new RedisPooledObjectFactory<>(connectionSupplier, validationPredicate), config) {
 
             @Override
             public T borrowObject() throws Exception {
@@ -149,7 +184,7 @@ public abstract class ConnectionPoolSupport {
      *
      * @param connectionSupplier must not be {@code null}.
      * @param wrapConnections {@code false} to return direct connections that need to be returned to the pool using
-     *        {@link ObjectPool#returnObject(Object)}. {@code true} to return wrapped connection that are returned to the pool
+     *        {@link ObjectPool#returnObject(Object)}. {@code true} to return wrapped connections that are returned to the pool
      *        when invoking {@link StatefulConnection#close()}.
      * @param <T> connection type.
      * @return the connection pool.
@@ -157,12 +192,30 @@ public abstract class ConnectionPoolSupport {
     @SuppressWarnings("unchecked")
     public static <T extends StatefulConnection<?, ?>> SoftReferenceObjectPool<T> createSoftReferenceObjectPool(
             Supplier<T> connectionSupplier, boolean wrapConnections) {
+        return createSoftReferenceObjectPool(connectionSupplier, wrapConnections, (c) -> c.isOpen());
+    }
+
+    /**
+     * Creates a new {@link SoftReferenceObjectPool} using the {@link Supplier}.
+     *
+     * @param connectionSupplier must not be {@code null}.
+     * @param wrapConnections {@code false} to return direct connections that need to be returned to the pool using
+     *        {@link ObjectPool#returnObject(Object)}. {@code true} to return wrapped connections that are returned to the pool
+     *        when invoking {@link StatefulConnection#close()}.
+     * @param validationPredicate a {@link Predicate} to help validate connections
+     * @param <T> connection type.
+     * @return the connection pool.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T extends StatefulConnection<?, ?>> SoftReferenceObjectPool<T> createSoftReferenceObjectPool(
+            Supplier<T> connectionSupplier, boolean wrapConnections, Predicate<T> validationPredicate) {
 
         LettuceAssert.notNull(connectionSupplier, "Connection supplier must not be null");
 
         AtomicReference<Origin<T>> poolRef = new AtomicReference<>();
 
-        SoftReferenceObjectPool<T> pool = new SoftReferenceObjectPool<T>(new RedisPooledObjectFactory<>(connectionSupplier)) {
+        SoftReferenceObjectPool<T> pool = new SoftReferenceObjectPool<T>(
+                new RedisPooledObjectFactory<>(connectionSupplier, validationPredicate)) {
 
             private final Lock lock = new ReentrantLock();
 
@@ -205,8 +258,11 @@ public abstract class ConnectionPoolSupport {
 
         private final Supplier<T> connectionSupplier;
 
-        RedisPooledObjectFactory(Supplier<T> connectionSupplier) {
+        private final Predicate<T> validationPredicate;
+
+        RedisPooledObjectFactory(Supplier<T> connectionSupplier, Predicate<T> validationPredicate) {
             this.connectionSupplier = connectionSupplier;
+            this.validationPredicate = validationPredicate;
         }
 
         @Override
@@ -226,7 +282,7 @@ public abstract class ConnectionPoolSupport {
 
         @Override
         public boolean validateObject(PooledObject<T> p) {
-            return p.getObject().isOpen();
+            return this.validationPredicate.test(p.getObject());
         }
 
     }
@@ -250,45 +306,6 @@ public abstract class ConnectionPoolSupport {
         public CompletableFuture<Void> returnObjectAsync(T o) throws Exception {
             pool.returnObject(o);
             return COMPLETED;
-        }
-
-    }
-
-    private static class EnhancedRedisPooledObjectFactory<T extends StatefulConnection<?, ?>>
-            extends BasePooledObjectFactory<T> {
-
-        private final Supplier<T> connectionSupplier;
-
-        private final Predicate<T> connectionValidator;
-
-        EnhancedRedisPooledObjectFactory(Supplier<T> connectionSupplier, Predicate<T> connectionValidator) {
-            this.connectionSupplier = connectionSupplier;
-            this.connectionValidator = connectionValidator;
-        }
-
-        @Override
-        public T create() throws Exception {
-            return connectionSupplier.get();
-        }
-
-        @Override
-        public PooledObject<T> wrap(T obj) {
-            return new DefaultPooledObject<>(obj);
-        }
-
-        @Override
-        public boolean validateObject(PooledObject<T> p) {
-            T connection = p.getObject();
-            return connection.isOpen() && connectionValidator.test(connection);
-        }
-
-        @Override
-        public void destroyObject(PooledObject<T> p) throws Exception {
-            try {
-                p.getObject().close();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
         }
 
     }

--- a/src/test/java/io/lettuce/core/dynamic/RedisCommandsIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/dynamic/RedisCommandsIntegrationTests.java
@@ -100,7 +100,13 @@ class RedisCommandsIntegrationTests extends TestSupport {
     void shouldWorkWithPooledConnection() throws Exception {
 
         GenericObjectPool<StatefulRedisConnection<String, String>> pool = ConnectionPoolSupport
-                .createGenericObjectPool(client::connect, new GenericObjectPoolConfig<>());
+                .createGenericObjectPool(client::connect, new GenericObjectPoolConfig<>(), connection -> {
+                    try {
+                        return "PONG".equals(connection.sync().ping());
+                    } catch (Exception e) {
+                        return false;
+                    }
+                });
 
         try (StatefulRedisConnection<String, String> connection = pool.borrowObject()) {
 

--- a/src/test/java/io/lettuce/core/dynamic/RedisCommandsIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/dynamic/RedisCommandsIntegrationTests.java
@@ -100,6 +100,22 @@ class RedisCommandsIntegrationTests extends TestSupport {
     void shouldWorkWithPooledConnection() throws Exception {
 
         GenericObjectPool<StatefulRedisConnection<String, String>> pool = ConnectionPoolSupport
+                .createGenericObjectPool(client::connect, new GenericObjectPoolConfig<>());
+
+        try (StatefulRedisConnection<String, String> connection = pool.borrowObject()) {
+
+            RedisCommandFactory factory = new RedisCommandFactory(connection);
+            SimpleCommands commands = factory.getCommands(SimpleCommands.class);
+            commands.get("foo");
+        }
+
+        pool.close();
+    }
+
+    @Test
+    void shouldWorkWithPooledConnectionAndCustomValidation() throws Exception {
+
+        GenericObjectPool<StatefulRedisConnection<String, String>> pool = ConnectionPoolSupport
                 .createGenericObjectPool(client::connect, new GenericObjectPoolConfig<>(), connection -> {
                     try {
                         return "PONG".equals(connection.sync().ping());

--- a/src/test/java/io/lettuce/core/support/ConnectionPoolSupportIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/support/ConnectionPoolSupportIntegrationTests.java
@@ -66,7 +66,13 @@ class ConnectionPoolSupportIntegrationTests extends TestSupport {
     void genericPoolShouldWorkWithWrappedConnections() throws Exception {
 
         GenericObjectPool<StatefulRedisConnection<String, String>> pool = ConnectionPoolSupport
-                .createGenericObjectPool(() -> client.connect(), new GenericObjectPoolConfig<>());
+                .createGenericObjectPool(() -> client.connect(), new GenericObjectPoolConfig<>(), connection -> {
+                    try {
+                        return "PONG".equals(connection.sync().ping());
+                    } catch (Exception e) {
+                        return false;
+                    }
+                });
 
         borrowAndReturn(pool);
         borrowAndClose(pool);
@@ -91,7 +97,13 @@ class ConnectionPoolSupportIntegrationTests extends TestSupport {
         poolConfig.setMaxIdle(2);
 
         GenericObjectPool<StatefulRedisConnection<String, String>> pool = ConnectionPoolSupport
-                .createGenericObjectPool(() -> client.connect(), poolConfig);
+                .createGenericObjectPool(() -> client.connect(), poolConfig, connection -> {
+                    try {
+                        return "PONG".equals(connection.sync().ping());
+                    } catch (Exception e) {
+                        return false;
+                    }
+                });
 
         borrowAndReturn(pool);
         borrowAndClose(pool);
@@ -120,7 +132,13 @@ class ConnectionPoolSupportIntegrationTests extends TestSupport {
     void genericPoolShouldWorkWithPlainConnections() throws Exception {
 
         GenericObjectPool<StatefulRedisConnection<String, String>> pool = ConnectionPoolSupport
-                .createGenericObjectPool(() -> client.connect(), new GenericObjectPoolConfig<>(), false);
+                .createGenericObjectPool(() -> client.connect(), new GenericObjectPoolConfig<>(), false, connection -> {
+                    try {
+                        return "PONG".equals(connection.sync().ping());
+                    } catch (Exception e) {
+                        return false;
+                    }
+                });
 
         borrowAndReturn(pool);
 
@@ -151,7 +169,13 @@ class ConnectionPoolSupportIntegrationTests extends TestSupport {
     void genericPoolUsingWrappingShouldPropagateExceptionsCorrectly() throws Exception {
 
         GenericObjectPool<StatefulRedisConnection<String, String>> pool = ConnectionPoolSupport
-                .createGenericObjectPool(() -> client.connect(), new GenericObjectPoolConfig<>());
+                .createGenericObjectPool(() -> client.connect(), new GenericObjectPoolConfig<>(), connection -> {
+                    try {
+                        return "PONG".equals(connection.sync().ping());
+                    } catch (Exception e) {
+                        return false;
+                    }
+                });
 
         StatefulRedisConnection<String, String> connection = pool.borrowObject();
         RedisCommands<String, String> sync = connection.sync();
@@ -172,7 +196,13 @@ class ConnectionPoolSupportIntegrationTests extends TestSupport {
     void wrappedConnectionShouldUseWrappers() throws Exception {
 
         GenericObjectPool<StatefulRedisConnection<String, String>> pool = ConnectionPoolSupport
-                .createGenericObjectPool(() -> client.connect(), new GenericObjectPoolConfig<>());
+                .createGenericObjectPool(() -> client.connect(), new GenericObjectPoolConfig<>(), connection -> {
+                    try {
+                        return "PONG".equals(connection.sync().ping());
+                    } catch (Exception e) {
+                        return false;
+                    }
+                });
 
         StatefulRedisConnection<String, String> connection = pool.borrowObject();
         RedisCommands<String, String> sync = connection.sync();
@@ -197,7 +227,13 @@ class ConnectionPoolSupportIntegrationTests extends TestSupport {
 
         GenericObjectPool<StatefulRedisMasterReplicaConnection<String, String>> pool = ConnectionPoolSupport
                 .createGenericObjectPool(() -> MasterReplica.connect(client, new StringCodec(), RedisURI.create(host, port)),
-                        new GenericObjectPoolConfig<>());
+                        new GenericObjectPoolConfig<>(), connection -> {
+                            try {
+                                return "PONG".equals(connection.sync().ping());
+                            } catch (Exception e) {
+                                return false;
+                            }
+                        });
 
         StatefulRedisMasterReplicaConnection<String, String> connection = pool.borrowObject();
         RedisCommands<String, String> sync = connection.sync();
@@ -223,7 +259,13 @@ class ConnectionPoolSupportIntegrationTests extends TestSupport {
                 RedisURI.create(TestSettings.host(), 7379));
 
         GenericObjectPool<StatefulRedisClusterConnection<String, String>> pool = ConnectionPoolSupport
-                .createGenericObjectPool(redisClusterClient::connect, new GenericObjectPoolConfig<>());
+                .createGenericObjectPool(redisClusterClient::connect, new GenericObjectPoolConfig<>(), connection -> {
+                    try {
+                        return "PONG".equals(connection.sync().ping());
+                    } catch (Exception e) {
+                        return false;
+                    }
+                });
 
         StatefulRedisClusterConnection<String, String> connection = pool.borrowObject();
         RedisAdvancedClusterCommands<String, String> sync = connection.sync();
@@ -250,7 +292,13 @@ class ConnectionPoolSupportIntegrationTests extends TestSupport {
     void plainConnectionShouldNotUseWrappers() throws Exception {
 
         GenericObjectPool<StatefulRedisConnection<String, String>> pool = ConnectionPoolSupport
-                .createGenericObjectPool(() -> client.connect(), new GenericObjectPoolConfig<>(), false);
+                .createGenericObjectPool(() -> client.connect(), new GenericObjectPoolConfig<>(), false, connection -> {
+                    try {
+                        return "PONG".equals(connection.sync().ping());
+                    } catch (Exception e) {
+                        return false;
+                    }
+                });
 
         StatefulRedisConnection<String, String> connection = pool.borrowObject();
         RedisCommands<String, String> sync = connection.sync();
@@ -295,7 +343,13 @@ class ConnectionPoolSupportIntegrationTests extends TestSupport {
     void wrappedObjectClosedAfterReturn() throws Exception {
 
         GenericObjectPool<StatefulRedisConnection<String, String>> pool = ConnectionPoolSupport
-                .createGenericObjectPool(() -> client.connect(), new GenericObjectPoolConfig<>(), true);
+                .createGenericObjectPool(() -> client.connect(), new GenericObjectPoolConfig<>(), true, connection -> {
+                    try {
+                        return "PONG".equals(connection.sync().ping());
+                    } catch (Exception e) {
+                        return false;
+                    }
+                });
 
         StatefulRedisConnection<String, String> connection = pool.borrowObject();
         RedisCommands<String, String> sync = connection.sync();
@@ -317,7 +371,13 @@ class ConnectionPoolSupportIntegrationTests extends TestSupport {
     void tryWithResourcesReturnsConnectionToPool() throws Exception {
 
         GenericObjectPool<StatefulRedisConnection<String, String>> pool = ConnectionPoolSupport
-                .createGenericObjectPool(() -> client.connect(), new GenericObjectPoolConfig<>());
+                .createGenericObjectPool(() -> client.connect(), new GenericObjectPoolConfig<>(), connection -> {
+                    try {
+                        return "PONG".equals(connection.sync().ping());
+                    } catch (Exception e) {
+                        return false;
+                    }
+                });
 
         StatefulRedisConnection<String, String> usedConnection = null;
         try (StatefulRedisConnection<String, String> connection = pool.borrowObject()) {


### PR DESCRIPTION
Overview
---
- Introduce Predicate<T extends StatefulConnection> for connection validation
- Add new overload to ConnectionPoolSupport.createGenericObjectPool()
- Implement ConnectionPoolConfig to encapsulate validation and wrapping options
- Update RedisPooledObjectFactory to use custom validation logic

Closes #3081 

