### PR TITLE
Enhance thread-safety in ClientSideCaching key retrieval 

### DIFF
--- a/src/test/java/io/lettuce/core/support/caching/ClientsideCachingIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/support/caching/ClientsideCachingIntegrationTests.java
@@ -316,13 +316,13 @@ public class ClientsideCachingIntegrationTests extends TestSupport {
         connection.sync().set(testKey1, initialValue);
         connection.sync().set(testKey2, initialValue);
 
-        ClientSideCaching<String, String> frontend = (ClientSideCaching<String, String>) ClientSideCaching.enable(
-                CacheAccessor.forMap(clientCache), connection, TrackingArgs.Builder.enabled());
+        ClientSideCaching<String, String> frontend = (ClientSideCaching<String, String>) ClientSideCaching
+                .enable(CacheAccessor.forMap(clientCache), connection, TrackingArgs.Builder.enabled());
 
         Field keyLocksField = ClientSideCaching.class.getDeclaredField("keyLocks");
         keyLocksField.setAccessible(true);
-        ConcurrentHashMap<String, ReentrantLock> keyLocks = (ConcurrentHashMap<String, ReentrantLock>) keyLocksField.get(
-                frontend);
+        ConcurrentHashMap<String, ReentrantLock> keyLocks = (ConcurrentHashMap<String, ReentrantLock>) keyLocksField
+                .get(frontend);
 
         try {
             frontend.get(testKey1);

--- a/src/test/java/io/lettuce/core/support/caching/ClientsideCachingIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/support/caching/ClientsideCachingIntegrationTests.java
@@ -3,19 +3,6 @@ package io.lettuce.core.support.caching;
 import static io.lettuce.TestTags.INTEGRATION_TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-
-import javax.inject.Inject;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.TestSupport;
@@ -29,11 +16,29 @@ import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 import io.lettuce.test.LettuceExtension;
 import io.lettuce.test.Wait;
 import io.lettuce.test.condition.EnabledOnCommand;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+import javax.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Integration tests for server-side assisted cache invalidation.
  *
  * @author Mark Paluch
+ * @author Yoobin Yoon
  */
 @Tag(INTEGRATION_TEST)
 @ExtendWith(LettuceExtension.class)
@@ -225,6 +230,129 @@ public class ClientsideCachingIntegrationTests extends TestSupport {
 
         otherParty.close();
         frontend.close();
+    }
+
+    @Test
+    void valueLoaderShouldBeInvokedOnceForConcurrentRequests() throws Exception {
+
+        Map<String, String> clientCache = new ConcurrentHashMap<>();
+
+        StatefulRedisConnection<String, String> connection = redisClient.connect();
+
+        final String testKey = "concurrent-loader-key";
+        connection.sync().del(testKey);
+
+        AtomicInteger loaderCallCount = new AtomicInteger(0);
+
+        CacheFrontend<String, String> frontend = ClientSideCaching.enable(CacheAccessor.forMap(clientCache), connection,
+                TrackingArgs.Builder.enabled());
+
+        try {
+            int threadCount = 10;
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch finishLatch = new CountDownLatch(threadCount);
+            List<String> results = new CopyOnWriteArrayList<>();
+
+            ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+            for (int i = 0; i < threadCount; i++) {
+                executor.submit(() -> {
+                    try {
+                        startLatch.await();
+
+                        String result = frontend.get(testKey, () -> {
+                            loaderCallCount.incrementAndGet();
+
+                            try {
+                                Thread.sleep(100);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+
+                            return "loaded-value";
+                        });
+
+                        results.add(result);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    } finally {
+                        finishLatch.countDown();
+                    }
+                });
+            }
+
+            startLatch.countDown();
+
+            finishLatch.await(5, TimeUnit.SECONDS);
+            executor.shutdown();
+
+            assertThat(loaderCallCount.get()).isEqualTo(1);
+
+            assertThat(results).hasSize(threadCount);
+            assertThat(results).containsOnly("loaded-value");
+
+            assertThat(connection.sync().get(testKey)).isEqualTo("loaded-value");
+
+            assertThat(clientCache).containsEntry(testKey, "loaded-value");
+        } finally {
+            frontend.close();
+            connection.close();
+        }
+    }
+
+    @Test
+    void locksShouldBeProperlyCleanedUp() throws Exception {
+
+        Map<String, String> clientCache = new ConcurrentHashMap<>();
+
+        StatefulRedisConnection<String, String> connection = redisClient.connect();
+        StatefulRedisConnection<String, String> otherClient = redisClient.connect();
+
+        final String testKey1 = "lock-test-key1";
+        final String testKey2 = "lock-test-key2";
+        final String initialValue = "initial-value";
+        final String updatedValue = "updated-value";
+
+        connection.sync().del(testKey1, testKey2);
+        connection.sync().set(testKey1, initialValue);
+        connection.sync().set(testKey2, initialValue);
+
+        ClientSideCaching<String, String> frontend = (ClientSideCaching<String, String>) ClientSideCaching.enable(
+                CacheAccessor.forMap(clientCache), connection, TrackingArgs.Builder.enabled());
+
+        Field keyLocksField = ClientSideCaching.class.getDeclaredField("keyLocks");
+        keyLocksField.setAccessible(true);
+        ConcurrentHashMap<String, ReentrantLock> keyLocks = (ConcurrentHashMap<String, ReentrantLock>) keyLocksField.get(
+                frontend);
+
+        try {
+            frontend.get(testKey1);
+            frontend.get(testKey2);
+
+            assertThat(keyLocks).containsKey(testKey1);
+            assertThat(keyLocks).containsKey(testKey2);
+            assertThat(keyLocks).hasSize(2);
+
+            otherClient.sync().set(testKey1, updatedValue);
+
+            Thread.sleep(200);
+
+            assertThat(keyLocks).doesNotContainKey(testKey1);
+            assertThat(keyLocks).containsKey(testKey2);
+            assertThat(keyLocks).hasSize(1);
+
+            frontend.get(testKey1);
+
+            assertThat(keyLocks).containsKey(testKey1);
+            assertThat(keyLocks).hasSize(2);
+
+            frontend.close();
+
+            assertThat(keyLocks).isEmpty();
+
+        } finally {
+            connection.close();
+            otherClient.close();
+        }
     }
 
 }


### PR DESCRIPTION
## Issue
Closes #2402 

The current implementation of the get method in the ClientSideCaching class does not provide a mechanism to ensure exclusive access by a single thread when retrieving a value from the Redis server for a specific key. As a result, in high concurrent load scenarios involving the same key, the current implementation may cause **redundant and unnecessary calls to the Redis server.**

##  Solution

Added a per-key locking mechanism using `ReentrantLock` to ensure that only a single thread can fetch a value from Redis for a specific key at any given time.

## Tests

1. `valueLoaderShouldBeInvokedOnceForConcurrentRequests`: Verifies that when multiple threads concurrently access the same key using a valueLoader, the loader is called exactly once

2. `locksShouldBeProperlyCleanedUp`: Verifies the proper lifecycle management of locks (creation, cleanup on invalidation, recreation, and final cleanup)