### PR TITLE
[hitless upgrade] Support for none moving-endpoint-type in maintenance event notifications (CAE-1285)

### DIFF
--- a/src/main/java/io/lettuce/core/MaintenanceEventsOptions.java
+++ b/src/main/java/io/lettuce/core/MaintenanceEventsOptions.java
@@ -192,7 +192,13 @@ public class MaintenanceEventsOptions {
         /** External IP address (for public network connections) */
         EXTERNAL_IP,
         /** External fully qualified domain name (for public network connections with TLS) */
-        EXTERNAL_FQDN
+        EXTERNAL_FQDN,
+        /**
+         * none indicates that the MOVING message doesn’t need to contain an endpoint. In such a case, the client is expected to
+         * schedule a graceful reconnect to its currently configured endpoint after half of the grace period that was
+         * communicated by the server is over.
+         */
+        NONE
     }
 
     private static class FixedAddressTypeSource extends MaintenanceEventsOptions.AddressTypeSource {

--- a/src/main/java/io/lettuce/core/RedisHandshake.java
+++ b/src/main/java/io/lettuce/core/RedisHandshake.java
@@ -308,6 +308,8 @@ class RedisHandshake implements ConnectionInitializer {
                 return "external-ip";
             case EXTERNAL_FQDN:
                 return "external-fqdn";
+            case NONE:
+                return "none";
             default:
                 throw new IllegalArgumentException("Unknown moving endpoint address type:" + addressType);
         }

--- a/src/main/java/io/lettuce/core/protocol/MaintenanceAwareConnectionWatchdog.java
+++ b/src/main/java/io/lettuce/core/protocol/MaintenanceAwareConnectionWatchdog.java
@@ -260,8 +260,7 @@ public class MaintenanceAwareConnectionWatchdog extends ConnectionWatchdog imple
 
                 InetSocketAddress endpoint = null;
                 if (addressBuffer != null) {
-                    String addressAndPort = StringCodec.UTF8.decodeKey((ByteBuffer) addressBuffer);
-                    InetSocketAddress addr = null;
+                    String addressAndPort = StringCodec.UTF8.decodeKey(addressBuffer);
 
                     // Handle "none" option where endpoint is null
                     if (addressAndPort != null && !"null".equals(addressAndPort)) {

--- a/src/main/java/io/lettuce/core/protocol/MaintenanceAwareConnectionWatchdog.java
+++ b/src/main/java/io/lettuce/core/protocol/MaintenanceAwareConnectionWatchdog.java
@@ -370,7 +370,7 @@ public class MaintenanceAwareConnectionWatchdog extends ConnectionWatchdog imple
         public Mono<SocketAddress> wrappedSupplier(Mono<SocketAddress> original) {
             return Mono.defer(() -> {
                 State current = state.get();
-                if (current != null && clock.instant().isBefore(current.cutoff)) {
+                if (current != null && current.rebindAddress != null && clock.instant().isBefore(current.cutoff)) {
                     return Mono.just(current.rebindAddress);
                 } else {
                     state.compareAndSet(current, null);

--- a/src/test/java/io/lettuce/core/protocol/MaintenanceAwareConnectionWatchdogUnitTests.java
+++ b/src/test/java/io/lettuce/core/protocol/MaintenanceAwareConnectionWatchdogUnitTests.java
@@ -9,7 +9,6 @@ package io.lettuce.core.protocol;
 import static io.lettuce.TestTags.UNIT_TEST;
 import static io.lettuce.test.ReflectionTestUtils.getField;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static io.lettuce.test.ReflectionTestUtils.setField;
 

--- a/src/test/java/io/lettuce/core/protocol/MaintenanceAwareConnectionWatchdogUnitTests.java
+++ b/src/test/java/io/lettuce/core/protocol/MaintenanceAwareConnectionWatchdogUnitTests.java
@@ -9,6 +9,7 @@ package io.lettuce.core.protocol;
 import static io.lettuce.TestTags.UNIT_TEST;
 import static io.lettuce.test.ReflectionTestUtils.getField;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static io.lettuce.test.ReflectionTestUtils.setField;
 
@@ -27,10 +28,14 @@ import io.netty.channel.*;
 import io.netty.util.Attribute;
 import io.netty.util.Timer;
 import io.netty.util.concurrent.EventExecutorGroup;
+import io.netty.channel.embedded.EmbeddedChannel;
+
+import io.netty.util.concurrent.ScheduledFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -50,7 +55,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Unit tests for {@link MaintenanceAwareConnectionWatchdog}.
@@ -97,6 +102,9 @@ class MaintenanceAwareConnectionWatchdogUnitTests {
 
     @Mock
     private ChannelPipeline pipeline;
+
+    @Mock
+    private EventLoop eventLoop;
 
     @Mock
     private CommandHandler commandHandler;
@@ -245,71 +253,6 @@ class MaintenanceAwareConnectionWatchdogUnitTests {
         verify(channel).close();
         verify(rebindAttribute).set(RebindState.COMPLETED);
         verify(component1, never()).onRebindStarted(any(), any()); // Not called when stack is empty
-    }
-
-    /**
-     * MOVING <seq_number> <time> <endpoint>: A specific endpoint is going to move to another node within <time> seconds
-     *
-     * @param seqNumber unique sequence number, can be use to match requests handled by different connections
-     * @param time estimated operation completion time
-     * @param addressAndPort address and port of the new endpoint
-     * @return
-     */
-    private static List<Object> movingPushContent(long seqNumber, long time, String addressAndPort) {
-        ByteBuffer addressBuffer = StringCodec.UTF8.encodeKey(addressAndPort);
-        return Arrays.asList("MOVING", seqNumber, time, addressBuffer);
-    }
-
-    /**
-     * MIGRATING <seq_number> <time> <shard_id-s>: A shard migration is going to start within <time> seconds.
-     *
-     * @param seqNumber unique sequence number, can be use to match requests handled by different connections
-     * @param time operation will start after <time> seconds
-     * @param shards comma-separated list of shard IDs
-     * @return
-     */
-    private static List<Object> migratingPushContent(long seqNumber, long time, String shards) {
-        ByteBuffer shardsBuffer = StringCodec.UTF8.encodeKey(shards);
-        return Arrays.asList("MIGRATING", seqNumber, time, shardsBuffer);
-    }
-
-    /**
-     * MIGRATED <seq_number> <shard_id-s>: A shard migration ended.
-     *
-     * @param seqNumber unique sequence number, can be use to match requests handled by different connections
-     * @param time
-     * @param shards address and port of the new endpoint
-     * @return
-     */
-    private static List<Object> migratedPushContent(long seqNumber, String shards) {
-        ByteBuffer shardsBuffer = StringCodec.UTF8.encodeKey(shards);
-        return Arrays.asList("MIGRATED", seqNumber, shardsBuffer);
-    }
-
-    /**
-     * MIGRATING <seq_number> <time> <shard_id-s>: A shard migration is going to start within <time> seconds.
-     *
-     * @param seqNumber unique sequence number, can be use to match requests handled by different connections
-     * @param time operation will start after <time> seconds
-     * @param shards comma-separated list of shard IDs
-     * @return
-     */
-    private static List<Object> failingoverPushContent(long seqNumber, long time, String shards) {
-        ByteBuffer shardsBuffer = StringCodec.UTF8.encodeKey(shards);
-        return Arrays.asList("FAILING_OVER", seqNumber, time, shardsBuffer);
-    }
-
-    /**
-     * MIGRATED <seq_number> <shard_id-s>: A shard migration ended.
-     *
-     * @param seqNumber unique sequence number, can be use to match requests handled by different connections
-     * @param time
-     * @param addressAndPort address and port of the new endpoint
-     * @return
-     */
-    private static List<Object> failedoverPushContent(long seqNumber, String shards) {
-        ByteBuffer shardsBuffer = StringCodec.UTF8.encodeKey(shards);
-        return Arrays.asList("FAILED_OVER", seqNumber, shardsBuffer);
     }
 
     @Test
@@ -633,6 +576,120 @@ class MaintenanceAwareConnectionWatchdogUnitTests {
 
         // Then - should return original address
         StepVerifier.create(wrappedSupplier).expectNext(originalAddress).verifyComplete();
+    }
+
+    @Test
+    void testMovingEventWithNullEndpoint() {
+        // Given
+        List<Object> content = movingPushContent(123L, 30L, null);
+
+        when(pushMessage.getType()).thenReturn("MOVING");
+        when(pushMessage.getContent()).thenReturn(content);
+        when(channel.attr(MaintenanceAwareConnectionWatchdog.REBIND_ATTRIBUTE)).thenReturn(rebindAttribute);
+        when(channel.pipeline()).thenReturn(pipeline);
+        when(pipeline.get(CommandHandler.class)).thenReturn(commandHandler);
+        when(commandHandler.getStack()).thenReturn(commandStack);
+        when(commandStack.isEmpty()).thenReturn(false);
+
+        EventLoop eventLoop = mock(EventLoop.class);
+        ScheduledFuture<?> future = mock(ScheduledFuture.class);
+        when(channel.eventLoop()).thenReturn(eventLoop);
+
+        // Capture arguments passed to schedule(...)
+        ArgumentCaptor<Long> delayCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<TimeUnit> unitCaptor = ArgumentCaptor.forClass(TimeUnit.class);
+        ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+
+        when(eventLoop.schedule(taskCaptor.capture(), delayCaptor.capture(), unitCaptor.capture()))
+                .thenAnswer(invocation -> {
+                    // For test, execute immediately
+                    taskCaptor.getValue().run();
+                    return future;
+                });
+
+        // Set up channel field using ReflectionTestUtils
+        setField(watchdog, "channel", channel);
+
+        watchdog.setMaintenanceEventListener(component1);
+
+        // When
+        watchdog.onPushMessage(pushMessage);
+
+        // Then
+        verify(eventLoop).schedule(any(Runnable.class), anyLong(), any());
+        assertThat(delayCaptor.getValue()).isEqualTo(15000L); // expected delay
+        assertThat(unitCaptor.getValue()).isEqualTo(TimeUnit.MILLISECONDS);
+        verify(rebindAttribute).set(RebindState.STARTED);
+        verify(channel, never()).close();
+        verify(component1).onRebindStarted(any(), any()); // Called when stack is not empty
+    }
+
+    /**
+     * MOVING <seq_number> <time> <endpoint>: A specific endpoint is going to move to another node within <time> seconds
+     *
+     * @param seqNumber unique sequence number, can be use to match requests handled by different connections
+     * @param time estimated operation completion time
+     * @param addressAndPort address and port of the new endpoint
+     * @return
+     */
+    private static List<Object> movingPushContent(long seqNumber, long time, String addressAndPort) {
+        if (addressAndPort == null) {
+            return Arrays.asList("MOVING", seqNumber, time, null);
+        } else {
+            return Arrays.asList("MOVING", seqNumber, time, StringCodec.UTF8.encodeKey(addressAndPort));
+        }
+    }
+
+    /**
+     * MIGRATING <seq_number> <time> <shard_id-s>: A shard migration is going to start within <time> seconds.
+     *
+     * @param seqNumber unique sequence number, can be use to match requests handled by different connections
+     * @param time operation will start after <time> seconds
+     * @param shards comma-separated list of shard IDs
+     * @return
+     */
+    private static List<Object> migratingPushContent(long seqNumber, long time, String shards) {
+        ByteBuffer shardsBuffer = StringCodec.UTF8.encodeKey(shards);
+        return Arrays.asList("MIGRATING", seqNumber, time, shardsBuffer);
+    }
+
+    /**
+     * MIGRATED <seq_number> <shard_id-s>: A shard migration ended.
+     *
+     * @param seqNumber unique sequence number, can be use to match requests handled by different connections
+     * @param time
+     * @param shards address and port of the new endpoint
+     * @return
+     */
+    private static List<Object> migratedPushContent(long seqNumber, String shards) {
+        ByteBuffer shardsBuffer = StringCodec.UTF8.encodeKey(shards);
+        return Arrays.asList("MIGRATED", seqNumber, shardsBuffer);
+    }
+
+    /**
+     * MIGRATING <seq_number> <time> <shard_id-s>: A shard migration is going to start within <time> seconds.
+     *
+     * @param seqNumber unique sequence number, can be use to match requests handled by different connections
+     * @param time operation will start after <time> seconds
+     * @param shards comma-separated list of shard IDs
+     * @return
+     */
+    private static List<Object> failingoverPushContent(long seqNumber, long time, String shards) {
+        ByteBuffer shardsBuffer = StringCodec.UTF8.encodeKey(shards);
+        return Arrays.asList("FAILING_OVER", seqNumber, time, shardsBuffer);
+    }
+
+    /**
+     * MIGRATED <seq_number> <shard_id-s>: A shard migration ended.
+     *
+     * @param seqNumber unique sequence number, can be use to match requests handled by different connections
+     * @param time
+     * @param addressAndPort address and port of the new endpoint
+     * @return
+     */
+    private static List<Object> failedoverPushContent(long seqNumber, String shards) {
+        ByteBuffer shardsBuffer = StringCodec.UTF8.encodeKey(shards);
+        return Arrays.asList("FAILED_OVER", seqNumber, shardsBuffer);
     }
 
 }

--- a/src/test/java/io/lettuce/core/protocol/MaintenanceAwareConnectionWatchdogUnitTests.java
+++ b/src/test/java/io/lettuce/core/protocol/MaintenanceAwareConnectionWatchdogUnitTests.java
@@ -600,12 +600,11 @@ class MaintenanceAwareConnectionWatchdogUnitTests {
         ArgumentCaptor<TimeUnit> unitCaptor = ArgumentCaptor.forClass(TimeUnit.class);
         ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
 
-        when(eventLoop.schedule(taskCaptor.capture(), delayCaptor.capture(), unitCaptor.capture()))
-                .thenAnswer(invocation -> {
-                    // For test, execute immediately
-                    taskCaptor.getValue().run();
-                    return future;
-                });
+        when(eventLoop.schedule(taskCaptor.capture(), delayCaptor.capture(), unitCaptor.capture())).thenAnswer(invocation -> {
+            // For test, execute immediately
+            taskCaptor.getValue().run();
+            return future;
+        });
 
         // Set up channel field using ReflectionTestUtils
         setField(watchdog, "channel", channel);


### PR DESCRIPTION
### Description:
This change extends Lettuce’s support for Redis **maintenance event notifications** by adding the none option for `moving-endpoint-type` when enabling maintenance events.

According to the specification, `moving-endpoint-type` determines whether the `MOVING` push message contains an internal/external IP or FQDN.
The new special value none indicates that the `MOVING` message should not contain any endpoint; instead, the endpoint field is null.

When the client receives a MOVING message with moving-endpoint-type=none, it will schedule a **graceful reconnect** to the currently configured endpoint after half of the grace period specified in the message has elapsed.

### Summary of changes:
- 	Added support for moving-endpoint-type=none option in CLIENT MAINT_NOTIFICATIONS.
- 	Implemented delayed rebind behavior: reconnect is scheduled after half of the grace period when none is used.

### Example to enable maintenance notifications with none
`CLIENT MAINT_NOTIFICATIONS ON moving-endpoint-type none`

Tested manually & unit test
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
