### PR TITLE
chore: remove usage of deprecated connection methods in command APIs in integration tests (#3328)

### DIFF
--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -1549,11 +1549,6 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
     }
 
     @Override
-    public boolean isOpen() {
-        return connection.isOpen();
-    }
-
-    @Override
     public RedisFuture<String> ftCreate(K index, CreateArgs<K, V> options, List<FieldArgs<K>> fieldArgs) {
         return dispatch(searchCommandBuilder.ftCreate(index, options, fieldArgs));
     }

--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -1114,11 +1114,6 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
     }
 
     @Override
-    public void flushCommands() {
-        connection.flushCommands();
-    }
-
-    @Override
     public RedisFuture<String> flushall() {
         return dispatch(commandBuilder.flushall());
     }
@@ -2601,11 +2596,6 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
     @Override
     public RedisFuture<V> setGet(K key, V value, SetArgs setArgs) {
         return dispatch(commandBuilder.setGet(key, value, setArgs));
-    }
-
-    @Override
-    public void setAutoFlushCommands(boolean autoFlush) {
-        connection.setAutoFlushCommands(autoFlush);
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -492,10 +492,6 @@ public abstract class AbstractRedisReactiveCommands<K, V>
         return createMono(() -> commandBuilder.clientUnblock(id, type));
     }
 
-    public void close() {
-        connection.close();
-    }
-
     @Override
     public Mono<String> clusterAddSlots(int... slots) {
         return createMono(() -> commandBuilder.clusterAddslots(slots));
@@ -1178,11 +1174,6 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
-    public void flushCommands() {
-        connection.flushCommands();
-    }
-
-    @Override
     public Mono<String> flushall() {
         return createMono(commandBuilder::flushall);
     }
@@ -1616,11 +1607,6 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     @Override
     public Mono<String> info(String section) {
         return createMono(() -> commandBuilder.info(section));
-    }
-
-    @Override
-    public boolean isOpen() {
-        return connection.isOpen();
     }
 
     @Override
@@ -2686,11 +2672,6 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     @Override
     public Mono<V> setGet(K key, V value, SetArgs setArgs) {
         return createMono(() -> commandBuilder.setGet(key, value, setArgs));
-    }
-
-    @Override
-    public void setAutoFlushCommands(boolean autoFlush) {
-        connection.setAutoFlushCommands(autoFlush);
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/api/async/BaseRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/BaseRedisAsyncCommands.java
@@ -209,4 +209,5 @@ public interface BaseRedisAsyncCommands<K, V> {
      */
     @Deprecated
     void flushCommands();
+
 }

--- a/src/main/java/io/lettuce/core/api/async/BaseRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/BaseRedisAsyncCommands.java
@@ -188,26 +188,4 @@ public interface BaseRedisAsyncCommands<K, V> {
      */
     <T> RedisFuture<T> dispatch(ProtocolKeyword type, CommandOutput<K, V, T> output, CommandArgs<K, V> args);
 
-    /**
-     * Disable or enable auto-flush behavior. Default is {@code true}. If autoFlushCommands is disabled, multiple commands can
-     * be issued without writing them actually to the transport. Commands are buffered until a {@link #flushCommands()} is
-     * issued. After calling {@link #flushCommands()} commands are sent to the transport and executed by Redis.
-     *
-     * @param autoFlush state of autoFlush.
-     * @deprecated since 6.2. Use the corresponding {@link io.lettuce.core.api.StatefulConnection#setAutoFlushCommands(boolean)}
-     *             method on the connection interface. To be removed with Lettuce 7.0.
-     */
-    @Deprecated
-    void setAutoFlushCommands(boolean autoFlush);
-
-    /**
-     * Flush pending commands. This commands forces a flush on the channel and can be used to buffer ("pipeline") commands to
-     * achieve batching. No-op if channel is not connected.
-     *
-     * @deprecated since 6.2. Use the corresponding {@link io.lettuce.core.api.StatefulConnection#flushCommands()} method on the
-     *             connection interface. To be removed with Lettuce 7.0.
-     */
-    @Deprecated
-    void flushCommands();
-
 }

--- a/src/main/java/io/lettuce/core/api/async/BaseRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/BaseRedisAsyncCommands.java
@@ -189,14 +189,6 @@ public interface BaseRedisAsyncCommands<K, V> {
     <T> RedisFuture<T> dispatch(ProtocolKeyword type, CommandOutput<K, V, T> output, CommandArgs<K, V> args);
 
     /**
-     * @return {@code true} if the connection is open (connected and not closed).
-     * @deprecated since 6.2. Use the corresponding {@link io.lettuce.core.api.StatefulConnection#isOpen()} method on the
-     *             connection interface. To be removed with Lettuce 7.0.
-     */
-    @Deprecated
-    boolean isOpen();
-
-    /**
      * Disable or enable auto-flush behavior. Default is {@code true}. If autoFlushCommands is disabled, multiple commands can
      * be issued without writing them actually to the transport. Commands are buffered until a {@link #flushCommands()} is
      * issued. After calling {@link #flushCommands()} commands are sent to the transport and executed by Redis.

--- a/src/main/java/io/lettuce/core/api/async/BaseRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/BaseRedisAsyncCommands.java
@@ -217,5 +217,4 @@ public interface BaseRedisAsyncCommands<K, V> {
      */
     @Deprecated
     void flushCommands();
-
 }

--- a/src/main/java/io/lettuce/core/api/reactive/BaseRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/BaseRedisReactiveCommands.java
@@ -190,36 +190,6 @@ public interface BaseRedisReactiveCommands<K, V> {
     <T> Flux<T> dispatch(ProtocolKeyword type, CommandOutput<K, V, ?> output, CommandArgs<K, V> args);
 
     /**
-     * @return {@code true} if the connection is open (connected and not closed).
-     * @deprecated since 6.2. Use the corresponding {@link io.lettuce.core.api.StatefulConnection#isOpen()} method on the
-     *             connection interface. To be removed with Lettuce 7.0.
-     */
-    @Deprecated
-    boolean isOpen();
-
-    /**
-     * Disable or enable auto-flush behavior. Default is {@code true}. If autoFlushCommands is disabled, multiple commands can
-     * be issued without writing them actually to the transport. Commands are buffered until a {@link #flushCommands()} is
-     * issued. After calling {@link #flushCommands()} commands are sent to the transport and executed by Redis.
-     *
-     * @param autoFlush state of autoFlush.
-     * @deprecated since 6.2. Use the corresponding {@link io.lettuce.core.api.StatefulConnection#setAutoFlushCommands(boolean)}
-     *             method on the connection interface. To be removed with Lettuce 7.0.
-     */
-    @Deprecated
-    void setAutoFlushCommands(boolean autoFlush);
-
-    /**
-     * Flush pending commands. This commands forces a flush on the channel and can be used to buffer ("pipeline") commands to
-     * achieve batching. No-op if channel is not connected.
-     *
-     * @deprecated since 6.2. Use the corresponding {@link io.lettuce.core.api.StatefulConnection#flushCommands()} method on the
-     *             connection interface. To be removed with Lettuce 7.0.
-     */
-    @Deprecated
-    void flushCommands();
-
-    /**
      * @return the currently configured instance of the {@link JsonParser}
      * @since 6.5
      */

--- a/src/main/java/io/lettuce/core/api/sync/BaseRedisCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/BaseRedisCommands.java
@@ -187,12 +187,4 @@ public interface BaseRedisCommands<K, V> {
      */
     <T> T dispatch(ProtocolKeyword type, CommandOutput<K, V, T> output, CommandArgs<K, V> args);
 
-    /**
-     * @return {@code true} if the connection is open (connected and not closed).
-     * @deprecated since 6.2. Use the corresponding {@link io.lettuce.core.api.StatefulConnection#isOpen()} method on the
-     *             connection interface. To be removed with Lettuce 7.0.
-     */
-    @Deprecated
-    boolean isOpen();
-
 }

--- a/src/main/java/io/lettuce/core/sentinel/RedisSentinelAsyncCommandsImpl.java
+++ b/src/main/java/io/lettuce/core/sentinel/RedisSentinelAsyncCommandsImpl.java
@@ -196,15 +196,6 @@ public class RedisSentinelAsyncCommandsImpl<K, V> implements RedisSentinelAsyncC
         return asyncCommand;
     }
 
-    public void close() {
-        connection.close();
-    }
-
-    @Override
-    public boolean isOpen() {
-        return connection.isOpen();
-    }
-
     @Override
     public StatefulRedisSentinelConnection<K, V> getStatefulConnection() {
         return (StatefulRedisSentinelConnection<K, V>) connection;

--- a/src/main/java/io/lettuce/core/sentinel/RedisSentinelReactiveCommandsImpl.java
+++ b/src/main/java/io/lettuce/core/sentinel/RedisSentinelReactiveCommandsImpl.java
@@ -190,16 +190,6 @@ public class RedisSentinelReactiveCommandsImpl<K, V> extends AbstractRedisReacti
     }
 
     @Override
-    public void close() {
-        getStatefulConnection().close();
-    }
-
-    @Override
-    public boolean isOpen() {
-        return getStatefulConnection().isOpen();
-    }
-
-    @Override
     public StatefulRedisSentinelConnection<K, V> getStatefulConnection() {
         return (StatefulRedisSentinelConnection<K, V>) super.getConnection();
     }

--- a/src/main/java/io/lettuce/core/sentinel/api/async/RedisSentinelAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/sentinel/api/async/RedisSentinelAsyncCommands.java
@@ -250,11 +250,6 @@ public interface RedisSentinelAsyncCommands<K, V> {
     <T> RedisFuture<T> dispatch(ProtocolKeyword type, CommandOutput<K, V, T> output, CommandArgs<K, V> args);
 
     /**
-     * @return {@code true} if the connection is open (connected and not closed).
-     */
-    boolean isOpen();
-
-    /**
      * @return the underlying connection.
      */
     StatefulRedisSentinelConnection<K, V> getStatefulConnection();

--- a/src/main/java/io/lettuce/core/sentinel/api/reactive/RedisSentinelReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/sentinel/api/reactive/RedisSentinelReactiveCommands.java
@@ -250,11 +250,6 @@ public interface RedisSentinelReactiveCommands<K, V> {
     <T> Flux<T> dispatch(ProtocolKeyword type, CommandOutput<K, V, ?> output, CommandArgs<K, V> args);
 
     /**
-     * @return {@code true} if the connection is open (connected and not closed).
-     */
-    boolean isOpen();
-
-    /**
      * @return the underlying connection.
      */
     StatefulRedisSentinelConnection<K, V> getStatefulConnection();

--- a/src/main/java/io/lettuce/core/sentinel/api/sync/RedisSentinelCommands.java
+++ b/src/main/java/io/lettuce/core/sentinel/api/sync/RedisSentinelCommands.java
@@ -249,11 +249,6 @@ public interface RedisSentinelCommands<K, V> {
     <T> T dispatch(ProtocolKeyword type, CommandOutput<K, V, T> output, CommandArgs<K, V> args);
 
     /**
-     * @return {@code true} if the connection is open (connected and not closed).
-     */
-    boolean isOpen();
-
-    /**
      * @return the underlying connection.
      */
     StatefulRedisSentinelConnection<K, V> getStatefulConnection();

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/BaseRedisCoroutinesCommands.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/BaseRedisCoroutinesCommands.kt
@@ -188,34 +188,5 @@ interface BaseRedisCoroutinesCommands<K : Any, V : Any> {
      */
     fun <T : Any> dispatch(type: ProtocolKeyword, output: CommandOutput<K, V, T>, args: CommandArgs<K, V>): Flow<T>
 
-    /**
-     * @return {@code true} if the connection is open (connected and not closed).
-     * @deprecated since 6.2. Use the corresponding [io.lettuce.core.api.StatefulConnection#isOpen()] method on the connection
-     * interface. To be removed with Lettuce 7.0.
-     */
-    @Deprecated("since 6.2, to be removed with Lettuce 7")
-    fun isOpen(): Boolean
-
-    /**
-     * Disable or enable auto-flush behavior. Default is `true`. If autoFlushCommands is disabled, multiple commands can
-     * be issued without writing them actually to the transport. Commands are buffered until a [flushCommands] is
-     * issued. After calling [flushCommands] commands are sent to the transport and executed by Redis.
-     *
-     * @param autoFlush state of autoFlush.
-     * @deprecated since 6.2. Use the corresponding [io.lettuce.core.api.StatefulConnection#setAutoFlushCommands(boolean)] method on the connection
-     * interface. To be removed with Lettuce 7.0.
-     */
-    @Deprecated("since 6.2, to be removed with Lettuce 7")
-    fun setAutoFlushCommands(autoFlush: Boolean)
-
-    /**
-     * Flush pending commands. This commands forces a flush on the channel and can be used to buffer ("pipeline") commands to
-     * achieve batching. No-op if channel is not connected.
-     * @deprecated since 6.2. Use the corresponding [io.lettuce.core.api.StatefulConnection#flushCommands()] method on the connection
-     * interface. To be removed with Lettuce 7.0.
-     */
-    @Deprecated("since 6.2, to be removed with Lettuce 7")
-    fun flushCommands()
-
 }
 

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/BaseRedisCoroutinesCommandsImpl.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/BaseRedisCoroutinesCommandsImpl.kt
@@ -80,11 +80,5 @@ internal class BaseRedisCoroutinesCommandsImpl<K : Any, V : Any>(internal val op
 
     override fun <T : Any> dispatch(type: ProtocolKeyword, output: CommandOutput<K, V, T>, args: CommandArgs<K, V>): Flow<T> = ops.dispatch<T>(type, output, args).asFlow()
 
-    override fun isOpen(): Boolean = ops.isOpen
-
-    override fun setAutoFlushCommands(autoFlush: Boolean) = ops.setAutoFlushCommands(autoFlush)
-
-    override fun flushCommands() = ops.flushCommands()
-
 }
 

--- a/src/main/kotlin/io/lettuce/core/sentinel/api/coroutines/RedisSentinelCoroutinesCommands.kt
+++ b/src/main/kotlin/io/lettuce/core/sentinel/api/coroutines/RedisSentinelCoroutinesCommands.kt
@@ -246,11 +246,5 @@ interface RedisSentinelCoroutinesCommands<K : Any, V : Any> {
      */
     fun <T : Any> dispatch(type: ProtocolKeyword, output: CommandOutput<K, V, T>, args: CommandArgs<K, V>): Flow<T>
 
-    /**
-     *
-     * @return @code true} if the connection is open (connected and not closed).
-     */
-    fun isOpen(): Boolean
-
 }
 

--- a/src/main/kotlin/io/lettuce/core/sentinel/api/coroutines/RedisSentinelCoroutinesCommandsImpl.kt
+++ b/src/main/kotlin/io/lettuce/core/sentinel/api/coroutines/RedisSentinelCoroutinesCommandsImpl.kt
@@ -99,7 +99,5 @@ internal class RedisSentinelCoroutinesCommandsImpl<K : Any, V : Any>(internal va
 
     override fun <T : Any> dispatch(type: ProtocolKeyword, output: CommandOutput<K, V, T>, args: CommandArgs<K, V>): Flow<T> = ops.dispatch<T>(type, output, args).asFlow()
 
-    override fun isOpen(): Boolean = ops.isOpen
-
 }
 

--- a/src/main/templates/io/lettuce/core/api/BaseRedisCommands.java
+++ b/src/main/templates/io/lettuce/core/api/BaseRedisCommands.java
@@ -188,36 +188,4 @@ public interface BaseRedisCommands<K, V> {
      */
     <T> T dispatch(ProtocolKeyword type, CommandOutput<K, V, T> output, CommandArgs<K, V> args);
 
-    /**
-     * @return {@code true} if the connection is open (connected and not closed).
-     * @deprecated since 6.2. Use the corresponding {@link io.lettuce.core.api.StatefulConnection#isOpen()} method on the
-     *             connection interface. To be removed with Lettuce 7.0.
-     */
-    @Deprecated
-    boolean isOpen();
-
-    /**
-     * Disable or enable auto-flush behavior. Default is {@code true}. If autoFlushCommands is disabled, multiple commands can
-     * be issued without writing them actually to the transport. Commands are buffered until a {@link #flushCommands()} is
-     * issued. After calling {@link #flushCommands()} commands are sent to the transport and executed by Redis.
-     *
-     * @param autoFlush state of autoFlush.
-     * @deprecated since 6.2. Use the corresponding {@link io.lettuce.core.api.StatefulConnection#setAutoFlushCommands(boolean)}
-     *             method on the connection interface. To be removed with Lettuce 7.0.
-     * 
-     */
-    @Deprecated
-    void setAutoFlushCommands(boolean autoFlush);
-
-    /**
-     * Flush pending commands. This commands forces a flush on the channel and can be used to buffer ("pipeline") commands to
-     * achieve batching. No-op if channel is not connected.
-     * 
-     * @deprecated since 6.2. Use the corresponding {@link io.lettuce.core.api.StatefulConnection#flushCommands()} method on the
-     *             connection interface. To be removed with Lettuce 7.0.
-     * 
-     */
-    @Deprecated
-    void flushCommands();
-
 }

--- a/src/main/templates/io/lettuce/core/api/RedisSentinelCommands.java
+++ b/src/main/templates/io/lettuce/core/api/RedisSentinelCommands.java
@@ -249,12 +249,6 @@ public interface RedisSentinelCommands<K, V> {
 
     /**
      *
-     * @return {@code true} if the connection is open (connected and not closed).
-     */
-    boolean isOpen();
-
-    /**
-     *
      * @return the underlying connection.
      */
     StatefulRedisSentinelConnection<K, V> getStatefulConnection();

--- a/src/test/java/biz/paluch/redis/extensibility/MyExtendedRedisClientIntegrationTests.java
+++ b/src/test/java/biz/paluch/redis/extensibility/MyExtendedRedisClientIntegrationTests.java
@@ -50,7 +50,7 @@ class MyExtendedRedisClientIntegrationTests {
         StatefulRedisPubSubConnection<String, String> connection = client.connectPubSub();
         RedisPubSubAsyncCommands<String, String> commands = connection.async();
         assertThat(commands).isInstanceOf(RedisPubSubAsyncCommandsImpl.class);
-        assertThat(commands.getStatefulConnection()).isInstanceOf(MyPubSubConnection.class);
+        assertThat(connection).isInstanceOf(MyPubSubConnection.class);
         commands.set("key", "value").get();
         connection.close();
     }

--- a/src/test/java/biz/paluch/redis/extensibility/MyExtendedRedisClientIntegrationTests.java
+++ b/src/test/java/biz/paluch/redis/extensibility/MyExtendedRedisClientIntegrationTests.java
@@ -47,12 +47,12 @@ class MyExtendedRedisClientIntegrationTests {
 
     @Test
     void testPubsub() throws Exception {
-        StatefulRedisPubSubConnection<String, String> connection = client.connectPubSub();
-        RedisPubSubAsyncCommands<String, String> commands = connection.async();
-        assertThat(commands).isInstanceOf(RedisPubSubAsyncCommandsImpl.class);
-        assertThat(connection).isInstanceOf(MyPubSubConnection.class);
-        commands.set("key", "value").get();
-        connection.close();
+        try (StatefulRedisPubSubConnection<String, String> connection = client.connectPubSub()) {
+            RedisPubSubAsyncCommands<String, String> commands = connection.async();
+            assertThat(commands).isInstanceOf(RedisPubSubAsyncCommandsImpl.class);
+            assertThat(connection).isInstanceOf(MyPubSubConnection.class);
+            commands.set("key", "value").get();
+        }
     }
 
 }

--- a/src/test/java/io/lettuce/core/AbstractRedisClientTest.java
+++ b/src/test/java/io/lettuce/core/AbstractRedisClientTest.java
@@ -19,13 +19,13 @@
  */
 package io.lettuce.core;
 
+import io.lettuce.core.api.StatefulRedisConnection;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.test.resource.DefaultRedisClient;
-import io.lettuce.test.resource.TestClientResources;
 
 /**
  * @author Will Glozer
@@ -37,23 +37,21 @@ public abstract class AbstractRedisClientTest extends TestSupport {
 
     protected RedisCommands<String, String> redis;
 
+    protected StatefulRedisConnection<String, String> statefulRedisConnection;
+
     @BeforeAll
     public static void setupClient() {
         client = DefaultRedisClient.get();
         client.setOptions(ClientOptions.create());
     }
 
-    private static RedisClient newRedisClient() {
-        return RedisClient.create(TestClientResources.get(), RedisURI.Builder.redis(host, port).build());
-    }
-
     protected RedisCommands<String, String> connect() {
-        RedisCommands<String, String> connect = client.connect().sync();
-        return connect;
+        statefulRedisConnection = client.connect();
+        return statefulRedisConnection.sync();
     }
 
     @BeforeEach
-    public void openConnection() throws Exception {
+    public void openConnection() {
         client.setOptions(ClientOptions.builder().build());
         redis = connect();
         boolean scriptRunning;
@@ -77,9 +75,9 @@ public abstract class AbstractRedisClientTest extends TestSupport {
     }
 
     @AfterEach
-    public void closeConnection() throws Exception {
-        if (redis != null) {
-            redis.getStatefulConnection().close();
+    public void closeConnection() {
+        if (statefulRedisConnection != null) {
+            statefulRedisConnection.close();
         }
     }
 

--- a/src/test/java/io/lettuce/core/AsyncConnectionIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/AsyncConnectionIntegrationTests.java
@@ -44,6 +44,7 @@ import io.lettuce.test.TestFutures;
 /**
  * @author Will Glozer
  * @author Mark Paluch
+ * @author Hari Mani
  */
 @Tag(INTEGRATION_TEST)
 @ExtendWith(LettuceExtension.class)
@@ -51,16 +52,13 @@ class AsyncConnectionIntegrationTests extends TestSupport {
 
     private final RedisClient client;
 
-    private final StatefulRedisConnection<String, String> connection;
-
     private final RedisAsyncCommands<String, String> async;
 
     @Inject
     AsyncConnectionIntegrationTests(RedisClient client, StatefulRedisConnection<String, String> connection) {
         this.client = client;
-        this.connection = connection;
         this.async = connection.async();
-        this.connection.sync().flushall();
+        connection.sync().flushall();
     }
 
     @Test
@@ -121,8 +119,6 @@ class AsyncConnectionIntegrationTests extends TestSupport {
         Delay.delay(Duration.ofMillis(100));
 
         assertThat(run).hasSize(1);
-
-        connection.getStatefulConnection().close();
     }
 
     @Test
@@ -130,14 +126,7 @@ class AsyncConnectionIntegrationTests extends TestSupport {
 
         final List<Object> run = new ArrayList<>();
 
-        Runnable listener = new Runnable() {
-
-            @Override
-            public void run() {
-                run.add(new Object());
-            }
-
-        };
+        Runnable listener = () -> run.add(new Object());
 
         RedisAsyncCommands<String, String> connection = client.connect().async();
 
@@ -147,8 +136,6 @@ class AsyncConnectionIntegrationTests extends TestSupport {
         set.thenRun(listener);
 
         assertThat(run).hasSize(1);
-
-        connection.getStatefulConnection().close();
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/ConnectMethodsIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/ConnectMethodsIntegrationTests.java
@@ -42,14 +42,14 @@ class ConnectMethodsIntegrationTests {
 
     @Test
     void standaloneAsync() {
-        try(final StatefulRedisConnection<String, String> connection = redisClient.connect()) {
+        try (StatefulRedisConnection<String, String> connection = redisClient.connect()) {
             connection.async();
         }
     }
 
     @Test
     void standaloneReactive() {
-        try(final StatefulRedisConnection<String, String> connection = redisClient.connect()) {
+        try (StatefulRedisConnection<String, String> connection = redisClient.connect()) {
             connection.reactive();
         }
     }
@@ -83,21 +83,21 @@ class ConnectMethodsIntegrationTests {
     // Sentinel
     @Test
     void sentinelSync() {
-        try(final StatefulRedisSentinelConnection<String, String> connection = redisClient.connectSentinel()) {
+        try (StatefulRedisSentinelConnection<String, String> connection = redisClient.connectSentinel()) {
             connection.sync();
         }
     }
 
     @Test
     void sentinelAsync() {
-        try(final StatefulRedisSentinelConnection<String, String> connection = redisClient.connectSentinel()) {
+        try (StatefulRedisSentinelConnection<String, String> connection = redisClient.connectSentinel()) {
             connection.async();
         }
     }
 
     @Test
     void sentinelReactive() {
-        try(final StatefulRedisSentinelConnection<String, String> connection = redisClient.connectSentinel()) {
+        try (StatefulRedisSentinelConnection<String, String> connection = redisClient.connectSentinel()) {
             connection.reactive();
         }
     }
@@ -110,21 +110,21 @@ class ConnectMethodsIntegrationTests {
     // Cluster
     @Test
     void clusterSync() {
-        try(final StatefulRedisClusterConnection<String, String> connection = clusterClient.connect()) {
+        try (StatefulRedisClusterConnection<String, String> connection = clusterClient.connect()) {
             connection.sync();
         }
     }
 
     @Test
     void clusterAsync() {
-        try(final StatefulRedisClusterConnection<String, String> connection = clusterClient.connect()) {
+        try (StatefulRedisClusterConnection<String, String> connection = clusterClient.connect()) {
             connection.async();
         }
     }
 
     @Test
     void clusterReactive() {
-        try(final StatefulRedisClusterConnection<String, String> connection = clusterClient.connect()) {
+        try (StatefulRedisClusterConnection<String, String> connection = clusterClient.connect()) {
             connection.reactive();
         }
     }
@@ -136,21 +136,21 @@ class ConnectMethodsIntegrationTests {
 
     @Test
     void clusterPubSubSync() {
-        try(final StatefulRedisClusterPubSubConnection<String, String> connection = clusterClient.connectPubSub()) {
+        try (StatefulRedisClusterPubSubConnection<String, String> connection = clusterClient.connectPubSub()) {
             connection.sync();
         }
     }
 
     @Test
     void clusterPubSubAsync() {
-        try(final StatefulRedisClusterPubSubConnection<String, String> connection = clusterClient.connectPubSub()) {
+        try (StatefulRedisClusterPubSubConnection<String, String> connection = clusterClient.connectPubSub()) {
             connection.async();
         }
     }
 
     @Test
     void clusterPubSubReactive() {
-        try(final StatefulRedisClusterPubSubConnection<String, String> connection = clusterClient.connectPubSub()) {
+        try (StatefulRedisClusterPubSubConnection<String, String> connection = clusterClient.connectPubSub()) {
             connection.reactive();
         }
     }
@@ -163,26 +163,26 @@ class ConnectMethodsIntegrationTests {
     // Advanced Cluster
     @Test
     void advancedClusterSync() {
-        StatefulRedisClusterConnection<String, String> statefulConnection = clusterClient.connect();
-        RedisURI uri = clusterClient.getPartitions().getPartition(0).getUri();
-        statefulConnection.getConnection(uri.getHost(), uri.getPort()).sync();
-        statefulConnection.close();
+        try (StatefulRedisClusterConnection<String, String> statefulConnection = clusterClient.connect()) {
+            RedisURI uri = clusterClient.getPartitions().getPartition(0).getUri();
+            statefulConnection.getConnection(uri.getHost(), uri.getPort()).sync();
+        }
     }
 
     @Test
     void advancedClusterAsync() {
-        StatefulRedisClusterConnection<String, String> statefulConnection = clusterClient.connect();
-        RedisURI uri = clusterClient.getPartitions().getPartition(0).getUri();
-        statefulConnection.getConnection(uri.getHost(), uri.getPort()).sync();
-        statefulConnection.close();
+        try (StatefulRedisClusterConnection<String, String> statefulConnection = clusterClient.connect()) {
+            RedisURI uri = clusterClient.getPartitions().getPartition(0).getUri();
+            statefulConnection.getConnection(uri.getHost(), uri.getPort()).sync();
+        }
     }
 
     @Test
     void advancedClusterReactive() {
-        StatefulRedisClusterConnection<String, String> statefulConnection = clusterClient.connect();
-        RedisURI uri = clusterClient.getPartitions().getPartition(0).getUri();
-        statefulConnection.getConnection(uri.getHost(), uri.getPort()).reactive();
-        statefulConnection.close();
+        try (StatefulRedisClusterConnection<String, String> statefulConnection = clusterClient.connect()) {
+            RedisURI uri = clusterClient.getPartitions().getPartition(0).getUri();
+            statefulConnection.getConnection(uri.getHost(), uri.getPort()).reactive();
+        }
     }
 
     @Test
@@ -193,9 +193,9 @@ class ConnectMethodsIntegrationTests {
     // Cluster node selection
     @Test
     void nodeSelectionClusterAsync() {
-        StatefulRedisClusterConnection<String, String> statefulConnection = clusterClient.connect();
-        AsyncNodeSelection<String, String> masters = statefulConnection.async().masters();
-        statefulConnection.close();
+        try (StatefulRedisClusterConnection<String, String> statefulConnection = clusterClient.connect()) {
+            AsyncNodeSelection<String, String> masters = statefulConnection.async().masters();
+        }
     }
 
 }

--- a/src/test/java/io/lettuce/core/ConnectMethodsIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/ConnectMethodsIntegrationTests.java
@@ -2,6 +2,9 @@ package io.lettuce.core;
 
 import javax.inject.Inject;
 
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.cluster.pubsub.StatefulRedisClusterPubSubConnection;
+import io.lettuce.core.sentinel.api.StatefulRedisSentinelConnection;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +18,7 @@ import static io.lettuce.TestTags.INTEGRATION_TEST;
 
 /**
  * @author Mark Paluch
+ * @author Hari Mani
  */
 @Tag(INTEGRATION_TEST)
 @ExtendWith(LettuceExtension.class)
@@ -38,12 +42,16 @@ class ConnectMethodsIntegrationTests {
 
     @Test
     void standaloneAsync() {
-        redisClient.connect().async().getStatefulConnection().close();
+        try(final StatefulRedisConnection<String, String> connection = redisClient.connect()) {
+            connection.async();
+        }
     }
 
     @Test
     void standaloneReactive() {
-        redisClient.connect().reactive().getStatefulConnection().close();
+        try(final StatefulRedisConnection<String, String> connection = redisClient.connect()) {
+            connection.reactive();
+        }
     }
 
     @Test
@@ -75,17 +83,23 @@ class ConnectMethodsIntegrationTests {
     // Sentinel
     @Test
     void sentinelSync() {
-        redisClient.connectSentinel().sync().getStatefulConnection().close();
+        try(final StatefulRedisSentinelConnection<String, String> connection = redisClient.connectSentinel()) {
+            connection.sync();
+        }
     }
 
     @Test
     void sentinelAsync() {
-        redisClient.connectSentinel().async().getStatefulConnection().close();
+        try(final StatefulRedisSentinelConnection<String, String> connection = redisClient.connectSentinel()) {
+            connection.async();
+        }
     }
 
     @Test
     void sentinelReactive() {
-        redisClient.connectSentinel().reactive().getStatefulConnection().close();
+        try(final StatefulRedisSentinelConnection<String, String> connection = redisClient.connectSentinel()) {
+            connection.reactive();
+        }
     }
 
     @Test
@@ -96,17 +110,23 @@ class ConnectMethodsIntegrationTests {
     // Cluster
     @Test
     void clusterSync() {
-        clusterClient.connect().sync().getStatefulConnection().close();
+        try(final StatefulRedisClusterConnection<String, String> connection = clusterClient.connect()) {
+            connection.sync();
+        }
     }
 
     @Test
     void clusterAsync() {
-        clusterClient.connect().async().getStatefulConnection().close();
+        try(final StatefulRedisClusterConnection<String, String> connection = clusterClient.connect()) {
+            connection.async();
+        }
     }
 
     @Test
     void clusterReactive() {
-        clusterClient.connect().reactive().getStatefulConnection().close();
+        try(final StatefulRedisClusterConnection<String, String> connection = clusterClient.connect()) {
+            connection.reactive();
+        }
     }
 
     @Test
@@ -116,17 +136,23 @@ class ConnectMethodsIntegrationTests {
 
     @Test
     void clusterPubSubSync() {
-        clusterClient.connectPubSub().sync().getStatefulConnection().close();
+        try(final StatefulRedisClusterPubSubConnection<String, String> connection = clusterClient.connectPubSub()) {
+            connection.sync();
+        }
     }
 
     @Test
     void clusterPubSubAsync() {
-        clusterClient.connectPubSub().async().getStatefulConnection().close();
+        try(final StatefulRedisClusterPubSubConnection<String, String> connection = clusterClient.connectPubSub()) {
+            connection.async();
+        }
     }
 
     @Test
     void clusterPubSubReactive() {
-        clusterClient.connectPubSub().reactive().getStatefulConnection().close();
+        try(final StatefulRedisClusterPubSubConnection<String, String> connection = clusterClient.connectPubSub()) {
+            connection.reactive();
+        }
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/cluster/AdvancedClusterClientIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/AdvancedClusterClientIntegrationTests.java
@@ -89,7 +89,6 @@ class AdvancedClusterClientIntegrationTests extends TestSupport {
     AdvancedClusterClientIntegrationTests(RedisClusterClient clusterClient,
             StatefulRedisClusterConnection<String, String> clusterConnection) {
         this.clusterClient = clusterClient;
-
         this.clusterConnection = clusterConnection;
         this.async = clusterConnection.async();
         this.sync = clusterConnection.sync();
@@ -235,7 +234,7 @@ class AdvancedClusterClientIntegrationTests extends TestSupport {
             expectation.add(kv(key, "value-" + key));
         }
 
-        List<KeyValue<String, String>> result = sync.mget(keys.toArray(new String[keys.size()]));
+        List<KeyValue<String, String>> result = sync.mget(keys.toArray(new String[0]));
 
         assertThat(result).hasSize(keys.size());
         assertThat(result).isEqualTo(expectation);
@@ -257,7 +256,7 @@ class AdvancedClusterClientIntegrationTests extends TestSupport {
 
         List<String> keys = prepareKeys();
 
-        Long result = sync.del(keys.toArray(new String[keys.size()]));
+        Long result = sync.del(keys.toArray(new String[0]));
 
         assertThat(result).isEqualTo(25);
 
@@ -284,7 +283,7 @@ class AdvancedClusterClientIntegrationTests extends TestSupport {
 
         List<String> keys = prepareKeys();
 
-        Long result = sync.unlink(keys.toArray(new String[keys.size()]));
+        Long result = sync.unlink(keys.toArray(new String[0]));
 
         assertThat(result).isEqualTo(25);
 

--- a/src/test/java/io/lettuce/core/commands/RunOnlyOnceServerCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/RunOnlyOnceServerCommandIntegrationTests.java
@@ -36,15 +36,11 @@ class RunOnlyOnceServerCommandIntegrationTests extends TestSupport {
 
     private final RedisClient client;
 
-    private final StatefulRedisConnection<String, String> connection;
-
     private final RedisCommands<String, String> redis;
 
     @Inject
     RunOnlyOnceServerCommandIntegrationTests(RedisClient client, StatefulRedisConnection<String, String> connection) {
-
         this.client = client;
-        this.connection = connection;
         this.redis = connection.sync();
     }
 
@@ -56,16 +52,14 @@ class RunOnlyOnceServerCommandIntegrationTests extends TestSupport {
     @Disabled
     @Order(1)
     void debugSegfault() {
-
         assumeTrue(CanConnect.to(host(), port(1)));
-
         final RedisURI redisURI = RedisURI.Builder.redis(host(), port(1)).build();
-        try (final StatefulRedisConnection<String, String> cnxn = client.connect(redisURI)) {
-            final RedisAsyncCommands<String, String> commands = cnxn.async();
+        try (StatefulRedisConnection<String, String> connection = client.connect(redisURI)) {
+            final RedisAsyncCommands<String, String> commands = connection.async();
             commands.debugSegfault();
 
-            Wait.untilTrue(() -> !cnxn.isOpen()).waitOrTimeout();
-            assertThat(cnxn.isOpen()).isFalse();
+            Wait.untilTrue(() -> !connection.isOpen()).waitOrTimeout();
+            assertThat(connection.isOpen()).isFalse();
         }
     }
 
@@ -112,10 +106,9 @@ class RunOnlyOnceServerCommandIntegrationTests extends TestSupport {
     @Test
     @Order(4)
     void shutdown() {
-
         assumeTrue(CanConnect.to(host(), port(7)));
         final RedisURI redisURI = RedisURI.Builder.redis(host(), port(2)).build();
-        try (final StatefulRedisConnection<String, String> cnxn = client.connect(redisURI)) {
+        try (StatefulRedisConnection<String, String> cnxn = client.connect(redisURI)) {
             final RedisAsyncCommands<String, String> commands = cnxn.async();
             commands.shutdown(true);
             commands.shutdown(false);

--- a/src/test/java/io/lettuce/core/protocol/ConnectionFailureIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/protocol/ConnectionFailureIntegrationTests.java
@@ -168,7 +168,6 @@ class ConnectionFailureIntegrationTests extends TestSupport {
         }
     }
 
-
     @Test
     void emitEventOnReconnectFailure() throws Exception {
 

--- a/src/test/java/io/lettuce/core/protocol/ConnectionFailureIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/protocol/ConnectionFailureIntegrationTests.java
@@ -99,7 +99,7 @@ class ConnectionFailureIntegrationTests extends TestSupport {
         RedisURI redisUri = RedisURI.Builder.redis(TestSettings.host(), TestSettings.port()).build();
         redisUri.setTimeout(Duration.ofSeconds(5));
 
-        try (final StatefulRedisConnection<String, String> cnxn = client.connect(redisUri)) {
+        try (StatefulRedisConnection<String, String> cnxn = client.connect(redisUri)) {
             RedisAsyncCommands<String, String> commands = cnxn.async();
             ConnectionWatchdog connectionWatchdog = ConnectionTestUtil.getConnectionWatchdog(cnxn);
 
@@ -140,7 +140,7 @@ class ConnectionFailureIntegrationTests extends TestSupport {
         RedisURI redisUri = RedisURI.create(defaultRedisUri.toURI());
         redisUri.setTimeout(Duration.ofSeconds(5));
 
-        try (final StatefulRedisConnection<String, String> connection = client.connect(redisUri)) {
+        try (StatefulRedisConnection<String, String> connection = client.connect(redisUri)) {
             final BlockingQueue<ConnectionEvents.Reconnect> events = new LinkedBlockingDeque<>();
 
             RedisAsyncCommands<String, String> commands = connection.async();
@@ -182,7 +182,7 @@ class ConnectionFailureIntegrationTests extends TestSupport {
         client.setOptions(
                 ClientOptions.builder().timeoutOptions(TimeoutOptions.builder().timeoutCommands(false).build()).build());
 
-        try (final StatefulRedisConnection<String, String> connection = client.connect(redisUri)) {
+        try (StatefulRedisConnection<String, String> connection = client.connect(redisUri)) {
             RedisAsyncCommandsImpl<String, String> commands = (RedisAsyncCommandsImpl<String, String>) connection.async();
             ConnectionWatchdog connectionWatchdog = ConnectionTestUtil.getConnectionWatchdog(connection);
 

--- a/src/test/java/io/lettuce/core/reliability/AtMostOnceIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/reliability/AtMostOnceIntegrationTests.java
@@ -66,10 +66,11 @@ class AtMostOnceIntegrationTests {
 
     @BeforeEach
     void before() {
-        RedisCommands<String, String> connection = client.connect().sync();
-        connection.flushall();
-        connection.flushdb();
-        connection.getStatefulConnection().close();
+        try (final StatefulRedisConnection<String, String> connection = client.connect()) {
+            RedisCommands<String, String> command = connection.sync();
+            command.flushall();
+            command.flushdb();
+        }
     }
 
     @AfterEach
@@ -99,13 +100,12 @@ class AtMostOnceIntegrationTests {
 
     @Test
     void basicOperations() {
+        try (final StatefulRedisConnection<String, String> connection = client.connect()) {
+            RedisCommands<String, String> command = connection.sync();
 
-        RedisCommands<String, String> connection = client.connect().sync();
-
-        connection.set(key, "1");
-        assertThat(connection.get("key")).isEqualTo("1");
-
-        connection.getStatefulConnection().close();
+            command.set(key, "1");
+            assertThat(command.get("key")).isEqualTo("1");
+        }
     }
 
     @Test
@@ -294,13 +294,10 @@ class AtMostOnceIntegrationTests {
 
     @Test
     void commandsCancelledOnDisconnect() {
-
-        StatefulRedisConnection<String, String> connection = client.connect();
-
-        try {
+        try (final StatefulRedisConnection<String, String> connection = client.connect()) {
 
             RedisAsyncCommands<String, String> async = connection.async();
-            async.setAutoFlushCommands(false);
+            connection.setAutoFlushCommands(false);
             async.quit();
 
             RedisFuture<Long> incr = async.incr(key);
@@ -312,8 +309,6 @@ class AtMostOnceIntegrationTests {
         } catch (Exception e) {
             assertThat(e).hasRootCauseInstanceOf(RedisException.class).hasMessageContaining("Connection disconnected");
         }
-
-        connection.close();
     }
 
     private Throwable getException(RedisFuture<?> command) {

--- a/src/test/java/io/lettuce/core/reliability/AtMostOnceIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/reliability/AtMostOnceIntegrationTests.java
@@ -66,7 +66,7 @@ class AtMostOnceIntegrationTests {
 
     @BeforeEach
     void before() {
-        try (final StatefulRedisConnection<String, String> connection = client.connect()) {
+        try (StatefulRedisConnection<String, String> connection = client.connect()) {
             RedisCommands<String, String> command = connection.sync();
             command.flushall();
             command.flushdb();
@@ -100,7 +100,7 @@ class AtMostOnceIntegrationTests {
 
     @Test
     void basicOperations() {
-        try (final StatefulRedisConnection<String, String> connection = client.connect()) {
+        try (StatefulRedisConnection<String, String> connection = client.connect()) {
             RedisCommands<String, String> command = connection.sync();
 
             command.set(key, "1");
@@ -294,7 +294,7 @@ class AtMostOnceIntegrationTests {
 
     @Test
     void commandsCancelledOnDisconnect() {
-        try (final StatefulRedisConnection<String, String> connection = client.connect()) {
+        try (StatefulRedisConnection<String, String> connection = client.connect()) {
 
             RedisAsyncCommands<String, String> async = connection.async();
             connection.setAutoFlushCommands(false);

--- a/src/test/java/io/lettuce/core/sentinel/SentinelConnectionIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/sentinel/SentinelConnectionIntegrationTests.java
@@ -115,29 +115,6 @@ public class SentinelConnectionIntegrationTests extends TestSupport {
     }
 
     @Test
-    void testSyncClose() {
-
-        StatefulRedisSentinelConnection<String, String> statefulConnection = sentinel.getStatefulConnection();
-        statefulConnection.sync().getStatefulConnection().close();
-
-        Wait.untilTrue(() -> !sentinel.isOpen()).waitOrTimeout();
-
-        assertThat(sentinel.isOpen()).isFalse();
-        assertThat(statefulConnection.isOpen()).isFalse();
-    }
-
-    @Test
-    void testAsyncClose() {
-        StatefulRedisSentinelConnection<String, String> statefulConnection = sentinel.getStatefulConnection();
-        statefulConnection.async().getStatefulConnection().close();
-
-        Wait.untilTrue(() -> !sentinel.isOpen()).waitOrTimeout();
-
-        assertThat(sentinel.isOpen()).isFalse();
-        assertThat(statefulConnection.isOpen()).isFalse();
-    }
-
-    @Test
     void connectToOneNode() {
         RedisSentinelCommands<String, String> connection = redisClient.connectSentinel(SentinelTestSettings.SENTINEL_URI)
                 .sync();


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

Part of #3328

# Changes

- remove usage of deprecated `flushCommands`,  `isOpen`, `setAutoFlushCommands` and `close` in integration tests and changed to use alternate methods from `StatefulRedisConnection` and `StatefulRedisClusterConnection`. 
- remove usage of deprecated `isOpen` in set client name flow for cluster commands
- remove some usages of deprecated `getStatefulConnection` from integration tests
- remove deprecated `flushCommands`,  `isOpen`, `setAutoFlushCommands` and `close` methods from command APIs

# Follow up

- `getStatefulConnection` is still being used in > 50 integration tests, this is to be removed before the method can be removed from the command APIs