### PR TITLE
Fix sharded pubsub auto-resubscription after Redis cluster rebalancing

### DIFF
--- a/src/main/java/io/lettuce/core/pubsub/RedisPubSubAsyncCommandsImpl.java
+++ b/src/main/java/io/lettuce/core/pubsub/RedisPubSubAsyncCommandsImpl.java
@@ -114,6 +114,14 @@ public class RedisPubSubAsyncCommandsImpl<K, V> extends RedisAsyncCommandsImpl<K
     @Override
     @SuppressWarnings("unchecked")
     public RedisFuture<Void> sunsubscribe(K... channels) {
+        // Mark these channels as intentionally unsubscribed to prevent auto-resubscription
+        StatefulRedisPubSubConnection<K, V> connection = getStatefulConnection();
+        if (connection instanceof StatefulRedisPubSubConnectionImpl) {
+            StatefulRedisPubSubConnectionImpl<K, V> impl = (StatefulRedisPubSubConnectionImpl<K, V>) connection;
+            for (K channel : channels) {
+                impl.markIntentionalUnsubscribe(channel);
+            }
+        }
         return (RedisFuture<Void>) dispatch(commandBuilder.sunsubscribe(channels));
     }
 

--- a/src/main/java/io/lettuce/core/pubsub/RedisPubSubReactiveCommandsImpl.java
+++ b/src/main/java/io/lettuce/core/pubsub/RedisPubSubReactiveCommandsImpl.java
@@ -171,6 +171,14 @@ public class RedisPubSubReactiveCommandsImpl<K, V> extends RedisReactiveCommands
 
     @Override
     public Mono<Void> sunsubscribe(K... shardChannels) {
+        // Mark these channels as intentionally unsubscribed to prevent auto-resubscription
+        StatefulRedisPubSubConnection<K, V> connection = getStatefulConnection();
+        if (connection instanceof StatefulRedisPubSubConnectionImpl) {
+            StatefulRedisPubSubConnectionImpl<K, V> impl = (StatefulRedisPubSubConnectionImpl<K, V>) connection;
+            for (K channel : shardChannels) {
+                impl.markIntentionalUnsubscribe(channel);
+            }
+        }
         return createFlux(() -> commandBuilder.sunsubscribe(shardChannels)).then();
     }
 

--- a/src/test/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnectionImplUnitTests.java
+++ b/src/test/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnectionImplUnitTests.java
@@ -14,8 +14,16 @@ import org.junit.jupiter.api.Test;
 import static io.lettuce.TestTags.UNIT_TEST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
+import io.lettuce.core.protocol.AsyncCommand;
+import io.lettuce.core.pubsub.api.async.RedisPubSubAsyncCommands;
+import io.lettuce.core.pubsub.PubSubOutput;
+import io.lettuce.core.pubsub.RedisPubSubAdapter;
+
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -120,6 +128,94 @@ class StatefulRedisPubSubConnectionImplUnitTests {
         assertInstanceOf(AsyncCommand.class, subscriptions.get(0));
         assertInstanceOf(AsyncCommand.class, subscriptions.get(1));
         assertInstanceOf(AsyncCommand.class, subscriptions.get(1));
+    }
+
+    @Test
+    void autoResubscribeListenerIsRegistered() {
+        // Verify that the connection has the markIntentionalUnsubscribe method
+        // This confirms the auto-resubscribe functionality is available
+        connection.markIntentionalUnsubscribe("test-channel");
+        // If no exception is thrown, the method exists and works
+        assertTrue(true);
+    }
+
+    @Test
+    void intentionalUnsubscribeBypassesAutoResubscribe() throws Exception {
+        // Test 1: Intentional unsubscribe should NOT trigger auto-resubscribe
+
+        // Create a mock async commands to verify ssubscribe is NOT called
+        RedisPubSubAsyncCommands<String, String> mockAsync = mock(RedisPubSubAsyncCommands.class);
+        StatefulRedisPubSubConnectionImpl<String, String> spyConnection = spy(connection);
+        when(spyConnection.async()).thenReturn(mockAsync);
+
+        // Mark the channel as intentionally unsubscribed
+        spyConnection.markIntentionalUnsubscribe("test-channel");
+
+        // Use reflection to access the private endpoint and trigger sunsubscribed event
+        PubSubEndpoint<String, String> endpoint = getEndpointViaReflection(spyConnection);
+        PubSubOutput<String, String> sunsubscribeMessage = createSunsubscribeMessage("test-channel", codec);
+        endpoint.notifyMessage(sunsubscribeMessage);
+
+        // Wait a moment for any async processing
+        Thread.sleep(50);
+
+        // Verify that ssubscribe was NOT called (intentional unsubscribe bypassed auto-resubscribe)
+        verify(mockAsync, never()).ssubscribe("test-channel");
+    }
+
+    @Test
+    void unintentionalUnsubscribeTriggersAutoResubscribe() throws Exception {
+        // Test 2: Unintentional unsubscribe (from Redis) should trigger auto-resubscribe
+
+        // Create a fresh connection with a mock async
+        PubSubEndpoint<String, String> mockEndpoint = mock(PubSubEndpoint.class);
+        StatefulRedisPubSubConnectionImpl<String, String> testConnection = new StatefulRedisPubSubConnectionImpl<>(mockEndpoint,
+                mockedWriter, codec, timeout);
+
+        // Create a mock async commands to verify ssubscribe IS called
+        RedisPubSubAsyncCommands<String, String> mockAsync = mock(RedisPubSubAsyncCommands.class);
+        @SuppressWarnings("unchecked")
+        RedisFuture<Void> mockFuture = mock(RedisFuture.class);
+        when(mockAsync.ssubscribe("test-channel")).thenReturn(mockFuture);
+
+        StatefulRedisPubSubConnectionImpl<String, String> spyConnection = spy(testConnection);
+        when(spyConnection.async()).thenReturn(mockAsync);
+
+        // Get the auto-resubscribe listener directly and trigger it
+        RedisPubSubListener<String, String> autoResubscribeListener = getAutoResubscribeListener(spyConnection);
+
+        // Do NOT mark as intentional - simulate Redis server sunsubscribe during slot movement
+        autoResubscribeListener.sunsubscribed("test-channel", 0);
+
+        // Wait a moment for async processing
+        Thread.sleep(50);
+
+        // Verify that ssubscribe WAS called (auto-resubscribe triggered)
+        verify(mockAsync, times(1)).ssubscribe("test-channel");
+    }
+
+    @SuppressWarnings("unchecked")
+    private PubSubEndpoint<String, String> getEndpointViaReflection(
+            StatefulRedisPubSubConnectionImpl<String, String> connection) throws Exception {
+        Field endpointField = StatefulRedisPubSubConnectionImpl.class.getDeclaredField("endpoint");
+        endpointField.setAccessible(true);
+        return (PubSubEndpoint<String, String>) endpointField.get(connection);
+    }
+
+    @SuppressWarnings("unchecked")
+    private RedisPubSubListener<String, String> getAutoResubscribeListener(
+            StatefulRedisPubSubConnectionImpl<String, String> connection) throws Exception {
+        Field listenerField = StatefulRedisPubSubConnectionImpl.class.getDeclaredField("autoResubscribeListener");
+        listenerField.setAccessible(true);
+        return (RedisPubSubListener<String, String>) listenerField.get(connection);
+    }
+
+    private PubSubOutput<String, String> createSunsubscribeMessage(String channel, RedisCodec<String, String> codec) {
+        PubSubOutput<String, String> output = new PubSubOutput<>(codec);
+        output.set(ByteBuffer.wrap("sunsubscribe".getBytes()));
+        output.set(ByteBuffer.wrap(channel.getBytes()));
+        output.set(0L); // count
+        return output;
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.


### Summary
Fixes missing auto-resubscription for Sharded Pub/Sub after Redis cluster rebalancing.

### Issues
 - No resubscribe mechanism on slot movement (https://github.com/redis/lettuce/issues/3213)

### Fixes
 - Introduced ShardedPubSubAutoResubscribeListener for automatic resubscribe
 - Tracked intentional unsubscribes in async/reactive sunsubscribe
 - Leveraged existing cluster redirection for reconnection

### Result
Sharded Pub/Sub subscriptions now automatically resubscribe on slot rebalancing while preserving intentional client unsubscribe behavior.

 <!--
Great! Live long and prosper.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sharded Pub/Sub unsubscribe/resubscribe behavior by automatically issuing `SSUBSCRIBE` on `SUNSUBSCRIBED` events, which could cause unexpected resubscriptions or extra traffic if edge cases are missed. Added tracking for intentional `sunsubscribe` to reduce behavioral regressions, but it still touches connection-level event handling.
> 
> **Overview**
> Fixes sharded Pub/Sub behavior after Redis Cluster slot rebalancing by adding an internal `SUNSUBSCRIBED` listener in `StatefulRedisPubSubConnectionImpl` that triggers an `SSUBSCRIBE` to force cluster redirection and re-establish the subscription.
> 
> To avoid undoing user intent, `RedisPubSubAsyncCommandsImpl.sunsubscribe` and `RedisPubSubReactiveCommandsImpl.sunsubscribe` now mark channels as *intentionally unsubscribed*, and the internal listener skips auto-resubscribe for those channels. Adds unit and integration tests covering both auto-resubscribe triggering and the intentional-unsubscribe bypass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e45757c7034792bb0d37698841c4ba92aca6392c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->