### PR TITLE
Optimize string concatenation in NodeSelectionInvocationHandler.getNodeDescription()

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/NodeSelectionInvocationHandler.java
+++ b/src/main/java/io/lettuce/core/cluster/NodeSelectionInvocationHandler.java
@@ -264,7 +264,7 @@ class NodeSelectionInvocationHandler extends AbstractInvocationHandler {
     }
 
     private String getNodeDescription(List<RedisClusterNode> notFinished) {
-        return String.join(", ", notFinished.stream().map(this::getDescriptor).collect(Collectors.toList()));
+        return notFinished.stream().map(this::getDescriptor).collect(Collectors.joining(", "));
     }
 
     private String getDescriptor(RedisClusterNode redisClusterNode) {


### PR DESCRIPTION
Replace String.join with Collectors.joining to avoid intermediate collection creation, improving performance by eliminating the unnecessary List creation step.

Make sure that:
- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket #3261
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don't submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

This optimization changes the `getNodeDescription()` method to use the more efficient Stream collector pattern, which directly collects stream elements into a joined string rather than first collecting to an intermediate list. While the functional outcome remains identical, this approach avoids the unnecessary memory allocation of the temporary list collection, resulting in improved performance especially in high-throughput scenarios.

The existing test suite confirms that the behavior remains consistent with the previous implementation.

### Related Issue
Closes #3261