### PR TITLE
Fix inaccurate Javadoc for deprecated withPassword(String) method

### DIFF
--- a/src/main/java/io/lettuce/core/RedisURI.java
+++ b/src/main/java/io/lettuce/core/RedisURI.java
@@ -1770,14 +1770,19 @@ public class RedisURI implements Serializable, ConnectionPoint {
         /**
          * Configures authentication. Empty password is supported (although not recommended for security reasons).
          * <p>
-         * This method is deprecated as of Lettuce 6.0. The reason is that {@link String} has a strong caching affinity and the
-         * JVM cannot easily GC {@code String} instances. Therefore, we suggest using either {@code char[]} or a custom
-         * {@link CharSequence} (e.g. {@link StringBuilder} or netty's {@link io.netty.util.AsciiString}).
+         * This method is deprecated as of Lettuce 6.0. The reason is that {@link String} literals are stored in the
+         * String Pool, which is not subject to regular garbage collection and may persist in memory for the lifetime
+         * of the application. Additionally, {@code String} instances are immutable and cannot be explicitly cleared
+         * from memory, creating potential security risks for sensitive data like passwords.
+         * <p>
+         * Therefore, we suggest using either {@code char[]} or a custom {@link CharSequence} implementation
+         * (e.g. {@link StringBuilder} or netty's {@link io.netty.util.AsciiString}) that allows for
+         * explicit memory management.
          *
          * @param password the password
          * @return the builder
          * @deprecated since 6.0. Use {@link #withPassword(CharSequence)} or {@link #withPassword(char[])} to avoid String
-         *             caching.
+         *             pooling and enable explicit memory clearing.
          */
         @Deprecated
         public Builder withPassword(String password) {


### PR DESCRIPTION
# Improve documentation for deprecated password method

## Description

This PR improves the documentation for the deprecated `withPassword(String)` method by providing a more technically accurate explanation of why String parameters are discouraged for sensitive data like passwords.

The updated documentation:

- Correctly identifies the String Pool mechanism rather than using the vaguer term "caching affinity"
- Explicitly mentions the security implications of storing sensitive data in immutable Strings
- Provides clearer explanation of why `char[]` and custom `CharSequence` implementations are recommended alternatives
- Gives developers more educational context about JVM memory management as it relates to security

## Checklist

- [x] I have read the [contribution guidelines](vscode-file://vscode-app/c:/Users/NHN/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html).
- [ ] I have created a feature request first to discuss my contribution intent.
- [ ] I applied code formatting rules using the `mvn formatter:format` target. No formatting-related changes included.
- [x] Documentation-only change, no test cases needed.