### PR TITLE
Add basic connection interruption tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -583,6 +583,14 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Dependencies for FaultInjectionClient -->
+        <dependency>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty-http</artifactId>
+            <version>1.1.16</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/test/java/io/lettuce/TestTags.java
+++ b/src/test/java/io/lettuce/TestTags.java
@@ -34,4 +34,9 @@ public class TestTags {
      */
     public static final String ENTRA_ID = "entraid";
 
+    /**
+     * Tag for scenario tests
+     */
+    public static final String SCENARIO_TEST = "scenario";
+
 }

--- a/src/test/java/io/lettuce/scenario/ConnectionInterruptionReactiveTest.java
+++ b/src/test/java/io/lettuce/scenario/ConnectionInterruptionReactiveTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -59,8 +60,9 @@ public class ConnectionInterruptionReactiveTest {
         assumeTrue(standalone != null, "Skipping test because no Redis endpoint is configured!");
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "Reactive Client Recovery on {0}")
     @ValueSource(strings = { "dmc_restart", "network_failure" })
+    @DisplayName("Reactive client should reconnect automatically during connection interruptions")
     public void testWithReactiveCommands(String triggerAction) {
         RedisURI uri = RedisURI.builder(RedisURI.create(standalone.getEndpoints().get(0)))
                 .withAuthentication(standalone.getUsername(), standalone.getPassword()).build();
@@ -115,8 +117,9 @@ public class ConnectionInterruptionReactiveTest {
         client.shutdown();
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "PubSub Reconnection on {0}")
     @ValueSource(strings = { "dmc_restart", "network_failure" })
+    @DisplayName("PubSub connections should automatically reconnect and resume message delivery during failures")
     public void testWithPubSub(String triggerAction) {
         RedisURI uri = RedisURI.builder(RedisURI.create(standalone.getEndpoints().get(0)))
                 .withAuthentication(standalone.getUsername(), standalone.getPassword()).build();

--- a/src/test/java/io/lettuce/scenario/ConnectionInterruptionReactiveTest.java
+++ b/src/test/java/io/lettuce/scenario/ConnectionInterruptionReactiveTest.java
@@ -1,0 +1,196 @@
+package io.lettuce.scenario;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
+import io.lettuce.core.pubsub.RedisPubSubAdapter;
+import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
+import io.lettuce.core.pubsub.api.reactive.RedisPubSubReactiveCommands;
+import io.lettuce.test.Wait;
+import io.lettuce.test.env.Endpoints;
+import io.lettuce.test.env.Endpoints.Endpoint;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static io.lettuce.TestTags.SCENARIO_TEST;
+
+/**
+ * Tests for connection interruption using reactive API.
+ */
+@Tag(SCENARIO_TEST)
+public class ConnectionInterruptionReactiveTest {
+
+    private static final Logger log = LoggerFactory.getLogger(ConnectionInterruptionReactiveTest.class);
+
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
+
+    private static final Duration CHECK_INTERVAL = Duration.ofSeconds(1);
+
+    private static final Duration DELAY_AFTER = Duration.ofMillis(500);
+
+    private static Endpoint standalone;
+
+    private final FaultInjectionClient faultClient = new FaultInjectionClient();
+
+    @BeforeAll
+    public static void setup() {
+        standalone = Endpoints.DEFAULT.getEndpoint("standalone");
+        assumeTrue(standalone != null, "Skipping test because no Redis endpoint is configured!");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "dmc_restart", "network_failure" })
+    public void testWithReactiveCommands(String triggerAction) {
+        RedisURI uri = RedisURI.builder(RedisURI.create(standalone.getEndpoints().get(0)))
+                .withAuthentication(standalone.getUsername(), standalone.getPassword()).build();
+        RedisClient client = RedisClient.create(uri);
+
+        client.setOptions(ClientOptions.builder().autoReconnect(true).build());
+
+        StatefulRedisConnection<String, String> connection = client.connect();
+        RedisReactiveCommands<String, String> reactive = connection.reactive();
+
+        String keyName = "counter";
+
+        // Setup: Set initial counter value
+        StepVerifier.create(reactive.set(keyName, "0")).expectNext("OK").verifyComplete();
+
+        AtomicLong commandsSubmitted = new AtomicLong();
+        List<Throwable> capturedExceptions = new CopyOnWriteArrayList<>();
+
+        // Start a flux that imitates an application using the client
+        Disposable subscription = Flux.interval(Duration.ofMillis(100)).flatMap(i -> reactive.incr(keyName)
+                // We should count all attempts, because Lettuce retransmits failed commands
+                .doFinally(value -> {
+                    commandsSubmitted.incrementAndGet();
+                    log.info("Commands submitted {}", commandsSubmitted.get());
+                }).onErrorResume(e -> {
+                    log.warn("Error executing command", e);
+                    capturedExceptions.add(e);
+                    return Mono.empty();
+                })).subscribe();
+
+        // Trigger the fault injection
+        Map<String, Object> params = new HashMap<>();
+        params.put("bdb_id", standalone.getBdbId());
+
+        Mono<Boolean> actionCompleted = faultClient.triggerActionAndWait(triggerAction, params, CHECK_INTERVAL, DELAY_AFTER,
+                DEFAULT_TIMEOUT);
+
+        StepVerifier.create(actionCompleted).expectNext(true).verifyComplete();
+
+        // Stop the command execution
+        subscription.dispose();
+
+        // Verify results
+        StepVerifier.create(reactive.get(keyName).map(Long::parseLong)).consumeNextWith(value -> {
+            log.info("Final counter value: {}, commands submitted: {}", value, commandsSubmitted.get());
+            assertThat(value).isEqualTo(commandsSubmitted.get());
+        }).verifyComplete();
+
+        log.info("Captured exceptions: {}", capturedExceptions);
+
+        connection.close();
+        client.shutdown();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "dmc_restart", "network_failure" })
+    public void testWithPubSub(String triggerAction) {
+        RedisURI uri = RedisURI.builder(RedisURI.create(standalone.getEndpoints().get(0)))
+                .withAuthentication(standalone.getUsername(), standalone.getPassword()).build();
+        
+        RedisClient subscriberClient = RedisClient.create(uri);
+        subscriberClient.setOptions(ClientOptions.builder().autoReconnect(true).build());
+
+        RedisClient publisherClient = RedisClient.create(uri);
+        publisherClient.setOptions(ClientOptions.builder().autoReconnect(true).build());
+
+        StatefulRedisConnection<String, String> publisherConnection = publisherClient.connect();
+        RedisReactiveCommands<String, String> publisherReactive = publisherConnection.reactive();
+
+        AtomicLong messagesSent = new AtomicLong();
+        AtomicLong messagesReceived = new AtomicLong();
+        List<Throwable> subscriberExceptions = new CopyOnWriteArrayList<>();        
+        List<String> receivedMessages = new CopyOnWriteArrayList<>();
+        
+        StatefulRedisPubSubConnection<String, String> pubSubConnection = subscriberClient.connectPubSub();
+        RedisPubSubReactiveCommands<String, String> pubSubReactive = pubSubConnection.reactive();
+        pubSubConnection.addListener(new RedisPubSubAdapter<String, String>() {
+
+            @Override
+            public void message(String channel, String message) {
+                log.info("Received message: {}", message);
+                messagesReceived.incrementAndGet();
+                receivedMessages.add(message);
+            }
+
+        });
+
+        StepVerifier.create(pubSubReactive.subscribe("test")).verifyComplete();
+
+        Disposable publisherSubscription = Flux.interval(Duration.ofMillis(200))
+                .flatMap(i -> publisherReactive.publish("test", String.valueOf(messagesSent.getAndIncrement())).onErrorResume(e -> {
+                    log.warn("Error publishing message", e);
+                    subscriberExceptions.add(e);
+                    return Mono.empty();
+                })).subscribe();
+
+        // Wait for messages to be sent and processed
+        Wait.untilTrue(() -> messagesReceived.get() > 0).waitOrTimeout();
+
+        // Trigger the fault injection
+        Map<String, Object> params = new HashMap<>();
+        params.put("bdb_id", standalone.getBdbId());
+        
+        Mono<Boolean> actionCompleted = faultClient.triggerActionAndWait(triggerAction, params, CHECK_INTERVAL, DELAY_AFTER,
+                DEFAULT_TIMEOUT);
+
+        StepVerifier.create(actionCompleted).expectNext(true).verifyComplete();
+
+        // Stop the publisher
+        publisherSubscription.dispose();
+
+        log.info("Messages sent: {}, messages received: {}", messagesSent.get(), messagesReceived.get());
+        log.info("Received messages: {}", receivedMessages);
+
+        assertThat(messagesReceived.get()).isGreaterThan(0);
+        assertThat(messagesReceived.get()).isLessThanOrEqualTo(messagesSent.get());
+
+        // Assert that the last received message has an ID equal to the number of sent messages minus one
+        assertThat(receivedMessages).isNotEmpty();
+
+        String lastMessage = receivedMessages.get(receivedMessages.size() - 1);
+        log.info("Last received message: {}, expected ID: {}", lastMessage, messagesSent.get() - 1);
+        assertThat(lastMessage).isEqualTo(String.valueOf(messagesSent.get() - 1));
+
+        log.info("Captured exceptions: {}", subscriberExceptions);
+
+        pubSubConnection.close();
+        publisherConnection.close();
+        publisherClient.shutdown();
+        subscriberClient.shutdown();
+    }
+
+}

--- a/src/test/java/io/lettuce/scenario/ConnectionInterruptionReactiveTest.java
+++ b/src/test/java/io/lettuce/scenario/ConnectionInterruptionReactiveTest.java
@@ -56,7 +56,7 @@ public class ConnectionInterruptionReactiveTest {
 
     @BeforeAll
     public static void setup() {
-        standalone = Endpoints.DEFAULT.getEndpoint("standalone");
+        standalone = Endpoints.DEFAULT.getEndpoint("re-standalone");
         assumeTrue(standalone != null, "Skipping test because no Redis endpoint is configured!");
     }
 

--- a/src/test/java/io/lettuce/scenario/ConnectionInterruptionReactiveTest.java
+++ b/src/test/java/io/lettuce/scenario/ConnectionInterruptionReactiveTest.java
@@ -120,7 +120,7 @@ public class ConnectionInterruptionReactiveTest {
     public void testWithPubSub(String triggerAction) {
         RedisURI uri = RedisURI.builder(RedisURI.create(standalone.getEndpoints().get(0)))
                 .withAuthentication(standalone.getUsername(), standalone.getPassword()).build();
-        
+
         RedisClient subscriberClient = RedisClient.create(uri);
         subscriberClient.setOptions(ClientOptions.builder().autoReconnect(true).build());
 
@@ -132,9 +132,9 @@ public class ConnectionInterruptionReactiveTest {
 
         AtomicLong messagesSent = new AtomicLong();
         AtomicLong messagesReceived = new AtomicLong();
-        List<Throwable> subscriberExceptions = new CopyOnWriteArrayList<>();        
+        List<Throwable> subscriberExceptions = new CopyOnWriteArrayList<>();
         List<String> receivedMessages = new CopyOnWriteArrayList<>();
-        
+
         StatefulRedisPubSubConnection<String, String> pubSubConnection = subscriberClient.connectPubSub();
         RedisPubSubReactiveCommands<String, String> pubSubReactive = pubSubConnection.reactive();
         pubSubConnection.addListener(new RedisPubSubAdapter<String, String>() {
@@ -150,8 +150,8 @@ public class ConnectionInterruptionReactiveTest {
 
         StepVerifier.create(pubSubReactive.subscribe("test")).verifyComplete();
 
-        Disposable publisherSubscription = Flux.interval(Duration.ofMillis(200))
-                .flatMap(i -> publisherReactive.publish("test", String.valueOf(messagesSent.getAndIncrement())).onErrorResume(e -> {
+        Disposable publisherSubscription = Flux.interval(Duration.ofMillis(200)).flatMap(
+                i -> publisherReactive.publish("test", String.valueOf(messagesSent.getAndIncrement())).onErrorResume(e -> {
                     log.warn("Error publishing message", e);
                     subscriberExceptions.add(e);
                     return Mono.empty();
@@ -163,7 +163,7 @@ public class ConnectionInterruptionReactiveTest {
         // Trigger the fault injection
         Map<String, Object> params = new HashMap<>();
         params.put("bdb_id", standalone.getBdbId());
-        
+
         Mono<Boolean> actionCompleted = faultClient.triggerActionAndWait(triggerAction, params, CHECK_INTERVAL, DELAY_AFTER,
                 DEFAULT_TIMEOUT);
 

--- a/src/test/java/io/lettuce/scenario/FaultInjectionClient.java
+++ b/src/test/java/io/lettuce/scenario/FaultInjectionClient.java
@@ -115,13 +115,11 @@ public class FaultInjectionClient {
                     // Return empty to trigger retry
                     return Mono.empty();
                 })
-                .retryWhen(reactor.util.retry.Retry.backoff(3, Duration.ofMillis(300))
-                    .maxBackoff(Duration.ofSeconds(2))
-                    .filter(throwable -> !(throwable instanceof RuntimeException &&
-                                          throwable.getMessage() != null &&
-                                          throwable.getMessage().contains("Fault injection proxy error")))
-                    .doBeforeRetry(retrySignal ->
-                        log.warn("Retrying action status check after error, attempt: {}", retrySignal.totalRetries() + 1)))
+                .retryWhen(reactor.util.retry.Retry.backoff(3, Duration.ofMillis(300)).maxBackoff(Duration.ofSeconds(2))
+                        .filter(throwable -> !(throwable instanceof RuntimeException && throwable.getMessage() != null
+                                && throwable.getMessage().contains("Fault injection proxy error")))
+                        .doBeforeRetry(retrySignal -> log.warn("Retrying action status check after error, attempt: {}",
+                                retrySignal.totalRetries() + 1)))
                 .onErrorResume(e -> {
                     log.error("Fault injection proxy error after retries", e);
                     return Mono.error(new RuntimeException("Fault injection proxy error", e));

--- a/src/test/java/io/lettuce/scenario/FaultInjectionClient.java
+++ b/src/test/java/io/lettuce/scenario/FaultInjectionClient.java
@@ -1,0 +1,171 @@
+package io.lettuce.scenario;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import reactor.core.publisher.Mono;
+import reactor.netty.ByteBufFlux;
+import reactor.netty.http.client.HttpClient;
+
+/**
+ * Async Fault Injection Client using reactor.netty.http.client.HttpClient.
+ */
+public class FaultInjectionClient {
+
+    private static final String BASE_URL;
+
+    static {
+        BASE_URL = System.getenv().getOrDefault("FAULT_INJECTION_API_URL", "http://127.0.0.1:20324");
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(FaultInjectionClient.class);
+
+    private final HttpClient httpClient;
+
+    private final ObjectMapper objectMapper;
+
+    public FaultInjectionClient() {
+        this.httpClient = HttpClient.create().responseTimeout(Duration.ofSeconds(10));
+
+        this.objectMapper = new ObjectMapper().setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    }
+
+    public static class TriggerActionResponse {
+
+        @JsonProperty("action_id")
+        private String actionId;
+
+        // Default constructor for Jackson
+        public TriggerActionResponse() {
+        }
+
+        public TriggerActionResponse(String actionId) {
+            this.actionId = actionId;
+        }
+
+        public String getActionId() {
+            return actionId;
+        }
+
+        public void setActionId(String actionId) {
+            this.actionId = actionId;
+        }
+
+    }
+
+    /**
+     * Triggers an action with the specified type and parameters.
+     *
+     * @param actionType the type of action to trigger
+     * @param parameters the parameters for the action
+     * @return a Mono that emits the TriggerActionResponse when the action is triggered
+     */
+    public Mono<TriggerActionResponse> triggerAction(String actionType, Map<String, Object> parameters) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("type", actionType);
+        payload.put("parameters", parameters);
+
+        try {
+            String jsonString = objectMapper.writeValueAsString(payload);
+            byte[] bytes = jsonString.getBytes();
+            ByteBuf byteBuf = Unpooled.wrappedBuffer(bytes);
+
+            return httpClient.headers(h -> h.add("Content-Type", "application/json")).post().uri(BASE_URL + "/action")
+                    .send(ByteBufFlux.fromInbound(Mono.just(byteBuf))).responseSingle((response, body) -> body.asString())
+                    .map(result -> {
+                        log.info("Trigger action response: {}", result);
+                        try {
+                            return objectMapper.readValue(result, TriggerActionResponse.class);
+                        } catch (Exception e) {
+                            throw new RuntimeException("Failed to parse response", e);
+                        }
+                    }).onErrorResume(e -> {
+                        log.error("Failed to trigger action", e);
+                        return Mono.error(new RuntimeException("Failed to trigger action", e));
+                    });
+        } catch (Exception e) {
+            log.error("Failed to serialize request", e);
+            return Mono.error(new RuntimeException("Failed to serialize request", e));
+        }
+    }
+
+    /**
+     * Checks the status of an action.
+     *
+     * @param actionId the ID of the action to check
+     * @return Mono that emits true if the action is completed, empty if still in progress
+     */
+    private Mono<Boolean> checkActionStatus(String actionId) {
+        return httpClient.get().uri(BASE_URL + "/action/" + actionId).responseSingle((response, body) -> body.asString())
+                .flatMap(result -> {
+                    log.info("Action status: {}", result);
+                    if (result.contains("success")) {
+                        return Mono.just(true);
+                    }
+                    // Return empty to trigger retry
+                    return Mono.empty();
+                })
+                .retryWhen(reactor.util.retry.Retry.backoff(3, Duration.ofMillis(300))
+                    .maxBackoff(Duration.ofSeconds(2))
+                    .filter(throwable -> !(throwable instanceof RuntimeException &&
+                                          throwable.getMessage() != null &&
+                                          throwable.getMessage().contains("Fault injection proxy error")))
+                    .doBeforeRetry(retrySignal ->
+                        log.warn("Retrying action status check after error, attempt: {}", retrySignal.totalRetries() + 1)))
+                .onErrorResume(e -> {
+                    log.error("Fault injection proxy error after retries", e);
+                    return Mono.error(new RuntimeException("Fault injection proxy error", e));
+                });
+    }
+
+    /**
+     * Waits for an action to complete by polling the status endpoint. Uses Reactor's retry capabilities for a more idiomatic
+     * approach.
+     *
+     * @param actionId the ID of the action to wait for
+     * @param checkInterval interval between status checks
+     * @param delayAfter delay after completion before returning true
+     * @param timeout maximum time to wait for completion
+     * @return Mono that completes with true when the action is completed and the delay has passed
+     */
+    public Mono<Boolean> waitForCompletion(String actionId, Duration checkInterval, Duration delayAfter, Duration timeout) {
+        return Mono.defer(() -> checkActionStatus(actionId)).flatMap(completed -> {
+            if (completed) {
+                // If we need to wait after completion, delay and then return true
+                if (!delayAfter.isZero()) {
+                    return Mono.delay(delayAfter).thenReturn(true);
+                }
+                return Mono.just(true);
+            }
+            return Mono.just(false);
+        }).repeatWhenEmpty(repeat -> repeat.delayElements(checkInterval).timeout(timeout)
+                .doOnError(e -> log.error("Timeout waiting for action to complete", e)));
+    }
+
+    /**
+     * Triggers an action and waits for it to complete.
+     *
+     * @param actionType the type of action to trigger
+     * @param parameters the parameters for the action
+     * @param checkInterval interval between status checks
+     * @param delayAfter delay after completion before returning true
+     * @param timeout maximum time to wait for completion
+     * @return a Mono that emits true when the action is completed
+     */
+    public Mono<Boolean> triggerActionAndWait(String actionType, Map<String, Object> parameters, Duration checkInterval,
+            Duration delayAfter, Duration timeout) {
+        return triggerAction(actionType, parameters)
+                .flatMap(response -> waitForCompletion(response.getActionId(), checkInterval, delayAfter, timeout));
+    }
+
+}

--- a/src/test/java/io/lettuce/scenario/RecommendedSettingsProvider.java
+++ b/src/test/java/io/lettuce/scenario/RecommendedSettingsProvider.java
@@ -1,0 +1,37 @@
+package io.lettuce.scenario;
+
+import java.time.Duration;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.SocketOptions;
+
+/**
+ * Utility class that provides pre-configured client options with recommended settings for connection interruption testing. This
+ * class helps standardize client configurations across tests and provides optimized settings for fast reconnection.
+ */
+public class RecommendedSettingsProvider {
+
+    private RecommendedSettingsProvider() {
+        // Utility class
+    }
+
+    /**
+     * Provides optimized client options for connection interruption testing scenarios.
+     * 
+     * @return ClientOptions configured for connection interruption testing
+     */
+    public static ClientOptions forConnectionInterruption() {
+        return ClientOptions.builder().autoReconnect(true).socketOptions(connectionInterruptionSocketOptions()).build();
+    }
+
+    public static SocketOptions connectionInterruptionSocketOptions() {
+        SocketOptions.TcpUserTimeoutOptions tcpUserTimeout = SocketOptions.TcpUserTimeoutOptions.builder()
+                .tcpUserTimeout(Duration.ofSeconds(4)).enable().build();
+
+        SocketOptions.KeepAliveOptions keepAliveOptions = SocketOptions.KeepAliveOptions.builder()
+                .interval(Duration.ofSeconds(1)).idle(Duration.ofSeconds(1)).count(3).enable().build();
+
+        return SocketOptions.builder().tcpUserTimeout(tcpUserTimeout).keepAlive(keepAliveOptions).build();
+    }
+
+}

--- a/src/test/java/io/lettuce/scenario/ReconnectionEvent.java
+++ b/src/test/java/io/lettuce/scenario/ReconnectionEvent.java
@@ -1,0 +1,101 @@
+package io.lettuce.scenario;
+
+import java.net.SocketAddress;
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Represents a reconnection-related event with timing information.
+ */
+public class ReconnectionEvent {
+
+    public enum Type {
+        DISCONNECTED, RECONNECTED, ATTEMPT, FAILED
+    }
+
+    private final Type type;
+
+    private final Instant timestamp;
+
+    private final SocketAddress remoteAddress;
+
+    private final Duration duration;
+
+    private final int attemptNumber;
+
+    private final Duration delay;
+
+    private final Throwable cause;
+
+    // Constructor for DISCONNECTED and basic RECONNECTED events
+    public ReconnectionEvent(Type type, Instant timestamp, SocketAddress remoteAddress) {
+        this(type, timestamp, remoteAddress, null, 0, null, null);
+    }
+
+    // Constructor for RECONNECTED events with duration
+    public ReconnectionEvent(Type type, Instant timestamp, SocketAddress remoteAddress, Duration duration) {
+        this(type, timestamp, remoteAddress, duration, 0, null, null);
+    }
+
+    // Constructor for ATTEMPT events
+    public ReconnectionEvent(Type type, Instant timestamp, SocketAddress remoteAddress, int attemptNumber, Duration delay) {
+        this(type, timestamp, remoteAddress, null, attemptNumber, delay, null);
+    }
+
+    // Constructor for FAILED events
+    public ReconnectionEvent(Type type, Instant timestamp, SocketAddress remoteAddress, int attemptNumber, Throwable cause) {
+        this(type, timestamp, remoteAddress, null, attemptNumber, null, cause);
+    }
+
+    // Full constructor
+    private ReconnectionEvent(Type type, Instant timestamp, SocketAddress remoteAddress, Duration duration, int attemptNumber,
+            Duration delay, Throwable cause) {
+        this.type = type;
+        this.timestamp = timestamp;
+        this.remoteAddress = remoteAddress;
+        this.duration = duration;
+        this.attemptNumber = attemptNumber;
+        this.delay = delay;
+        this.cause = cause;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public Duration getDuration() {
+        return duration;
+    }
+
+    public Duration getDelay() {
+        return delay;
+    }
+
+    public Throwable getCause() {
+        return cause;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("ReconnectionEvent{").append("type=").append(type).append(", timestamp=").append(timestamp)
+                .append(", remoteAddress=").append(remoteAddress);
+
+        if (duration != null) {
+            sb.append(", duration=").append(duration.toMillis()).append("ms");
+        }
+        if (attemptNumber > 0) {
+            sb.append(", attempt=").append(attemptNumber);
+        }
+        if (delay != null) {
+            sb.append(", delay=").append(delay.toMillis()).append("ms");
+        }
+        if (cause != null) {
+            sb.append(", cause=").append(cause.getMessage());
+        }
+
+        sb.append('}');
+        return sb.toString();
+    }
+
+}

--- a/src/test/java/io/lettuce/scenario/ReconnectionStats.java
+++ b/src/test/java/io/lettuce/scenario/ReconnectionStats.java
@@ -1,0 +1,165 @@
+package io.lettuce.scenario;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Statistics and analysis for reconnection timing data.
+ */
+public class ReconnectionStats {
+
+    private static final Logger log = LoggerFactory.getLogger(ReconnectionStats.class);
+
+    private final String trackerName;
+
+    private final List<Duration> eventBusReconnections;
+
+    private final List<Duration> stateListenerReconnections;
+
+    private final List<ReconnectionEvent> events;
+
+    public ReconnectionStats(String trackerName, List<Duration> eventBusReconnections,
+            List<Duration> stateListenerReconnections, List<ReconnectionEvent> events) {
+        this.trackerName = trackerName;
+        this.eventBusReconnections = Collections.unmodifiableList(new ArrayList<>(eventBusReconnections));
+        this.stateListenerReconnections = Collections.unmodifiableList(new ArrayList<>(stateListenerReconnections));
+        this.events = Collections.unmodifiableList(new ArrayList<>(events));
+    }
+
+    /**
+     * Get the number of reconnections detected by EventBus tracking.
+     */
+    public int getEventBusReconnectionCount() {
+        return eventBusReconnections.size();
+    }
+
+    /**
+     * Get the number of reconnections detected by state listener tracking.
+     */
+    public int getStateListenerReconnectionCount() {
+        return stateListenerReconnections.size();
+    }
+
+    /**
+     * Get total reconnection time from EventBus tracking.
+     */
+    public Duration getTotalEventBusReconnectionTime() {
+        return eventBusReconnections.stream().reduce(Duration.ZERO, Duration::plus);
+    }
+
+    /**
+     * Get average reconnection time from EventBus tracking.
+     */
+    public Duration getAverageEventBusReconnectionTime() {
+        if (eventBusReconnections.isEmpty()) {
+            return Duration.ZERO;
+        }
+        return Duration.ofMillis(getTotalEventBusReconnectionTime().toMillis() / eventBusReconnections.size());
+    }
+
+    /**
+     * Get total reconnection time from state listener tracking.
+     */
+    public Duration getTotalStateListenerReconnectionTime() {
+        return stateListenerReconnections.stream().reduce(Duration.ZERO, Duration::plus);
+    }
+
+    /**
+     * Get average reconnection time from state listener tracking.
+     */
+    public Duration getAverageStateListenerReconnectionTime() {
+        if (stateListenerReconnections.isEmpty()) {
+            return Duration.ZERO;
+        }
+        return Duration.ofMillis(getTotalStateListenerReconnectionTime().toMillis() / stateListenerReconnections.size());
+    }
+
+    /**
+     * Get the fastest reconnection time from EventBus tracking.
+     */
+    public Duration getFastestReconnection() {
+        return eventBusReconnections.stream().min(Duration::compareTo).orElse(Duration.ZERO);
+    }
+
+    /**
+     * Get the slowest reconnection time from EventBus tracking.
+     */
+    public Duration getSlowestReconnection() {
+        return eventBusReconnections.stream().max(Duration::compareTo).orElse(Duration.ZERO);
+    }
+
+    /**
+     * Get the number of failed reconnection attempts.
+     */
+    public long getFailedAttemptCount() {
+        return events.stream().filter(event -> event.getType() == ReconnectionEvent.Type.FAILED).count();
+    }
+
+    /**
+     * Get the total number of reconnection attempts (including successful ones).
+     */
+    public long getTotalAttemptCount() {
+        return events.stream().filter(
+                event -> event.getType() == ReconnectionEvent.Type.ATTEMPT || event.getType() == ReconnectionEvent.Type.FAILED)
+                .count();
+    }
+
+    /**
+     * Log comprehensive statistics.
+     */
+    public void logStatistics() {
+        log.info("=== {} Reconnection Statistics ===", trackerName);
+
+        if (!eventBusReconnections.isEmpty()) {
+            log.info("EventBus Tracking:");
+            log.info("  - Number of reconnections: {}", getEventBusReconnectionCount());
+            log.info("  - Total reconnection time: {} ms", getTotalEventBusReconnectionTime().toMillis());
+            log.info("  - Average reconnection time: {} ms", getAverageEventBusReconnectionTime().toMillis());
+            log.info("  - Fastest reconnection: {} ms", getFastestReconnection().toMillis());
+            log.info("  - Slowest reconnection: {} ms", getSlowestReconnection().toMillis());
+            log.info("  - Individual times: {}", formatDurations(eventBusReconnections));
+        }
+
+        if (!stateListenerReconnections.isEmpty()) {
+            log.info("State Listener Tracking:");
+            log.info("  - Number of reconnections: {}", getStateListenerReconnectionCount());
+            log.info("  - Total reconnection time: {} ms", getTotalStateListenerReconnectionTime().toMillis());
+            log.info("  - Average reconnection time: {} ms", getAverageStateListenerReconnectionTime().toMillis());
+            log.info("  - Individual times: {}", formatDurations(stateListenerReconnections));
+        }
+
+        if (getTotalAttemptCount() > 0) {
+            log.info("Reconnection Attempts:");
+            log.info("  - Total attempts: {}", getTotalAttemptCount());
+            log.info("  - Failed attempts: {}", getFailedAttemptCount());
+            log.info("  - Success rate: {}%", getSuccessRate());
+        }
+
+        if (eventBusReconnections.isEmpty() && stateListenerReconnections.isEmpty()) {
+            log.info("No reconnections detected");
+        }
+    }
+
+    /**
+     * Get the success rate of reconnection attempts.
+     */
+    public double getSuccessRate() {
+        long totalAttempts = getTotalAttemptCount();
+        if (totalAttempts == 0) {
+            return 100.0;
+        }
+        long failedAttempts = getFailedAttemptCount();
+        return ((double) (totalAttempts - failedAttempts) / totalAttempts) * 100.0;
+    }
+
+    private String formatDurations(List<Duration> durations) {
+        return durations.stream().map(d -> d.toMillis() + "ms").collect(Collectors.joining(", ", "[", "]"));
+    }
+
+}

--- a/src/test/java/io/lettuce/scenario/ReconnectionTimingTracker.java
+++ b/src/test/java/io/lettuce/scenario/ReconnectionTimingTracker.java
@@ -1,0 +1,202 @@
+package io.lettuce.scenario;
+
+import java.net.SocketAddress;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.lettuce.core.RedisChannelHandler;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisConnectionStateAdapter;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.event.connection.ConnectionActivatedEvent;
+import io.lettuce.core.event.connection.ConnectionDeactivatedEvent;
+import io.lettuce.core.event.connection.ReconnectAttemptEvent;
+import io.lettuce.core.event.connection.ReconnectFailedEvent;
+import reactor.core.Disposable;
+
+/**
+ * Utility class for tracking Redis connection reconnection timing. Provides comprehensive monitoring of connection lifecycle
+ * events and timing metrics.
+ */
+public class ReconnectionTimingTracker {
+
+    private static final Logger log = LoggerFactory.getLogger(ReconnectionTimingTracker.class);
+
+    private final String trackerName;
+
+    private final List<ReconnectionEvent> reconnectionEvents = new CopyOnWriteArrayList<>();
+
+    private final List<Duration> reconnectionDurations = new CopyOnWriteArrayList<>();
+
+    private final AtomicReference<Instant> lastDisconnectTime = new AtomicReference<>();
+
+    // Event bus tracking
+    private Disposable eventSubscription;
+
+    // Connection state tracking
+    private final AtomicReference<Instant> stateDisconnectTime = new AtomicReference<>();
+
+    private final List<Duration> stateReconnectionDurations = new CopyOnWriteArrayList<>();
+
+    /**
+     * Creates a new reconnection timing tracker.
+     * 
+     * @param trackerName descriptive name for this tracker (e.g., "PubSub", "Reactive")
+     */
+    public ReconnectionTimingTracker(String trackerName) {
+        this.trackerName = trackerName;
+    }
+
+    /**
+     * Start tracking reconnection events using the EventBus approach.
+     * 
+     * @param client the Redis client to monitor
+     * @return this tracker for method chaining
+     */
+    public ReconnectionTimingTracker trackWithEventBus(RedisClient client) {
+        eventSubscription = client.getResources().eventBus().get().subscribe(event -> {
+            Instant now = Instant.now();
+
+            if (event instanceof ConnectionDeactivatedEvent) {
+                ConnectionDeactivatedEvent deactivated = (ConnectionDeactivatedEvent) event;
+                log.info("{} connection disconnected: {} at {}", trackerName, deactivated.remoteAddress(), now);
+                lastDisconnectTime.set(now);
+                reconnectionEvents
+                        .add(new ReconnectionEvent(ReconnectionEvent.Type.DISCONNECTED, now, deactivated.remoteAddress()));
+
+            } else if (event instanceof ConnectionActivatedEvent) {
+                ConnectionActivatedEvent activated = (ConnectionActivatedEvent) event;
+                log.info("{} connection reconnected: {} at {}", trackerName, activated.remoteAddress(), now);
+
+                Instant disconnectTime = lastDisconnectTime.get();
+                if (disconnectTime != null) {
+                    Duration reconnectionDuration = Duration.between(disconnectTime, now);
+                    reconnectionDurations.add(reconnectionDuration);
+                    reconnectionEvents.add(new ReconnectionEvent(ReconnectionEvent.Type.RECONNECTED, now,
+                            activated.remoteAddress(), reconnectionDuration));
+                    log.info("{} reconnection completed in: {} ms", trackerName, reconnectionDuration.toMillis());
+                }
+
+            } else if (event instanceof ReconnectAttemptEvent) {
+                ReconnectAttemptEvent attempt = (ReconnectAttemptEvent) event;
+                log.info("{} reconnect attempt #{} with delay: {} ms", trackerName, attempt.getAttempt(),
+                        attempt.getDelay().toMillis());
+                reconnectionEvents.add(new ReconnectionEvent(ReconnectionEvent.Type.ATTEMPT, now, attempt.remoteAddress(),
+                        attempt.getAttempt(), attempt.getDelay()));
+
+            } else if (event instanceof ReconnectFailedEvent) {
+                ReconnectFailedEvent failed = (ReconnectFailedEvent) event;
+                log.warn("{} reconnect attempt #{} failed: {}", trackerName, failed.getAttempt(),
+                        failed.getCause().getMessage());
+                reconnectionEvents.add(new ReconnectionEvent(ReconnectionEvent.Type.FAILED, now, failed.remoteAddress(),
+                        failed.getAttempt(), failed.getCause()));
+            }
+        });
+
+        return this;
+    }
+
+    /**
+     * Start tracking reconnection events using the ConnectionStateListener approach.
+     *
+     * @param connection the Redis connection to monitor
+     * @return this tracker for method chaining
+     */
+    public <K, V> ReconnectionTimingTracker trackWithStateListener(StatefulRedisConnection<K, V> connection) {
+        connection.addListener(new RedisConnectionStateAdapter() {
+
+            @Override
+            public void onRedisDisconnected(RedisChannelHandler<?, ?> connection) {
+                Instant now = Instant.now();
+                stateDisconnectTime.set(now);
+                log.info("{} connection state: DISCONNECTED at {}", trackerName, now);
+            }
+
+            @Override
+            public void onRedisConnected(RedisChannelHandler<?, ?> connection, SocketAddress socketAddress) {
+                Instant now = Instant.now();
+                log.info("{} connection state: CONNECTED to {} at {}", trackerName, socketAddress, now);
+
+                Instant lastDisconnect = stateDisconnectTime.get();
+                if (lastDisconnect != null) {
+                    Duration duration = Duration.between(lastDisconnect, now);
+                    stateReconnectionDurations.add(duration);
+                    log.info("{} state listener reconnection duration: {} ms", trackerName, duration.toMillis());
+                }
+            }
+
+        });
+
+        return this;
+    }
+
+    /**
+     * Get reconnection statistics and optionally execute a callback with the stats.
+     * 
+     * @param statsConsumer optional consumer to process the statistics
+     * @return the reconnection statistics
+     */
+    public ReconnectionStats getStats(Consumer<ReconnectionStats> statsConsumer) {
+        ReconnectionStats stats = new ReconnectionStats(trackerName, reconnectionDurations, stateReconnectionDurations,
+                reconnectionEvents);
+
+        if (statsConsumer != null) {
+            statsConsumer.accept(stats);
+        }
+
+        return stats;
+    }
+
+    /**
+     * Get reconnection statistics.
+     * 
+     * @return the reconnection statistics
+     */
+    public ReconnectionStats getStats() {
+        return getStats(null);
+    }
+
+    /**
+     * Log comprehensive reconnection statistics.
+     */
+    public void logStats() {
+        ReconnectionStats stats = getStats();
+        stats.logStatistics();
+    }
+
+    /**
+     * Clean up resources and stop tracking.
+     */
+    public void dispose() {
+        if (eventSubscription != null && !eventSubscription.isDisposed()) {
+            eventSubscription.dispose();
+        }
+    }
+
+    /**
+     * Check if any reconnections were tracked.
+     * 
+     * @return true if reconnections were detected
+     */
+    public boolean hasReconnections() {
+        return !reconnectionDurations.isEmpty() || !stateReconnectionDurations.isEmpty();
+    }
+
+    /**
+     * Create a tracker with a custom name.
+     * 
+     * @param name the tracker name
+     * @return new tracker with the specified name
+     */
+    public static ReconnectionTimingTracker withName(String name) {
+        return new ReconnectionTimingTracker(name);
+    }
+
+}

--- a/src/test/resources/log4j2-test.xml
+++ b/src/test/resources/log4j2-test.xml
@@ -16,6 +16,7 @@
         <!--
         <Logger name="org.testcontainers" level="DEBUG"/>
         -->
+        <Logger name="io.lettuce.scenario" level="INFO"/>
         <Root level="FATAL">
             <AppenderRef ref="Console"/>
             <AppenderRef ref="File"/>


### PR DESCRIPTION
- Use reactor-netty-http client to interact with the Fault Injector
- Test command execution and PubSub with dmc_restart, network_failure failures injected
