### PR TITLE
Fixed SocketOptions.Builder validation messages

### DIFF
--- a/src/main/java/io/lettuce/core/SocketOptions.java
+++ b/src/main/java/io/lettuce/core/SocketOptions.java
@@ -129,7 +129,7 @@ public class SocketOptions {
          */
         public Builder connectTimeout(Duration connectTimeout) {
 
-            LettuceAssert.notNull(connectTimeout, "Connection timeout must not be null");
+            LettuceAssert.notNull(connectTimeout, "Connect timeout must not be null");
             LettuceAssert.isTrue(connectTimeout.toNanos() > 0, "Connect timeout must be greater 0");
 
             this.connectTimeout = connectTimeout;
@@ -149,7 +149,7 @@ public class SocketOptions {
         public Builder connectTimeout(long connectTimeout, TimeUnit connectTimeoutUnit) {
 
             LettuceAssert.isTrue(connectTimeout > 0, "Connect timeout must be greater 0");
-            LettuceAssert.notNull(connectTimeoutUnit, "TimeUnit must not be null");
+            LettuceAssert.notNull(connectTimeoutUnit, "Connect timeout unit must not be null");
 
             return connectTimeout(Duration.ofNanos(connectTimeoutUnit.toNanos(connectTimeout)));
         }
@@ -422,7 +422,7 @@ public class SocketOptions {
             public KeepAliveOptions.Builder idle(Duration idle) {
 
                 LettuceAssert.notNull(idle, "Idle time must not be null");
-                LettuceAssert.isTrue(!idle.isNegative(), "Idle time must not be begative");
+                LettuceAssert.isTrue(!idle.isNegative(), "Idle time must not be negative");
 
                 this.idle = idle;
                 return this;
@@ -439,8 +439,8 @@ public class SocketOptions {
              */
             public KeepAliveOptions.Builder interval(Duration interval) {
 
-                LettuceAssert.notNull(interval, "Idle time must not be null");
-                LettuceAssert.isTrue(!interval.isNegative(), "Idle time must not be begative");
+                LettuceAssert.notNull(interval, "Interval time must not be null");
+                LettuceAssert.isTrue(!interval.isNegative(), "Interval time must not be negative");
 
                 this.interval = interval;
                 return this;


### PR DESCRIPTION
Make sure that:

- [X] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [X] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

Hi guys.
During configuration, I have spotted some incorrect messages in SocketOptions builder validation.

1. 'begative' (typo)
2.  'idle' in interval() validation
3.  'connection' and 'connect' used interchangeably during validation the same exact variable.
4. Time unit validation message does not contain info about 'connect timeout' variable.

Let me know guys if you need tests for that. 
