### PR TITLE
[maintenance events]  Enable maintenance events support by default (CAE-1303)

### DIFF
--- a/src/main/java/io/lettuce/core/MaintenanceEventsOptions.java
+++ b/src/main/java/io/lettuce/core/MaintenanceEventsOptions.java
@@ -41,7 +41,9 @@ import java.net.SocketAddress;
  */
 public class MaintenanceEventsOptions {
 
-    public static final boolean DEFAULT_SUPPORT_MAINTENANCE_EVENTS = false;
+    public static final boolean DEFAULT_SUPPORT_MAINTENANCE_EVENTS = true;
+
+    public static final AddressTypeSource DEFAULT_ADDRESS_TYPE_SOURCE = new AutoresolveAddressTypeSource();
 
     private final boolean supportMaintenanceEvents;
 
@@ -121,7 +123,7 @@ public class MaintenanceEventsOptions {
 
         private boolean supportMaintenanceEvents = DEFAULT_SUPPORT_MAINTENANCE_EVENTS;
 
-        private AddressTypeSource addressTypeSource;
+        private AddressTypeSource addressTypeSource = DEFAULT_ADDRESS_TYPE_SOURCE;
 
         public MaintenanceEventsOptions.Builder supportMaintenanceEvents() {
             return supportMaintenanceEvents(true);

--- a/src/main/java/io/lettuce/core/TimeoutOptions.java
+++ b/src/main/java/io/lettuce/core/TimeoutOptions.java
@@ -28,7 +28,7 @@ public class TimeoutOptions implements Serializable {
 
     public static final boolean DEFAULT_TIMEOUT_COMMANDS = false;
 
-    public static final Duration DEFAULT_RELAXED_TIMEOUT = DISABLED_TIMEOUT;
+    public static final Duration DEFAULT_RELAXED_TIMEOUT = Duration.ofSeconds(10);
 
     private final boolean timeoutCommands;
 


### PR DESCRIPTION
## Enable Maintenance Events Support with 10s Relaxed Timeout

### Summary
Enables maintenance events support by default and uses auto mode for the MOVING address type resolver with a relaxed timeout of 10s.

### Key Changes
- **Enable maintenance events by default** - `MaintenanceEventsOptions.DEFAULT_SUPPORT_MAINTENANCE_EVENTS = true`
- **auto-resolve address type source** - Requested address type during rebind (`IP`/`FQDN`, `EXTERNAL`/`INTERNAL`) is autoresolved using `AutoresolveAddressTypeSource`
- **10-second relaxed timeout** - `TimeoutOptions.DEFAULT_RELAXED_TIMEOUT = Duration.ofSeconds(10)`