### PR TITLE
Refactor JsonValue to Object mapping #3412

### DIFF
--- a/src/main/java/io/lettuce/core/json/DefaultJsonParser.java
+++ b/src/main/java/io/lettuce/core/json/DefaultJsonParser.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
  *
  * @since 6.5
  * @author Tihomir Mateev
+ * @author Steffen Kreutz
  */
 public class DefaultJsonParser implements JsonParser {
 
@@ -63,19 +64,19 @@ public class DefaultJsonParser implements JsonParser {
 
     @Override
     public JsonObject createJsonObject() {
-        return new DelegateJsonObject();
+        return new DelegateJsonObject(objectMapper);
     }
 
     @Override
     public JsonArray createJsonArray() {
-        return new DelegateJsonArray();
+        return new DelegateJsonArray(objectMapper);
     }
 
     @Override
     public JsonValue fromObject(Object object) {
         try {
             JsonNode root = objectMapper.valueToTree(object);
-            return DelegateJsonValue.wrap(root);
+            return DelegateJsonValue.wrap(root, objectMapper);
         } catch (IllegalArgumentException e) {
             throw new RedisJsonException("Failed to process the provided object as JSON", e);
         }
@@ -83,12 +84,12 @@ public class DefaultJsonParser implements JsonParser {
 
     private JsonValue parse(String value) {
         if (value == null) {
-            return DelegateJsonValue.wrap(NullNode.getInstance());
+            return DelegateJsonValue.wrap(NullNode.getInstance(), objectMapper);
         }
 
         try {
             JsonNode root = objectMapper.readTree(value);
-            return DelegateJsonValue.wrap(root);
+            return DelegateJsonValue.wrap(root, objectMapper);
         } catch (JsonProcessingException e) {
             throw new RedisJsonException(
                     "Failed to process the provided value as JSON: " + String.format("%.50s", value) + "...", e);
@@ -97,14 +98,14 @@ public class DefaultJsonParser implements JsonParser {
 
     private JsonValue parse(ByteBuffer byteBuffer) {
         if (byteBuffer == null) {
-            return DelegateJsonValue.wrap(NullNode.getInstance());
+            return DelegateJsonValue.wrap(NullNode.getInstance(), objectMapper);
         }
 
         try {
             byte[] bytes = new byte[byteBuffer.remaining()];
             byteBuffer.get(bytes);
             JsonNode root = objectMapper.readTree(bytes);
-            return DelegateJsonValue.wrap(root);
+            return DelegateJsonValue.wrap(root, objectMapper);
         } catch (IOException e) {
             throw new RedisJsonException("Failed to process the provided value as JSON", e);
         }

--- a/src/main/java/io/lettuce/core/json/DelegateJsonArray.java
+++ b/src/main/java/io/lettuce/core/json/DelegateJsonArray.java
@@ -8,6 +8,7 @@
 package io.lettuce.core.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.lettuce.core.internal.LettuceAssert;
@@ -20,15 +21,16 @@ import java.util.List;
  * Implementation of the {@link DelegateJsonArray} that delegates most of its' functionality to the Jackson {@link ArrayNode}.
  *
  * @author Tihomir Mateev
+ * @author Steffen Kreutz
  */
 class DelegateJsonArray extends DelegateJsonValue implements JsonArray {
 
-    DelegateJsonArray() {
-        super(new ArrayNode(JsonNodeFactory.instance));
+    DelegateJsonArray(ObjectMapper objectMapper) {
+        super(new ArrayNode(JsonNodeFactory.instance), objectMapper);
     }
 
-    DelegateJsonArray(JsonNode node) {
-        super(node);
+    DelegateJsonArray(JsonNode node, ObjectMapper objectMapper) {
+        super(node, objectMapper);
     }
 
     @Override
@@ -57,7 +59,7 @@ class DelegateJsonArray extends DelegateJsonValue implements JsonArray {
         List<JsonValue> result = new ArrayList<>();
 
         for (JsonNode jsonNode : node) {
-            result.add(new DelegateJsonValue(jsonNode));
+            result.add(new DelegateJsonValue(jsonNode, objectMapper));
         }
 
         return result;
@@ -67,7 +69,7 @@ class DelegateJsonArray extends DelegateJsonValue implements JsonArray {
     public JsonValue get(int index) {
         JsonNode jsonNode = node.get(index);
 
-        return jsonNode == null ? null : wrap(jsonNode);
+        return jsonNode == null ? null : wrap(jsonNode, objectMapper);
     }
 
     @Override
@@ -84,7 +86,7 @@ class DelegateJsonArray extends DelegateJsonValue implements JsonArray {
     public JsonValue remove(int index) {
         JsonNode jsonNode = ((ArrayNode) node).remove(index);
 
-        return wrap(jsonNode);
+        return wrap(jsonNode, objectMapper);
     }
 
     @Override
@@ -92,7 +94,7 @@ class DelegateJsonArray extends DelegateJsonValue implements JsonArray {
         JsonNode replaceWith = ((DelegateJsonValue) newElement).getNode();
         JsonNode replaced = ((ArrayNode) node).set(index, replaceWith);
 
-        return wrap(replaced);
+        return wrap(replaced, objectMapper);
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/json/DelegateJsonObject.java
+++ b/src/main/java/io/lettuce/core/json/DelegateJsonObject.java
@@ -8,6 +8,7 @@
 package io.lettuce.core.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -15,15 +16,16 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * Implementation of the {@link DelegateJsonObject} that delegates most of its functionality to the Jackson {@link ObjectNode}.
  *
  * @author Tihomir Mateev
+ * @author Steffen Kreutz
  */
 class DelegateJsonObject extends DelegateJsonValue implements JsonObject {
 
-    DelegateJsonObject() {
-        super(new ObjectNode(JsonNodeFactory.instance));
+    DelegateJsonObject(ObjectMapper objectMapper) {
+        super(new ObjectNode(JsonNodeFactory.instance), objectMapper);
     }
 
-    DelegateJsonObject(JsonNode node) {
-        super(node);
+    DelegateJsonObject(JsonNode node, ObjectMapper objectMapper) {
+        super(node, objectMapper);
     }
 
     @Override
@@ -38,14 +40,14 @@ class DelegateJsonObject extends DelegateJsonValue implements JsonObject {
     public JsonValue get(String key) {
         JsonNode value = node.get(key);
 
-        return value == null ? null : wrap(value);
+        return value == null ? null : wrap(value, objectMapper);
     }
 
     @Override
     public JsonValue remove(String key) {
         JsonNode value = ((ObjectNode) node).remove(key);
 
-        return wrap(value);
+        return wrap(value, objectMapper);
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/json/DelegateJsonValue.java
+++ b/src/main/java/io/lettuce/core/json/DelegateJsonValue.java
@@ -17,13 +17,17 @@ import java.nio.ByteBuffer;
  * Implementation of the {@link JsonValue} that delegates most of its functionality to the Jackson {@link JsonNode}.
  *
  * @author Tihomir Mateev
+ * @author Steffen Kreutz
  */
 class DelegateJsonValue implements JsonValue {
 
     protected JsonNode node;
 
-    DelegateJsonValue(JsonNode node) {
+    protected final ObjectMapper objectMapper;
+
+    DelegateJsonValue(JsonNode node, ObjectMapper objectMapper) {
         this.node = node;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -101,22 +105,21 @@ class DelegateJsonValue implements JsonValue {
 
     @Override
     public <T> T toObject(Class<T> type) {
-        ObjectMapper mapper = new ObjectMapper();
         try {
-            return mapper.treeToValue(node, type);
+            return objectMapper.treeToValue(node, type);
         } catch (IllegalArgumentException | JsonProcessingException e) {
             throw new RedisJsonException("Unable to map the provided JsonValue to " + type.getName(), e);
         }
     }
 
-    static JsonValue wrap(JsonNode root) {
+    static JsonValue wrap(JsonNode root, ObjectMapper objectMapper) {
         if (root.isObject()) {
-            return new DelegateJsonObject(root);
+            return new DelegateJsonObject(root, objectMapper);
         } else if (root.isArray()) {
-            return new DelegateJsonArray(root);
+            return new DelegateJsonArray(root, objectMapper);
         }
 
-        return new DelegateJsonValue(root);
+        return new DelegateJsonValue(root, objectMapper);
     }
 
 }

--- a/src/test/java/io/lettuce/core/json/DelegateJsonArrayUnitTests.java
+++ b/src/test/java/io/lettuce/core/json/DelegateJsonArrayUnitTests.java
@@ -16,6 +16,8 @@ import static io.lettuce.TestTags.UNIT_TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
  * Unit tests for {@link DelegateJsonArray}.
  */
@@ -24,8 +26,9 @@ class DelegateJsonArrayUnitTests {
 
     @Test
     void add() {
-        DefaultJsonParser parser = new DefaultJsonParser();
-        DelegateJsonArray underTest = new DelegateJsonArray();
+        ObjectMapper objectMapper = new ObjectMapper();
+        DefaultJsonParser parser = new DefaultJsonParser(objectMapper);
+        DelegateJsonArray underTest = new DelegateJsonArray(objectMapper);
         underTest.add(parser.createJsonValue("\"test\"")).add(parser.createJsonValue("\"test2\""))
                 .add(parser.createJsonValue("\"test3\""));
 
@@ -40,8 +43,9 @@ class DelegateJsonArrayUnitTests {
 
     @Test
     void addCornerCases() {
-        DefaultJsonParser parser = new DefaultJsonParser();
-        DelegateJsonArray underTest = new DelegateJsonArray();
+        ObjectMapper objectMapper = new ObjectMapper();
+        DefaultJsonParser parser = new DefaultJsonParser(objectMapper);
+        DelegateJsonArray underTest = new DelegateJsonArray(objectMapper);
         underTest.add(null).add(parser.createJsonValue("null")).add(parser.createJsonValue("\"test3\""));
 
         assertThatThrownBy(() -> underTest.addAll(null)).isInstanceOf(IllegalArgumentException.class);
@@ -55,8 +59,9 @@ class DelegateJsonArrayUnitTests {
 
     @Test
     void getCornerCases() {
-        DefaultJsonParser parser = new DefaultJsonParser();
-        DelegateJsonArray underTest = new DelegateJsonArray();
+        ObjectMapper objectMapper = new ObjectMapper();
+        DefaultJsonParser parser = new DefaultJsonParser(objectMapper);
+        DelegateJsonArray underTest = new DelegateJsonArray(objectMapper);
         underTest.add(parser.createJsonValue("\"test\"")).add(parser.createJsonValue("\"test2\""))
                 .add(parser.createJsonValue("\"test3\""));
 
@@ -66,12 +71,13 @@ class DelegateJsonArrayUnitTests {
 
     @Test
     void addAll() {
-        DefaultJsonParser parser = new DefaultJsonParser();
-        DelegateJsonArray array = new DelegateJsonArray();
+        ObjectMapper objectMapper = new ObjectMapper();
+        DefaultJsonParser parser = new DefaultJsonParser(objectMapper);
+        DelegateJsonArray array = new DelegateJsonArray(objectMapper);
         array.add(parser.createJsonValue("\"test\"")).add(parser.createJsonValue("\"test2\""))
                 .add(parser.createJsonValue("\"test3\""));
 
-        DelegateJsonArray underTest = new DelegateJsonArray();
+        DelegateJsonArray underTest = new DelegateJsonArray(objectMapper);
         underTest.addAll(array);
         array.remove(1); // verify source array modifications not propagated
 
@@ -86,8 +92,9 @@ class DelegateJsonArrayUnitTests {
 
     @Test
     void asList() {
-        DefaultJsonParser parser = new DefaultJsonParser();
-        DelegateJsonArray underTest = new DelegateJsonArray();
+        ObjectMapper objectMapper = new ObjectMapper();
+        DefaultJsonParser parser = new DefaultJsonParser(objectMapper);
+        DelegateJsonArray underTest = new DelegateJsonArray(objectMapper);
         underTest.add(parser.createJsonValue("1")).add(parser.createJsonValue("2")).add(parser.createJsonValue("3"));
 
         assertThat(underTest.size()).isEqualTo(3);
@@ -98,8 +105,9 @@ class DelegateJsonArrayUnitTests {
 
     @Test
     void getFirst() {
-        DefaultJsonParser parser = new DefaultJsonParser();
-        DelegateJsonArray underTest = new DelegateJsonArray();
+        ObjectMapper objectMapper = new ObjectMapper();
+        DefaultJsonParser parser = new DefaultJsonParser(objectMapper);
+        DelegateJsonArray underTest = new DelegateJsonArray(objectMapper);
         underTest.add(parser.createJsonValue("\"test\"")).add(parser.createJsonValue("\"test2\""))
                 .add(parser.createJsonValue("\"test3\""));
 
@@ -110,8 +118,9 @@ class DelegateJsonArrayUnitTests {
 
     @Test
     void iterator() {
-        DefaultJsonParser parser = new DefaultJsonParser();
-        DelegateJsonArray underTest = new DelegateJsonArray();
+        ObjectMapper objectMapper = new ObjectMapper();
+        DefaultJsonParser parser = new DefaultJsonParser(objectMapper);
+        DelegateJsonArray underTest = new DelegateJsonArray(objectMapper);
         underTest.add(parser.createJsonValue("1")).add(parser.createJsonValue("2")).add(parser.createJsonValue("3"));
 
         Iterator<JsonValue> iterator = underTest.iterator();
@@ -123,8 +132,9 @@ class DelegateJsonArrayUnitTests {
 
     @Test
     void remove() {
-        DefaultJsonParser parser = new DefaultJsonParser();
-        DelegateJsonArray underTest = new DelegateJsonArray();
+        ObjectMapper objectMapper = new ObjectMapper();
+        DefaultJsonParser parser = new DefaultJsonParser(objectMapper);
+        DelegateJsonArray underTest = new DelegateJsonArray(objectMapper);
         underTest.add(parser.createJsonValue("1")).add(parser.createJsonValue("2")).add(parser.createJsonValue("3"));
 
         assertThat(underTest.remove(1).asNumber()).isEqualTo(2);
@@ -135,8 +145,9 @@ class DelegateJsonArrayUnitTests {
 
     @Test
     void replace() {
-        DefaultJsonParser parser = new DefaultJsonParser();
-        DelegateJsonArray underTest = new DelegateJsonArray();
+        ObjectMapper objectMapper = new ObjectMapper();
+        DefaultJsonParser parser = new DefaultJsonParser(objectMapper);
+        DelegateJsonArray underTest = new DelegateJsonArray(objectMapper);
         underTest.add(parser.createJsonValue("1")).add(parser.createJsonValue("2")).add(parser.createJsonValue("3"));
         underTest.replace(1, parser.createJsonValue("4"));
 
@@ -148,7 +159,8 @@ class DelegateJsonArrayUnitTests {
 
     @Test
     void isJsonArray() {
-        DelegateJsonArray underTest = new DelegateJsonArray();
+        ObjectMapper objectMapper = new ObjectMapper();
+        DelegateJsonArray underTest = new DelegateJsonArray(objectMapper);
         assertThat(underTest.isJsonArray()).isTrue();
 
         assertThat(underTest.isJsonObject()).isFalse();
@@ -159,13 +171,15 @@ class DelegateJsonArrayUnitTests {
 
     @Test
     void asJsonArray() {
-        DelegateJsonArray underTest = new DelegateJsonArray();
+        ObjectMapper objectMapper = new ObjectMapper();
+        DelegateJsonArray underTest = new DelegateJsonArray(objectMapper);
         assertThat(underTest.asJsonArray()).isSameAs(underTest);
     }
 
     @Test
     void asAnythingElse() {
-        DelegateJsonArray underTest = new DelegateJsonArray();
+        ObjectMapper objectMapper = new ObjectMapper();
+        DelegateJsonArray underTest = new DelegateJsonArray(objectMapper);
 
         assertThat(underTest.asBoolean()).isNull();
         assertThat(underTest.asJsonObject()).isNull();

--- a/src/test/java/io/lettuce/core/json/DelegateJsonObjectUnitTests.java
+++ b/src/test/java/io/lettuce/core/json/DelegateJsonObjectUnitTests.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.Test;
 import static io.lettuce.TestTags.UNIT_TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
  * Unit tests for {@link DelegateJsonObject}.
  */
@@ -21,8 +23,9 @@ class DelegateJsonObjectUnitTests {
 
     @Test
     void put() {
-        DefaultJsonParser parser = new DefaultJsonParser();
-        DelegateJsonObject underTest = new DelegateJsonObject();
+        ObjectMapper objectMapper = new ObjectMapper();
+        DefaultJsonParser parser = new DefaultJsonParser(objectMapper);
+        DelegateJsonObject underTest = new DelegateJsonObject(objectMapper);
 
         underTest.put("test", parser.createJsonValue("\"test\"")).put("test2", parser.createJsonValue("1")).put("test2",
                 parser.createJsonValue("true"));
@@ -34,8 +37,9 @@ class DelegateJsonObjectUnitTests {
 
     @Test
     void remove() {
-        DefaultJsonParser parser = new DefaultJsonParser();
-        DelegateJsonObject underTest = new DelegateJsonObject();
+        ObjectMapper objectMapper = new ObjectMapper();
+        DefaultJsonParser parser = new DefaultJsonParser(objectMapper);
+        DelegateJsonObject underTest = new DelegateJsonObject(objectMapper);
 
         underTest.put("test", parser.createJsonValue("\"test\"")).put("test2", parser.createJsonValue("1")).remove("test");
 
@@ -46,7 +50,8 @@ class DelegateJsonObjectUnitTests {
 
     @Test
     void isAnythingElse() {
-        DelegateJsonObject underTest = new DelegateJsonObject();
+        ObjectMapper objectMapper = new ObjectMapper();
+        DelegateJsonObject underTest = new DelegateJsonObject(objectMapper);
 
         assertThat(underTest.isJsonObject()).isTrue();
 
@@ -59,7 +64,8 @@ class DelegateJsonObjectUnitTests {
 
     @Test
     void asAnythingElse() {
-        DelegateJsonObject underTest = new DelegateJsonObject();
+        ObjectMapper objectMapper = new ObjectMapper();
+        DelegateJsonObject underTest = new DelegateJsonObject(objectMapper);
 
         assertThat(underTest.asJsonObject()).isNotNull();
 


### PR DESCRIPTION
We now pass the ObjectMapper defined on the DefaultJsonParser to JsonValue and its subclasses. This ObjectMapper is used to map raw JSON nodes to specialized object instances.

Benefits:

1. We avoid creating new ObjectMapper instances over and over again.
2. We are able to configure the ObjectMapper.

Closes #3412.

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
