### PR TITLE
Require explicit config to use io_uring transport

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -882,6 +882,16 @@ Native transports are available with:
   classifier `linux-x86_64`. Note that this transport is still
   experimental.
 
+Note that both epoll and io_uring transports are supported on Linux. If
+you need both libraries to be present—for example if you're using a
+different transport for another Netty library—you must resolve this
+ambiguity explicitly via one of the following options:
+ 1. Set the system property `io.lettuce.core.iouring=true` to prefer
+    io_uring for all supported functions. epoll will be used for Unix
+    domain sockets, which are not supported for io_uring.
+ 2. Set `io.lettuce.core.iouring=false` to completely disable io_uring.
+ 3. Set `io.lettuce.core.epoll=false` to completely disable epoll.
+
   ``` xml
   <dependency>
       <groupId>io.netty.incubator</groupId>


### PR DESCRIPTION
Fixes #3222

This mitigates the impact of the [breaking change](https://github.com/redis/lettuce/commit/52c705b549b05d7a31aa124426cc963ac7252c42) introduced version 6.1.0 that prefers the io_uring transport over epoll. Due to this change, some users may be inadvertently using io_uring when they intend to use epoll. Since other users are now expecting the new default of io_uring, the safest option is to require explicit configuration whenever both transports are available.

While this is also breaking change, it breaks in an obvious way by throwing an exception if the transport is not configured. io_uring support is also experimental, so breaking changes are allowed, and users should expect to have to resolve this sort of issue when they upgrade.