### PR TITLE
JSON integration tests now do not use the test-containers framework

### DIFF
--- a/src/test/java/io/lettuce/core/json/RedisJsonClusterIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/json/RedisJsonClusterIntegrationTests.java
@@ -7,7 +7,6 @@
 
 package io.lettuce.core.json;
 
-import io.lettuce.core.RedisContainerIntegrationTests;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
@@ -39,7 +38,7 @@ import static io.lettuce.TestTags.INTEGRATION_TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Tag(INTEGRATION_TEST)
-public class RedisJsonClusterIntegrationTests extends RedisContainerIntegrationTests {
+public class RedisJsonClusterIntegrationTests {
 
     protected static RedisClusterClient client;
 

--- a/src/test/java/io/lettuce/core/json/RedisJsonIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/json/RedisJsonIntegrationTests.java
@@ -9,7 +9,6 @@ package io.lettuce.core.json;
 
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.RedisClient;
-import io.lettuce.core.RedisContainerIntegrationTests;
 import io.lettuce.core.RedisFuture;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
@@ -26,7 +25,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.io.IOException;
@@ -43,7 +41,7 @@ import static io.lettuce.TestTags.INTEGRATION_TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Tag(INTEGRATION_TEST)
-public class RedisJsonIntegrationTests extends RedisContainerIntegrationTests {
+public class RedisJsonIntegrationTests {
 
     private static final String BIKES_INVENTORY = "bikes:inventory";
 

--- a/src/test/resources/docker-env/docker-compose.yml
+++ b/src/test/resources/docker-env/docker-compose.yml
@@ -1,5 +1,7 @@
 x-client-libs-image: &client-libs-image
   image: "redislabs/client-libs-test:${REDIS_VERSION:-8.0-M04-pre}"
+x-client-libs-stack-image: &client-libs-stack-image
+  image: "redislabs/client-libs-test:${REDIS_STACK_VERSION:-8.0-M04-pre}"
 
 services:
   # Standalone Redis Servers
@@ -101,6 +103,21 @@ services:
     networks:
       - redis-network
 
+  standalone-stack:
+    <<: *client-libs-stack-image
+    environment:
+      - REDIS_CLUSTER=no
+      - PORT=6379
+    ports:
+      - "16379:6379"
+
+  clustered-stack:
+    <<: *client-libs-stack-image
+    environment:
+      - REDIS_CLUSTER=yes
+      - PORT=36379
+    ports:
+      - "36379-36381:36379-36381"
 
   ssl-test-cluster:
     <<: *client-libs-image


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
The motivation behind this change is that on the CI the testcontainers often fail to start.

We may decide to add them back to all integration tests when we have the time to stabilize the environment.


Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
