### PR TITLE
CAE-534 - RediSearch: Sticky Cursor in Cluster (Stage 1)

### DIFF
--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -1713,17 +1713,26 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
     }
 
     @Override
-    public RedisFuture<AggregationReply<K, V>> ftCursorread(K index, long cursorId, int count) {
-        return dispatch(searchCommandBuilder.ftCursorread(index, cursorId, count));
+    public RedisFuture<AggregationReply<K, V>> ftCursorread(K index, AggregationReply<K, V> aggregateReply, int count) {
+        if (aggregateReply == null)
+            throw new IllegalArgumentException("aggregateReply must not be null");
+        return dispatch(searchCommandBuilder.ftCursorread(index, aggregateReply.getCursorId(), count));
     }
 
     @Override
-    public RedisFuture<AggregationReply<K, V>> ftCursorread(K index, long cursorId) {
-        return dispatch(searchCommandBuilder.ftCursorread(index, cursorId, -1));
+    public RedisFuture<AggregationReply<K, V>> ftCursorread(K index, AggregationReply<K, V> aggregateReply) {
+        return ftCursorread(index, aggregateReply, -1);
     }
 
     @Override
-    public RedisFuture<String> ftCursordel(K index, long cursorId) {
+    public RedisFuture<String> ftCursordel(K index, AggregationReply<K, V> aggregateReply) {
+        if (aggregateReply == null)
+            throw new IllegalArgumentException("aggregateReply must not be null");
+        long cursorId = aggregateReply.getCursorId();
+        if (cursorId <= 0) {
+            // idempotent OK for non-existent/finished cursor
+            return dispatch(searchCommandBuilder.ftCursordel(index, 0));
+        }
         return dispatch(searchCommandBuilder.ftCursordel(index, cursorId));
     }
 

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -1748,8 +1748,13 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
-    public Mono<String> ftCursordel(K index, long cursorId) {
-        return createMono(() -> searchCommandBuilder.ftCursordel(index, cursorId));
+    public Mono<String> ftCursordel(K index, AggregationReply<K, V> aggregateReply) {
+        return createMono(() -> {
+            if (aggregateReply == null)
+                throw new IllegalArgumentException("aggregateReply must not be null");
+            long cursorId = aggregateReply.getCursorId();
+            return searchCommandBuilder.ftCursordel(index, cursorId > 0 ? cursorId : 0);
+        });
     }
 
     @Override
@@ -1783,13 +1788,18 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
-    public Mono<AggregationReply<K, V>> ftCursorread(K index, long cursorId, int count) {
-        return createMono(() -> searchCommandBuilder.ftCursorread(index, cursorId, count));
+    public Mono<AggregationReply<K, V>> ftCursorread(K index, AggregationReply<K, V> aggregateReply, int count) {
+        return createMono(() -> {
+            if (aggregateReply == null)
+                throw new IllegalArgumentException("aggregateReply must not be null");
+            long cursorId = aggregateReply.getCursorId();
+            return searchCommandBuilder.ftCursorread(index, cursorId > 0 ? cursorId : 0, count);
+        });
     }
 
     @Override
-    public Mono<AggregationReply<K, V>> ftCursorread(K index, long cursorId) {
-        return createMono(() -> searchCommandBuilder.ftCursorread(index, cursorId, -1));
+    public Mono<AggregationReply<K, V>> ftCursorread(K index, AggregationReply<K, V> aggregateReply) {
+        return ftCursorread(index, aggregateReply, -1);
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/api/async/RediSearchAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RediSearchAsyncCommands.java
@@ -1157,7 +1157,7 @@ public interface RediSearchAsyncCommands<K, V> {
      * @see #ftAggregate(Object, Object, AggregateArgs)
      */
     @Experimental
-    RedisFuture<AggregationReply<K, V>> ftCursorread(K index, long cursorId, int count);
+    RedisFuture<AggregationReply<K, V>> ftCursorread(K index, AggregationReply<K, V> aggregateReply, int count);
 
     /**
      * Read next results from an existing cursor using the default batch size.
@@ -1190,7 +1190,7 @@ public interface RediSearchAsyncCommands<K, V> {
      * @see #ftAggregate(Object, Object, AggregateArgs)
      */
     @Experimental
-    RedisFuture<AggregationReply<K, V>> ftCursorread(K index, long cursorId);
+    RedisFuture<AggregationReply<K, V>> ftCursorread(K index, AggregationReply<K, V> aggregateReply);
 
     /**
      * Delete a cursor and free its associated resources.
@@ -1229,6 +1229,6 @@ public interface RediSearchAsyncCommands<K, V> {
      * @see #ftCursorread(Object, long, int)
      */
     @Experimental
-    RedisFuture<String> ftCursordel(K index, long cursorId);
+    RedisFuture<String> ftCursordel(K index, AggregationReply<K, V> aggregateReply);
 
 }

--- a/src/main/java/io/lettuce/core/api/reactive/RediSearchReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RediSearchReactiveCommands.java
@@ -1159,7 +1159,7 @@ public interface RediSearchReactiveCommands<K, V> {
      * @see #ftAggregate(Object, Object, AggregateArgs)
      */
     @Experimental
-    Mono<AggregationReply<K, V>> ftCursorread(K index, long cursorId, int count);
+    Mono<AggregationReply<K, V>> ftCursorread(K index, AggregationReply<K, V> aggregateReply, int count);
 
     /**
      * Read next results from an existing cursor using the default batch size.
@@ -1192,7 +1192,7 @@ public interface RediSearchReactiveCommands<K, V> {
      * @see #ftAggregate(Object, Object, AggregateArgs)
      */
     @Experimental
-    Mono<AggregationReply<K, V>> ftCursorread(K index, long cursorId);
+    Mono<AggregationReply<K, V>> ftCursorread(K index, AggregationReply<K, V> aggregateReply);
 
     /**
      * Delete a cursor and free its associated resources.
@@ -1231,6 +1231,6 @@ public interface RediSearchReactiveCommands<K, V> {
      * @see #ftCursorread(Object, long, int)
      */
     @Experimental
-    Mono<String> ftCursordel(K index, long cursorId);
+    Mono<String> ftCursordel(K index, AggregationReply<K, V> aggregateReply);
 
 }

--- a/src/main/java/io/lettuce/core/api/sync/RediSearchCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RediSearchCommands.java
@@ -1157,7 +1157,7 @@ public interface RediSearchCommands<K, V> {
      * @see #ftAggregate(Object, Object, AggregateArgs)
      */
     @Experimental
-    AggregationReply<K, V> ftCursorread(K index, long cursorId, int count);
+    AggregationReply<K, V> ftCursorread(K index, AggregationReply<K, V> aggregateReply, int count);
 
     /**
      * Read next results from an existing cursor using the default batch size.
@@ -1190,7 +1190,7 @@ public interface RediSearchCommands<K, V> {
      * @see #ftAggregate(Object, Object, AggregateArgs)
      */
     @Experimental
-    AggregationReply<K, V> ftCursorread(K index, long cursorId);
+    AggregationReply<K, V> ftCursorread(K index, AggregationReply<K, V> aggregateReply);
 
     /**
      * Delete a cursor and free its associated resources.
@@ -1229,6 +1229,6 @@ public interface RediSearchCommands<K, V> {
      * @see #ftCursorread(Object, long, int)
      */
     @Experimental
-    String ftCursordel(K index, long cursorId);
+    String ftCursordel(K index, AggregationReply<K, V> aggregateReply);
 
 }

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RediSearchCoroutinesCommands.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RediSearchCoroutinesCommands.kt
@@ -1158,7 +1158,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @see #ftAggregate(Any, Any, AggregateArgs)
      */
     @Experimental
-    suspend fun ftCursorread(index: K, cursorId: Long, count: Int): AggregationReply<K, V>?
+    suspend fun ftCursorread(index: K, aggregateReply: AggregationReply<K, V>, count: Int): AggregationReply<K, V>?
 
     /**
      * Read next results from an existing cursor using the default batch size.
@@ -1191,7 +1191,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @see #ftAggregate(Any, Any, AggregateArgs)
      */
     @Experimental
-    suspend fun ftCursorread(index: K, cursorId: Long): AggregationReply<K, V>?
+    suspend fun ftCursorread(index: K, aggregateReply: AggregationReply<K, V>): AggregationReply<K, V>?
 
     /**
      * Delete a cursor and free its associated resources.
@@ -1230,7 +1230,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @see #ftCursorread(Any, long, Integer)
      */
     @Experimental
-    suspend fun ftCursordel(index: K, cursorId: Long): String?
+    suspend fun ftCursordel(index: K, aggregateReply: AggregationReply<K, V>): String?
 
 }
 

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RediSearchCoroutinesCommandsImpl.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RediSearchCoroutinesCommandsImpl.kt
@@ -80,14 +80,14 @@ open class RediSearchCoroutinesCommandsImpl<K : Any, V : Any>(internal val ops: 
     override suspend fun ftAggregate(index: K, query: V): AggregationReply<K, V>? =
         ops.ftAggregate(index, query).awaitFirstOrNull()
 
-    override suspend fun ftCursorread(index: K, cursorId: Long): AggregationReply<K, V>? =
-        ops.ftCursorread(index, cursorId).awaitFirstOrNull()
+    override suspend fun ftCursorread(index: K, aggregateReply: AggregationReply<K, V>): AggregationReply<K, V>? =
+        ops.ftCursorread(index, aggregateReply).awaitFirstOrNull()
 
-    override suspend fun ftCursorread(index: K, cursorId: Long, count: Int): AggregationReply<K, V>? =
-        ops.ftCursorread(index, cursorId, count).awaitFirstOrNull()
+    override suspend fun ftCursorread(index: K, aggregateReply: AggregationReply<K, V>, count: Int): AggregationReply<K, V>? =
+        ops.ftCursorread(index, aggregateReply, count).awaitFirstOrNull()
 
-    override suspend fun ftCursordel(index: K, cursorId: Long): String? {
-        return ops.ftCursordel(index, cursorId).awaitFirstOrNull()
+    override suspend fun ftCursordel(index: K, aggregateReply: AggregationReply<K, V>): String? {
+        return ops.ftCursordel(index, aggregateReply).awaitFirstOrNull()
     }
 
     override suspend fun ftDictadd(dict: K, vararg terms: V): Long? =

--- a/src/test/java/io/lettuce/core/cluster/RedisAdvancedClusterAggregateUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisAdvancedClusterAggregateUnitTests.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2025
+ */
+package io.lettuce.core.cluster;
+
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.models.partitions.Partitions;
+import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.protocol.ConnectionIntent;
+import io.lettuce.core.search.AggregationReply;
+import io.lettuce.core.search.arguments.AggregateArgs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for cluster-specific Aggregation cursor behavior: stamping nodeId and routing cursor calls.
+ */
+class RedisAdvancedClusterAggregateUnitTests {
+
+    private StatefulRedisClusterConnection<String, String> clusterConn;
+
+    private StatefulRedisConnection<String, String> nodeConn;
+
+    private RedisAdvancedClusterAsyncCommandsImpl<String, String> async;
+
+    @BeforeEach
+    void setup() {
+        clusterConn = mock(StatefulRedisClusterConnection.class);
+        nodeConn = mock(StatefulRedisConnection.class);
+
+        // Partitions with a single node that owns all slots
+        Partitions partitions = new Partitions();
+        RedisClusterNode node = new RedisClusterNode();
+        node.setNodeId("node-1");
+        node.setUri(io.lettuce.core.RedisURI.Builder.redis("127.0.0.1").withPort(6379).build());
+        List<Integer> allSlots = new ArrayList<>();
+        for (int i = 0; i < io.lettuce.core.cluster.SlotHash.SLOT_COUNT; i++)
+            allSlots.add(i);
+        node.setSlots(allSlots);
+        partitions.addPartition(node);
+        partitions.updateCache();
+
+        when(clusterConn.getPartitions()).thenReturn(partitions);
+        when(clusterConn.getConnection(eq("node-1"), eq(ConnectionIntent.WRITE))).thenReturn(nodeConn);
+
+        async = new RedisAdvancedClusterAsyncCommandsImpl<>(clusterConn, StringCodec.UTF8);
+    }
+
+    @Test
+    void ftAggregate_stampsNodeId_whenCursorCreated() {
+        AggregateArgs<String, String> args = AggregateArgs.<String, String> builder()
+                .withCursor(AggregateArgs.WithCursor.of(1L)).build();
+
+        AggregationReply<String, String> replyWithCursor = new AggregationReply<>();
+        AggregationReply.stampNodeId(replyWithCursor, null);
+        // set cursor id via reflection to avoid package-private setter
+        try {
+            java.lang.reflect.Method m = AggregationReply.class.getDeclaredMethod("setCursorId", long.class);
+            m.setAccessible(true);
+            m.invoke(replyWithCursor, 42L);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        CompletableFuture<AggregationReply<String, String>> cf = new CompletableFuture<>();
+        cf.complete(replyWithCursor);
+        io.lettuce.core.RedisFuture<AggregationReply<String, String>> nodeFuture = new io.lettuce.core.cluster.PipelinedRedisFuture<>(
+                cf);
+
+        io.lettuce.core.api.async.RedisAsyncCommands<String, String> nodeAsync = mock(
+                io.lettuce.core.api.async.RedisAsyncCommands.class);
+        when(nodeConn.async()).thenReturn(nodeAsync);
+        when(nodeAsync.ftAggregate(anyString(), anyString(), any())).thenReturn(nodeFuture);
+
+        AggregationReply<String, String> out = async.ftAggregate("idx", "*", args).toCompletableFuture().join();
+
+        assertThat(out.getCursorId()).isEqualTo(42L);
+        assertThat(out.getNodeId()).contains("node-1");
+    }
+
+    @Test
+    void ftCursordel_throwsWhenMissingNodeId() {
+        AggregationReply<String, String> withoutNode = new AggregationReply<>();
+        try {
+            java.lang.reflect.Method m = AggregationReply.class.getDeclaredMethod("setCursorId", long.class);
+            m.setAccessible(true);
+            m.invoke(withoutNode, 5L);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        CompletableFuture<String> cf = async.ftCursordel("idx", withoutNode).toCompletableFuture();
+
+        assertThatThrownBy(cf::join).hasCauseInstanceOf(IllegalArgumentException.class).hasMessageContaining("missing nodeId");
+    }
+
+}

--- a/src/test/java/io/lettuce/core/search/RediSearchAggregateIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/search/RediSearchAggregateIntegrationTests.java
@@ -1080,8 +1080,7 @@ class RediSearchAggregateIntegrationTests extends TestSupport {
         assertThat(searchReply.getResults()).hasSize(2); // Should return 2 results per page
 
         // Read next page from cursor
-        long cursorId = result.getCursorId();
-        AggregationReply<String, String> nextResult = redis.ftCursorread("cursor-basic-test-idx", cursorId);
+        AggregationReply<String, String> nextResult = redis.ftCursorread("cursor-basic-test-idx", result);
 
         assertThat(nextResult).isNotNull();
         assertThat(nextResult.getReplies()).hasSize(1); // Should have 1 SearchReply
@@ -1122,8 +1121,7 @@ class RediSearchAggregateIntegrationTests extends TestSupport {
         assertThat(searchReply.getResults()).hasSize(3); // Should return 3 results per page
 
         // Read next page with different count
-        long cursorId = result.getCursorId();
-        AggregationReply<String, String> nextResult = redis.ftCursorread("cursor-count-test-idx", cursorId, 5);
+        AggregationReply<String, String> nextResult = redis.ftCursorread("cursor-count-test-idx", result, 5);
 
         assertThat(nextResult).isNotNull();
         assertThat(nextResult.getReplies()).hasSize(1); // Should have 1 SearchReply
@@ -1132,8 +1130,7 @@ class RediSearchAggregateIntegrationTests extends TestSupport {
         assertThat(nextResult.getCursorId()).isNotEqualTo(0L); // Should still have more results
 
         // Read final page
-        cursorId = nextResult.getCursorId();
-        AggregationReply<String, String> finalResult = redis.ftCursorread("cursor-count-test-idx", cursorId);
+        AggregationReply<String, String> finalResult = redis.ftCursorread("cursor-count-test-idx", nextResult);
 
         assertThat(finalResult).isNotNull();
         assertThat(finalResult.getReplies()).hasSize(1); // Should have 1 SearchReply
@@ -1172,8 +1169,7 @@ class RediSearchAggregateIntegrationTests extends TestSupport {
         assertThat(searchReply.getResults()).hasSize(2);
 
         // Read from cursor should work within timeout
-        long cursorId = result.getCursorId();
-        AggregationReply<String, String> nextResult = redis.ftCursorread("cursor-maxidle-test-idx", cursorId);
+        AggregationReply<String, String> nextResult = redis.ftCursorread("cursor-maxidle-test-idx", result);
 
         assertThat(nextResult).isNotNull();
         assertThat(nextResult.getReplies()).hasSize(1); // Should have 1 SearchReply
@@ -1208,8 +1204,7 @@ class RediSearchAggregateIntegrationTests extends TestSupport {
         assertThat(result.getCursorId()).isNotEqualTo(0L);
 
         // Delete the cursor explicitly
-        long cursorId = result.getCursorId();
-        String deleteResult = redis.ftCursordel("cursor-delete-test-idx", cursorId);
+        String deleteResult = redis.ftCursordel("cursor-delete-test-idx", result);
 
         assertThat(deleteResult).isEqualTo("OK");
 
@@ -1246,16 +1241,15 @@ class RediSearchAggregateIntegrationTests extends TestSupport {
 
         // Collect all results by paginating through cursor
         List<SearchReply.SearchResult<String, String>> allResults = new ArrayList<>(searchReply.getResults());
-        long cursorId = result.getCursorId();
-
-        while (cursorId != 0L) {
-            AggregationReply<String, String> nextResult = redis.ftCursorread("cursor-pagination-test-idx", cursorId);
+        AggregationReply<String, String> current = result;
+        while (current.getCursorId() != 0L) {
+            AggregationReply<String, String> nextResult = redis.ftCursorread("cursor-pagination-test-idx", current);
             assertThat(nextResult).isNotNull();
             assertThat(nextResult.getReplies()).hasSize(1); // Should have 1 SearchReply
             SearchReply<String, String> nextSearchReply = nextResult.getReplies().get(0);
 
             allResults.addAll(nextSearchReply.getResults());
-            cursorId = nextResult.getCursorId();
+            current = nextResult;
         }
 
         // Verify we got all 15 results
@@ -1338,8 +1332,7 @@ class RediSearchAggregateIntegrationTests extends TestSupport {
         assertThat(firstGroup.getFields()).containsKey("avg_price");
 
         // Read next group from cursor
-        long cursorId = result.getCursorId();
-        AggregationReply<String, String> nextResult = redis.ftCursorread("cursor-complex-test-idx", cursorId);
+        AggregationReply<String, String> nextResult = redis.ftCursorread("cursor-complex-test-idx", result);
 
         assertThat(nextResult).isNotNull();
         assertThat(nextResult.getReplies()).hasSize(1); // Should have 1 SearchReply

--- a/src/test/java/io/lettuce/core/search/RediSearchClusterCursorIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/search/RediSearchClusterCursorIntegrationTests.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2025
+ */
+package io.lettuce.core.search;
+
+import io.lettuce.core.TestSupport;
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import javax.inject.Inject;
+import org.junit.jupiter.api.extension.ExtendWith;
+import io.lettuce.test.LettuceExtension;
+import io.lettuce.core.cluster.api.async.RedisAdvancedClusterAsyncCommands;
+import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
+import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
+import io.lettuce.core.search.arguments.AggregateArgs;
+import io.lettuce.core.search.arguments.CreateArgs;
+import io.lettuce.core.search.arguments.FieldArgs;
+import io.lettuce.core.search.arguments.NumericFieldArgs;
+import io.lettuce.core.search.arguments.TagFieldArgs;
+import io.lettuce.core.search.arguments.TextFieldArgs;
+import io.lettuce.test.condition.RedisConditions;
+import org.junit.jupiter.api.*;
+import reactor.test.StepVerifier;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.lettuce.TestTags.INTEGRATION_TEST;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Integration tests for RediSearch aggregation cursor functionality in cluster mode.
+ *
+ * Covers sync, async, and reactive APIs. Demonstrates correct nodeId stamping, cursor stickiness, error handling for missing
+ * nodeId, and the full cursor lifecycle (create → read → delete).
+ */
+@Tag(INTEGRATION_TEST)
+@ExtendWith(LettuceExtension.class)
+public class RediSearchClusterCursorIntegrationTests extends TestSupport {
+
+    private static final String INDEX = "books-cursor-cluster-idx";
+
+    private static final String PREFIX = "book:cursor:cluster:";
+
+    private final RedisClusterClient clusterClient;
+
+    private StatefulRedisClusterConnection<String, String> connection;
+
+    private RedisAdvancedClusterCommands<String, String> sync;
+
+    private RedisAdvancedClusterAsyncCommands<String, String> async;
+
+    private RedisAdvancedClusterReactiveCommands<String, String> reactive;
+
+    @Inject
+    RediSearchClusterCursorIntegrationTests(RedisClusterClient clusterClient) {
+        this.clusterClient = clusterClient;
+    }
+
+    @BeforeEach
+    void open() {
+        connection = clusterClient.connect();
+        sync = connection.sync();
+        async = connection.async();
+        reactive = connection.reactive();
+    }
+
+    @AfterEach
+    void close() {
+        if (connection != null)
+            connection.close();
+    }
+
+    @BeforeEach
+    void setUp() {
+        // Require Redis 8+ to match CI expectations for RediSearch behavior
+        assumeTrue(RedisConditions.of(sync).hasVersionGreaterOrEqualsTo("8.0"));
+        sync.flushall();
+
+        // Create schema
+        FieldArgs<String> title = TextFieldArgs.<String> builder().name("title").build();
+        FieldArgs<String> author = TagFieldArgs.<String> builder().name("author").build();
+        FieldArgs<String> year = NumericFieldArgs.<String> builder().name("year").sortable().build();
+        FieldArgs<String> rating = NumericFieldArgs.<String> builder().name("rating").sortable().build();
+
+        CreateArgs<String, String> createArgs = CreateArgs.<String, String> builder().withPrefix(PREFIX)
+                .on(CreateArgs.TargetType.HASH).build();
+
+        assertThat(sync.ftCreate(INDEX, createArgs, Arrays.asList(title, author, year, rating))).isEqualTo("OK");
+
+        // Insert data across slots
+        String[][] books = { { "Dune", "frank_herbert", "1965", "4.2" }, { "Lord of the Rings", "tolkien", "1954", "4.5" },
+                { "Sherlock Holmes", "doyle", "1887", "4.1" }, { "Pride and Prejudice", "austen", "1813", "4.0" },
+                { "Gone Girl", "flynn", "2012", "3.9" }, { "Steve Jobs", "isaacson", "2011", "4.3" },
+                { "Sapiens", "harari", "2011", "4.4" }, { "Cosmos", "sagan", "1980", "4.6" } };
+        for (int i = 0; i < books.length; i++) {
+            Map<String, String> doc = new HashMap<>();
+            doc.put("title", books[i][0]);
+            doc.put("author", books[i][1]);
+            doc.put("year", books[i][2]);
+            doc.put("rating", books[i][3]);
+            sync.hmset(PREFIX + i, doc);
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        try {
+            sync.ftDropindex(INDEX);
+        } catch (Exception ignore) {
+        }
+        sync.flushall();
+    }
+
+    @Test
+    void sync_cursorLifecycle_and_stickiness() {
+        AggregateArgs<String, String> args = AggregateArgs.<String, String> builder()
+                .groupBy(AggregateArgs.GroupBy.<String, String> of("author")
+                        .reduce(AggregateArgs.Reducer.<String, String> avg("@rating").as("avg_rating")))
+                .withCursor(AggregateArgs.WithCursor.of(2L)).build();
+
+        AggregationReply<String, String> first = sync.ftAggregate(INDEX, "*", args);
+        assertThat(first.getCursorId()).isGreaterThan(0);
+        assertThat(first.getNodeId()).isPresent();
+        assertThat(first.getReplies()).isNotEmpty();
+        String nodeId = first.getNodeId().get();
+
+        // Stickiness: reads route to the same node and pages advance
+        AggregationReply<String, String> page2 = sync.ftCursorread(INDEX, first);
+        assertThat(page2).isNotNull();
+        assertThat(page2.getNodeId()).isPresent();
+        assertThat(page2.getNodeId().get()).isEqualTo(nodeId);
+        assertThat(page2.getReplies()).isNotEmpty();
+        assertThat(page2.getReplies()).isNotEqualTo(first.getReplies());
+
+        AggregationReply<String, String> page3 = sync.ftCursorread(INDEX, page2);
+        assertThat(page3.getNodeId()).isPresent();
+        assertThat(page3.getNodeId().get()).isEqualTo(nodeId);
+        assertThat(page3.getReplies()).isNotEmpty();
+        assertThat(page3.getReplies()).isNotEqualTo(page2.getReplies());
+
+        // Delete cursor
+        String del = sync.ftCursordel(INDEX, page3);
+        assertThat(del).isEqualTo("OK");
+    }
+
+    @Test
+    void async_cursorLifecycle_and_stickiness() {
+        AggregateArgs<String, String> args = AggregateArgs.<String, String> builder()
+                .groupBy(AggregateArgs.GroupBy.<String, String> of("author")
+                        .reduce(AggregateArgs.Reducer.<String, String> avg("@rating").as("avg_rating")))
+                .withCursor(AggregateArgs.WithCursor.of(2L)).build();
+
+        AggregationReply<String, String> first = async.ftAggregate(INDEX, "*", args).toCompletableFuture().join();
+        assertThat(first.getCursorId()).isGreaterThan(0);
+        assertThat(first.getNodeId()).isPresent();
+        assertThat(first.getReplies()).isNotEmpty();
+        String nodeId = first.getNodeId().get();
+
+        AggregationReply<String, String> page2 = async.ftCursorread(INDEX, first).toCompletableFuture().join();
+        assertThat(page2.getNodeId()).isPresent();
+        assertThat(page2.getNodeId().get()).isEqualTo(nodeId);
+        assertThat(page2.getReplies()).isNotEmpty();
+        assertThat(page2.getReplies()).isNotEqualTo(first.getReplies());
+
+        AggregationReply<String, String> page3 = async.ftCursorread(INDEX, page2).toCompletableFuture().join();
+        assertThat(page3.getNodeId()).isPresent();
+        assertThat(page3.getNodeId().get()).isEqualTo(nodeId);
+        assertThat(page3.getReplies()).isNotEmpty();
+        assertThat(page3.getReplies()).isNotEqualTo(page2.getReplies());
+
+        String del = async.ftCursordel(INDEX, page3).toCompletableFuture().join();
+        assertThat(del).isEqualTo("OK");
+    }
+
+    @Test
+    void reactive_cursorLifecycle_and_stickiness() {
+        AggregateArgs<String, String> args = AggregateArgs.<String, String> builder()
+                .groupBy(AggregateArgs.GroupBy.<String, String> of("author")
+                        .reduce(AggregateArgs.Reducer.<String, String> avg("@rating").as("avg_rating")))
+                .withCursor(AggregateArgs.WithCursor.of(2L)).build();
+
+        AggregationReply<String, String> first = reactive.ftAggregate(INDEX, "*", args).block();
+        assertThat(first).isNotNull();
+        assertThat(first.getCursorId()).isGreaterThan(0);
+        assertThat(first.getNodeId()).isPresent();
+        assertThat(first.getReplies()).isNotEmpty();
+        String nodeId = first.getNodeId().get();
+
+        AggregationReply<String, String> page2 = reactive.ftCursorread(INDEX, first).block();
+        assertThat(page2).isNotNull();
+        assertThat(page2.getNodeId()).isPresent();
+        assertThat(page2.getNodeId().get()).isEqualTo(nodeId);
+        assertThat(page2.getReplies()).isNotEmpty();
+        assertThat(page2.getReplies()).isNotEqualTo(first.getReplies());
+
+        AggregationReply<String, String> page3 = reactive.ftCursorread(INDEX, page2).block();
+        assertThat(page3.getNodeId()).isPresent();
+        assertThat(page3.getNodeId().get()).isEqualTo(nodeId);
+        assertThat(page3.getReplies()).isNotEmpty();
+        assertThat(page3.getReplies()).isNotEqualTo(page2.getReplies());
+
+        String del = reactive.ftCursordel(INDEX, page3).block();
+        assertThat(del).isEqualTo("OK");
+    }
+
+    @Test
+    void sync_errorHandling_missingNodeId_throws() {
+        AggregationReply<String, String> noNode = new AggregationReply<>();
+        try {
+            Method m = AggregationReply.class.getDeclaredMethod("setCursorId", long.class);
+            m.setAccessible(true);
+            m.invoke(noNode, 5L);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        assertThatThrownBy(() -> sync.ftCursorread(INDEX, noNode)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("missing nodeId");
+        assertThatThrownBy(() -> sync.ftCursordel(INDEX, noNode)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("missing nodeId");
+    }
+
+    @Test
+    void async_errorHandling_missingNodeId_throws() {
+        AggregationReply<String, String> noNode = new AggregationReply<>();
+        try {
+            Method m = AggregationReply.class.getDeclaredMethod("setCursorId", long.class);
+            m.setAccessible(true);
+            m.invoke(noNode, 5L);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        assertThatThrownBy(() -> async.ftCursorread(INDEX, noNode).toCompletableFuture().join())
+                .hasCauseInstanceOf(IllegalArgumentException.class).hasMessageContaining("missing nodeId");
+        assertThatThrownBy(() -> async.ftCursordel(INDEX, noNode).toCompletableFuture().join())
+                .hasCauseInstanceOf(IllegalArgumentException.class).hasMessageContaining("missing nodeId");
+    }
+
+    @Test
+    void reactive_errorHandling_missingNodeId_emitsError() {
+        AggregationReply<String, String> noNode = new AggregationReply<>();
+        try {
+            Method m = AggregationReply.class.getDeclaredMethod("setCursorId", long.class);
+            m.setAccessible(true);
+            m.invoke(noNode, 5L);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        StepVerifier.create(reactive.ftCursorread(INDEX, noNode))
+                .expectErrorSatisfies(
+                        t -> assertThat(t).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("missing nodeId"))
+                .verify();
+        StepVerifier.create(reactive.ftCursordel(INDEX, noNode))
+                .expectErrorSatisfies(
+                        t -> assertThat(t).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("missing nodeId"))
+                .verify();
+    }
+
+}

--- a/src/test/java/io/lettuce/core/search/RediSearchClusterIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/search/RediSearchClusterIntegrationTests.java
@@ -234,7 +234,7 @@ public class RediSearchClusterIntegrationTests {
         // Test cursor read functionality if cursor is available
         if (aggregateResults.getCursorId() != -1 && aggregateResults.getCursorId() > 0) {
             // Read next batch using cursor
-            AggregationReply<String, String> cursorResults = redis.ftCursorread(BOOKS_INDEX, aggregateResults.getCursorId());
+            AggregationReply<String, String> cursorResults = redis.ftCursorread(BOOKS_INDEX, aggregateResults);
 
             // Verify cursor read works
             assertThat(cursorResults).isNotNull();


### PR DESCRIPTION
**TL;DR:** Make `FT.AGGREGATE … WITHCURSOR` sticky to the shard that created it by carrying the routing token (`nodeId`) in the `AggregationReply` and routing `FT.CURSOR READ/DEL` accordingly. No writer changes.

## What changed

* **`AggregationReply<K,V>`**

  * Added `@Nullable String nodeId` + `getNodeId()`; package-private `setNodeId(...)`.
  * Not included in `equals`/`hashCode`.
* **API (all `@Experimental`)**

  * Cursor ops now consume the **reply**:

    * `ftCursorread(AggregationReply<K,V> reply, int count)`
    * `ftCursorread(AggregationReply<K,V> reply)`
    * `ftCursordel (AggregationReply<K,V> reply)`
  * Removed/adapted old `(index, cursorId)` variants.
* **Cluster behavior**

  * After decoding `FT.AGGREGATE`, if `cursorId > 0`, stamp `reply.setNodeId(executedNode.getNodeId())`.
  * `ftCursorread/ftCursordel` resolve `reply.nodeId → endpoint` via `Partitions` and dispatch to that node.
* **Single node / missing `nodeId`**

  * Falls back to existing single-node path.

## Migration note

* Breaking only for **experimental** cursor methods: pass the original `AggregationReply` instead of `(index, cursorId)`.

## What's next
**Stage 2:** read-write load-balancing for keyless commands, including `FT.SEARCH/FT.AGGREGATE`.
