### PR TITLE
Fix 'make test' test failures

### DIFF
--- a/src/test/java/io/lettuce/core/RedisContainerIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/RedisContainerIntegrationTests.java
@@ -26,22 +26,23 @@ public class RedisContainerIntegrationTests {
 
     private static final String REDIS_STACK_CLUSTER = "clustered-stack";
 
-    private static final String REDIS_STACK_VERSION = System.getProperty("REDIS_STACK_VERSION", "8.0-M04-pre");;
+    private static final String REDIS_STACK_VERSION = System.getProperty("REDIS_STACK_VERSION");
 
     private static Exception initializationException;
 
     public static ComposeContainer CLUSTERED_STACK = new ComposeContainer(
             new File("src/test/resources/docker/docker-compose.yml")).withExposedService(REDIS_STACK_CLUSTER, 36379)
                     .withExposedService(REDIS_STACK_CLUSTER, 36380).withExposedService(REDIS_STACK_CLUSTER, 36381)
-                    .withExposedService(REDIS_STACK_STANDALONE, 6379)
-                    .withEnv("CLIENT_LIBS_TEST_IMAGE", "redislabs/client-libs-test")
-                    .withEnv("REDIS_STACK_VERSION", REDIS_STACK_VERSION).withPull(false).withLocalCompose(true);
+                    .withExposedService(REDIS_STACK_STANDALONE, 6379).withPull(false).withLocalCompose(true);
 
     // Singleton container pattern - start the containers only once
     // See https://java.testcontainers.org/test_framework_integration/manual_lifecycle_control/#singleton-containers
     static {
         int attempts = 0;
 
+        if (REDIS_STACK_VERSION != null && !REDIS_STACK_VERSION.isEmpty()) {
+            CLUSTERED_STACK.withEnv("REDIS_VERSION", REDIS_STACK_VERSION);
+        }
         // In case you need to debug the container uncomment these lines to redirect the output
         CLUSTERED_STACK.withLogConsumer(REDIS_STACK_CLUSTER, (OutputFrame frame) -> LOGGER.debug(frame.getUtf8String()));
         CLUSTERED_STACK.withLogConsumer(REDIS_STACK_STANDALONE, (OutputFrame frame) -> LOGGER.debug(frame.getUtf8String()));

--- a/src/test/resources/docker/docker-compose.yml
+++ b/src/test/resources/docker/docker-compose.yml
@@ -1,8 +1,11 @@
 ---
+x-client-libs-stack-image: &client-libs-stack-image
+    image: "redislabs/client-libs-test:${REDIS_STACK_VERSION:-8.0-M02}"
+
 services:
 
   standalone-stack:
-    image: "${CLIENT_LIBS_TEST_IMAGE}:${REDIS_STACK_VERSION}"
+    <<: *client-libs-stack-image
     environment:
         - REDIS_CLUSTER=no
         - PORT=6379
@@ -10,7 +13,7 @@ services:
       - "16379:6379"
 
   clustered-stack:
-    image: "${CLIENT_LIBS_TEST_IMAGE}:${REDIS_STACK_VERSION}"
+    <<: *client-libs-stack-image
     environment:
       - REDIS_CLUSTER=yes
       - PORT=36379


### PR DESCRIPTION
In case REDIS_STACK_VERSION is not explicitly set, an empty string is propagated by surefire plugin causing containerised test infra to fail to start


Make sure that:

- [ ] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
