### PR TITLE
Remove deprecated `reset()` method from Lettuce API and internals

### DIFF
--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -2389,11 +2389,6 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
     }
 
     @Override
-    public void reset() {
-        getConnection().reset();
-    }
-
-    @Override
     public RedisFuture<String> restore(K key, long ttl, byte[] value) {
         return dispatch(commandBuilder.restore(key, value, RestoreArgs.Builder.ttl(ttl)));
     }

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -2473,11 +2473,6 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
-    public void reset() {
-        getConnection().reset();
-    }
-
-    @Override
     public Mono<String> restore(K key, long ttl, byte[] value) {
         return createMono(() -> commandBuilder.restore(key, value, RestoreArgs.Builder.ttl(ttl)));
     }

--- a/src/main/java/io/lettuce/core/CommandListenerWriter.java
+++ b/src/main/java/io/lettuce/core/CommandListenerWriter.java
@@ -110,12 +110,6 @@ public class CommandListenerWriter implements RedisChannelWriter {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-    public void reset() {
-        delegate.reset();
-    }
-
-    @Override
     public void setConnectionFacade(ConnectionFacade connection) {
         delegate.setConnectionFacade(connection);
     }

--- a/src/main/java/io/lettuce/core/RedisChannelHandler.java
+++ b/src/main/java/io/lettuce/core/RedisChannelHandler.java
@@ -305,12 +305,6 @@ public abstract class RedisChannelHandler<K, V> implements Closeable, Connection
         return active;
     }
 
-    @Deprecated
-    @Override
-    public void reset() {
-        channelWriter.reset();
-    }
-
     public ConnectionEvents getConnectionEvents() {
         return connectionEvents;
     }

--- a/src/main/java/io/lettuce/core/RedisChannelWriter.java
+++ b/src/main/java/io/lettuce/core/RedisChannelWriter.java
@@ -51,17 +51,6 @@ public interface RedisChannelWriter extends Closeable, AsyncCloseable {
     CompletableFuture<Void> closeAsync();
 
     /**
-     * Reset the command state. Queued commands will be canceled and the internal state will be reset. This is useful when the
-     * internal state machine gets out of sync with the connection (e.g. errors during external SSL tunneling). Calling this
-     * method will reset the protocol state, therefore it is considered unsafe.
-     *
-     * @deprecated since 5.2. This method is unsafe and can cause protocol offsets (i.e. Redis commands are completed with
-     *             previous command values).
-     */
-    @Deprecated
-    void reset();
-
-    /**
      * Set the corresponding connection facade in order to notify it about channel active/inactive state.
      *
      * @param connection the connection facade (external connection object)

--- a/src/main/java/io/lettuce/core/api/StatefulConnection.java
+++ b/src/main/java/io/lettuce/core/api/StatefulConnection.java
@@ -103,17 +103,6 @@ public interface StatefulConnection<K, V> extends AutoCloseable, AsyncCloseable 
     ClientResources getResources();
 
     /**
-     * Reset the command state. Queued commands will be canceled and the internal state will be reset. This is useful when the
-     * internal state machine gets out of sync with the connection (e.g. errors during external SSL tunneling). Calling this
-     * method will reset the protocol state, therefore it is considered unsafe.
-     *
-     * @deprecated since 5.2. To be removed with 7.0. This method is unsafe and can cause protocol offsets (i.e. Redis commands
-     *             are completed with previous command values).
-     */
-    @Deprecated
-    void reset();
-
-    /**
      * Disable or enable auto-flush behavior. Default is {@code true}. If autoFlushCommands is disabled, multiple commands can
      * be issued without writing them actually to the transport. Commands are buffered until a {@link #flushCommands()} is
      * issued. After calling {@link #flushCommands()} commands are sent to the transport and executed by Redis.

--- a/src/main/java/io/lettuce/core/api/async/BaseRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/BaseRedisAsyncCommands.java
@@ -197,16 +197,6 @@ public interface BaseRedisAsyncCommands<K, V> {
     boolean isOpen();
 
     /**
-     * Reset the command state. Queued commands will be canceled and the internal state will be reset. This is useful when the
-     * internal state machine gets out of sync with the connection.
-     *
-     * @deprecated since 6.2. Use the corresponding {@link io.lettuce.core.api.StatefulConnection#reset()} method on the
-     *             connection interface. To be removed with Lettuce 7.0.
-     */
-    @Deprecated
-    void reset();
-
-    /**
      * Disable or enable auto-flush behavior. Default is {@code true}. If autoFlushCommands is disabled, multiple commands can
      * be issued without writing them actually to the transport. Commands are buffered until a {@link #flushCommands()} is
      * issued. After calling {@link #flushCommands()} commands are sent to the transport and executed by Redis.

--- a/src/main/java/io/lettuce/core/api/reactive/BaseRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/BaseRedisReactiveCommands.java
@@ -198,16 +198,6 @@ public interface BaseRedisReactiveCommands<K, V> {
     boolean isOpen();
 
     /**
-     * Reset the command state. Queued commands will be canceled and the internal state will be reset. This is useful when the
-     * internal state machine gets out of sync with the connection.
-     *
-     * @deprecated since 6.2. Use the corresponding {@link io.lettuce.core.api.StatefulConnection#reset()} method on the
-     *             connection interface. To be removed with Lettuce 7.0.
-     */
-    @Deprecated
-    void reset();
-
-    /**
      * Disable or enable auto-flush behavior. Default is {@code true}. If autoFlushCommands is disabled, multiple commands can
      * be issued without writing them actually to the transport. Commands are buffered until a {@link #flushCommands()} is
      * issued. After calling {@link #flushCommands()} commands are sent to the transport and executed by Redis.

--- a/src/main/java/io/lettuce/core/api/sync/BaseRedisCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/BaseRedisCommands.java
@@ -195,14 +195,4 @@ public interface BaseRedisCommands<K, V> {
     @Deprecated
     boolean isOpen();
 
-    /**
-     * Reset the command state. Queued commands will be canceled and the internal state will be reset. This is useful when the
-     * internal state machine gets out of sync with the connection.
-     *
-     * @deprecated since 6.2. Use the corresponding {@link io.lettuce.core.api.StatefulConnection#reset()} method on the
-     *             connection interface. To be removed with Lettuce 7.0.
-     */
-    @Deprecated
-    void reset();
-
 }

--- a/src/main/java/io/lettuce/core/cluster/ClusterConnectionProvider.java
+++ b/src/main/java/io/lettuce/core/cluster/ClusterConnectionProvider.java
@@ -87,12 +87,6 @@ interface ClusterConnectionProvider extends Closeable {
     CompletableFuture<Void> closeAsync();
 
     /**
-     * Reset the writer state. Queued commands will be canceled and the internal state will be reset. This is useful when the
-     * internal state machine gets out of sync with the connection.
-     */
-    void reset();
-
-    /**
      * Close connections that are not in use anymore/not part of the cluster.
      */
     void closeStaleConnections();

--- a/src/main/java/io/lettuce/core/cluster/ClusterDistributionChannelWriter.java
+++ b/src/main/java/io/lettuce/core/cluster/ClusterDistributionChannelWriter.java
@@ -497,12 +497,6 @@ class ClusterDistributionChannelWriter implements RedisChannelWriter {
         return clusterConnectionProvider;
     }
 
-    @Override
-    public void reset() {
-        defaultWriter.reset();
-        clusterConnectionProvider.reset();
-    }
-
     public void setClusterConnectionProvider(ClusterConnectionProvider clusterConnectionProvider) {
         this.clusterConnectionProvider = clusterConnectionProvider;
         this.asyncClusterConnectionProvider = (AsyncClusterConnectionProvider) clusterConnectionProvider;

--- a/src/main/java/io/lettuce/core/cluster/PooledClusterConnectionProvider.java
+++ b/src/main/java/io/lettuce/core/cluster/PooledClusterConnectionProvider.java
@@ -525,11 +525,6 @@ class PooledClusterConnectionProvider<K, V>
         return connectionProvider.close();
     }
 
-    @Override
-    public void reset() {
-        connectionProvider.forEach(StatefulRedisConnection::reset);
-    }
-
     /**
      * Synchronize on {@code stateLock} to initiate a happens-before relation and clear the thread caches of other threads.
      *

--- a/src/main/java/io/lettuce/core/masterreplica/MasterReplicaChannelWriter.java
+++ b/src/main/java/io/lettuce/core/masterreplica/MasterReplicaChannelWriter.java
@@ -242,11 +242,6 @@ class MasterReplicaChannelWriter implements RedisChannelWriter {
         masterReplicaConnectionProvider.flushCommands();
     }
 
-    @Override
-    public void reset() {
-        masterReplicaConnectionProvider.reset();
-    }
-
     /**
      * Set from which nodes data is read. The setting is used as default for read operations on this connection. See the
      * documentation for {@link ReadFrom} for more information.

--- a/src/main/java/io/lettuce/core/masterreplica/MasterReplicaConnectionProvider.java
+++ b/src/main/java/io/lettuce/core/masterreplica/MasterReplicaConnectionProvider.java
@@ -209,15 +209,6 @@ class MasterReplicaConnectionProvider<K, V> {
     }
 
     /**
-     * Reset the command state of all connections.
-     *
-     * @see StatefulRedisConnection#reset()
-     */
-    public void reset() {
-        connectionProvider.forEach(StatefulRedisConnection::reset);
-    }
-
-    /**
      * Close all connections.
      */
     public void close() {

--- a/src/main/java/io/lettuce/core/masterslave/MasterSlaveConnectionWrapper.java
+++ b/src/main/java/io/lettuce/core/masterslave/MasterSlaveConnectionWrapper.java
@@ -125,12 +125,6 @@ class MasterSlaveConnectionWrapper<K, V> implements StatefulRedisMasterSlaveConn
     }
 
     @Override
-    @Deprecated
-    public void reset() {
-        delegate.reset();
-    }
-
-    @Override
     public void setAutoFlushCommands(boolean autoFlush) {
         delegate.setAutoFlushCommands(autoFlush);
     }

--- a/src/main/java/io/lettuce/core/protocol/CommandExpiryWriter.java
+++ b/src/main/java/io/lettuce/core/protocol/CommandExpiryWriter.java
@@ -152,11 +152,6 @@ public class CommandExpiryWriter implements RedisChannelWriter {
         return delegate.closeAsync();
     }
 
-    @Override
-    public void reset() {
-        delegate.reset();
-    }
-
     public void setTimeout(Duration timeout) {
         this.timeout = timeUnit.convert(timeout.toNanos(), TimeUnit.NANOSECONDS);
     }

--- a/src/main/java/io/lettuce/core/protocol/ConnectionFacade.java
+++ b/src/main/java/io/lettuce/core/protocol/ConnectionFacade.java
@@ -20,9 +20,4 @@ public interface ConnectionFacade {
      */
     void deactivated();
 
-    /**
-     * Reset the connection state.
-     */
-    void reset();
-
 }

--- a/src/main/java/io/lettuce/core/protocol/DefaultEndpoint.java
+++ b/src/main/java/io/lettuce/core/protocol/DefaultEndpoint.java
@@ -642,24 +642,6 @@ public class DefaultEndpoint implements RedisChannelWriter, Endpoint, PushHandle
     }
 
     /**
-     * Reset the writer state. Queued commands will be canceled and the internal state will be reset. This is useful when the
-     * internal state machine gets out of sync with the connection.
-     */
-    @Override
-    public void reset() {
-
-        if (debugEnabled) {
-            logger.debug("{} reset()", logPrefix());
-        }
-
-        Channel channel = this.channel;
-        if (channel != null) {
-            channel.pipeline().fireUserEventTriggered(new ConnectionEvents.Reset());
-        }
-        cancelBufferedCommands("Reset");
-    }
-
-    /**
      * Reset the command-handler to the initial not-connected state.
      */
     public void initialState() {

--- a/src/main/templates/io/lettuce/core/api/BaseRedisCommands.java
+++ b/src/main/templates/io/lettuce/core/api/BaseRedisCommands.java
@@ -197,16 +197,6 @@ public interface BaseRedisCommands<K, V> {
     boolean isOpen();
 
     /**
-     * Reset the command state. Queued commands will be canceled and the internal state will be reset. This is useful when the
-     * internal state machine gets out of sync with the connection.
-     * 
-     * @deprecated since 6.2. Use the corresponding {@link io.lettuce.core.api.StatefulConnection#reset()} method on the
-     *             connection interface. To be removed with Lettuce 7.0.
-     */
-    @Deprecated
-    void reset();
-
-    /**
      * Disable or enable auto-flush behavior. Default is {@code true}. If autoFlushCommands is disabled, multiple commands can
      * be issued without writing them actually to the transport. Commands are buffered until a {@link #flushCommands()} is
      * issued. After calling {@link #flushCommands()} commands are sent to the transport and executed by Redis.

--- a/src/test/java/io/lettuce/core/ClientIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/ClientIntegrationTests.java
@@ -212,34 +212,6 @@ class ClientIntegrationTests extends TestSupport {
     }
 
     @Test
-    void reset() {
-
-        StatefulRedisConnection<String, String> connection = client.connect();
-        RedisAsyncCommands<String, String> async = connection.async();
-
-        connection.sync().set(key, value);
-        async.reset();
-        connection.sync().set(key, value);
-        connection.sync().flushall();
-
-        RedisFuture<KeyValue<String, String>> eval = async.blpop(5, key);
-
-        Delay.delay(Duration.ofMillis(500));
-
-        assertThat(eval.isDone()).isFalse();
-        assertThat(eval.isCancelled()).isFalse();
-
-        async.reset();
-
-        Wait.untilTrue(eval::isCancelled).waitOrTimeout();
-
-        assertThat(eval.isCancelled()).isTrue();
-        assertThat(eval.isDone()).isTrue();
-
-        connection.close();
-    }
-
-    @Test
     void standaloneConnectionShouldSetClientName() {
 
         RedisURI redisURI = RedisURI.create(host, port);

--- a/src/test/java/io/lettuce/core/cluster/ClusterCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/ClusterCommandIntegrationTests.java
@@ -151,25 +151,6 @@ class ClusterCommandIntegrationTests extends TestSupport {
     }
 
     @Test
-    void testReset() {
-
-        clusterClient.reloadPartitions();
-
-        StatefulRedisClusterConnection<String, String> clusterConnection = clusterClient.connect();
-
-        TestFutures.awaitOrTimeout(clusterConnection.async().set("a", "myValue1"));
-
-        clusterConnection.reset();
-
-        RedisFuture<String> setA = clusterConnection.async().set("a", "myValue1");
-
-        assertThat(TestFutures.getOrTimeout(setA)).isEqualTo("OK");
-        assertThat(setA.getError()).isNull();
-
-        connection.close();
-    }
-
-    @Test
     void testClusterSlots() {
 
         List<Object> reply = sync.clusterSlots();

--- a/src/test/java/io/lettuce/core/cluster/RedisClusterClientIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisClusterClientIntegrationTests.java
@@ -262,19 +262,6 @@ class RedisClusterClientIntegrationTests extends TestSupport {
     }
 
     @Test
-    void testReset() {
-
-        clusterClient.reloadPartitions();
-        StatefulRedisClusterConnection<String, String> connection = clusterClient.connect();
-
-        connection.sync().set(ClusterTestSettings.KEY_A, value);
-        connection.reset();
-
-        assertThat(connection.sync().set(ClusterTestSettings.KEY_A, value)).isEqualTo("OK");
-        connection.close();
-    }
-
-    @Test
     @SuppressWarnings({ "rawtypes" })
     void testClusterCommandRedirection() {
 


### PR DESCRIPTION
## Overview

This PR completes the removal of the unsafe `reset()` method from Lettuce, finalizing deprecations from versions 5.2 and 6.2. The change addresses [#3328](https://github.com/redis/lettuce/issues/3328) and [#907](https://github.com/redis/lettuce/issues/907).

## Summary of Changes

* Eliminated the `reset()` method from the API and implementation.
* Removed related documentation and deprecation markers.

## Impact

* **Breaking Change**: Code referencing `reset()` will fail to compile.