### PR TITLE
Return name method to ProtocolKeyword public interface.

### DIFF
--- a/src/main/java/io/lettuce/core/protocol/ProtocolKeyword.java
+++ b/src/main/java/io/lettuce/core/protocol/ProtocolKeyword.java
@@ -19,4 +19,14 @@ public interface ProtocolKeyword {
      */
     String toString();
 
+    /**
+     * Return the keyword as a String. This method is retained for
+     * binary compatibility with existing integrations.
+     *
+     * @deprecated since 6.5, use {@link #toString()} instead.
+     */
+    @Deprecated
+    default String name() {
+        return this.toString();
+    }
 }


### PR DESCRIPTION
Fixes #3368 