### PR TITLE
Make search commands truly keyless

### DIFF
--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -1705,17 +1705,17 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
     }
 
     @Override
-    public RedisFuture<AggregationReply<K, V>> ftCursorread(K index, long cursorId, int count) {
+    public RedisFuture<AggregationReply<K, V>> ftCursorread(String index, long cursorId, int count) {
         return dispatch(searchCommandBuilder.ftCursorread(index, cursorId, count));
     }
 
     @Override
-    public RedisFuture<AggregationReply<K, V>> ftCursorread(K index, long cursorId) {
+    public RedisFuture<AggregationReply<K, V>> ftCursorread(String index, long cursorId) {
         return dispatch(searchCommandBuilder.ftCursorread(index, cursorId, -1));
     }
 
     @Override
-    public RedisFuture<String> ftCursordel(K index, long cursorId) {
+    public RedisFuture<String> ftCursordel(String index, long cursorId) {
         return dispatch(searchCommandBuilder.ftCursordel(index, cursorId));
     }
 

--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -1580,17 +1580,17 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
     }
 
     @Override
-    public RedisFuture<List<V>> ftTagvals(K index, K fieldName) {
+    public RedisFuture<List<V>> ftTagvals(String index, K fieldName) {
         return dispatch(searchCommandBuilder.ftTagvals(index, fieldName));
     }
 
     @Override
-    public RedisFuture<SpellCheckResult<V>> ftSpellcheck(K index, V query) {
+    public RedisFuture<SpellCheckResult<V>> ftSpellcheck(String index, V query) {
         return dispatch(searchCommandBuilder.ftSpellcheck(index, query));
     }
 
     @Override
-    public RedisFuture<SpellCheckResult<V>> ftSpellcheck(K index, V query, SpellCheckArgs<K, V> args) {
+    public RedisFuture<SpellCheckResult<V>> ftSpellcheck(String index, V query, SpellCheckArgs<K, V> args) {
         return dispatch(searchCommandBuilder.ftSpellcheck(index, query, args));
     }
 
@@ -1605,17 +1605,17 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
     }
 
     @Override
-    public RedisFuture<List<V>> ftDictdump(K dict) {
+    public RedisFuture<List<V>> ftDictdump(String dict) {
         return dispatch(searchCommandBuilder.ftDictdump(dict));
     }
 
     @Override
-    public RedisFuture<String> ftExplain(K index, V query) {
+    public RedisFuture<String> ftExplain(String index, V query) {
         return dispatch(searchCommandBuilder.ftExplain(index, query));
     }
 
     @Override
-    public RedisFuture<String> ftExplain(K index, V query, ExplainArgs<K, V> args) {
+    public RedisFuture<String> ftExplain(String index, V query, ExplainArgs<K, V> args) {
         return dispatch(searchCommandBuilder.ftExplain(index, query, args));
     }
 
@@ -1625,7 +1625,7 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
     }
 
     @Override
-    public RedisFuture<Map<V, List<V>>> ftSyndump(K index) {
+    public RedisFuture<Map<V, List<V>>> ftSyndump(String index) {
         return dispatch(searchCommandBuilder.ftSyndump(index));
     }
 
@@ -1685,22 +1685,22 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
     }
 
     @Override
-    public RedisFuture<SearchReply<K, V>> ftSearch(K index, V query, SearchArgs<K, V> args) {
+    public RedisFuture<SearchReply<K, V>> ftSearch(String index, V query, SearchArgs<K, V> args) {
         return dispatch(searchCommandBuilder.ftSearch(index, query, args));
     }
 
     @Override
-    public RedisFuture<SearchReply<K, V>> ftSearch(K index, V query) {
+    public RedisFuture<SearchReply<K, V>> ftSearch(String index, V query) {
         return dispatch(searchCommandBuilder.ftSearch(index, query, SearchArgs.<K, V> builder().build()));
     }
 
     @Override
-    public RedisFuture<AggregationReply<K, V>> ftAggregate(K index, V query, AggregateArgs<K, V> args) {
+    public RedisFuture<AggregationReply<K, V>> ftAggregate(String index, V query, AggregateArgs<K, V> args) {
         return dispatch(searchCommandBuilder.ftAggregate(index, query, args));
     }
 
     @Override
-    public RedisFuture<AggregationReply<K, V>> ftAggregate(K index, V query) {
+    public RedisFuture<AggregationReply<K, V>> ftAggregate(String index, V query) {
         return dispatch(searchCommandBuilder.ftAggregate(index, query, null));
     }
 

--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -1550,37 +1550,37 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
     }
 
     @Override
-    public RedisFuture<String> ftCreate(K index, CreateArgs<K, V> options, List<FieldArgs<K>> fieldArgs) {
+    public RedisFuture<String> ftCreate(String index, CreateArgs<K, V> options, List<FieldArgs<K>> fieldArgs) {
         return dispatch(searchCommandBuilder.ftCreate(index, options, fieldArgs));
     }
 
     @Override
-    public RedisFuture<String> ftCreate(K index, List<FieldArgs<K>> fieldArgs) {
+    public RedisFuture<String> ftCreate(String index, List<FieldArgs<K>> fieldArgs) {
         return dispatch(searchCommandBuilder.ftCreate(index, null, fieldArgs));
     }
 
     @Override
-    public RedisFuture<String> ftAliasadd(K alias, K index) {
+    public RedisFuture<String> ftAliasadd(String alias, String index) {
         return dispatch(searchCommandBuilder.ftAliasadd(alias, index));
     }
 
     @Override
-    public RedisFuture<String> ftAliasupdate(K alias, K index) {
+    public RedisFuture<String> ftAliasupdate(String alias, String index) {
         return dispatch(searchCommandBuilder.ftAliasupdate(alias, index));
     }
 
     @Override
-    public RedisFuture<String> ftAliasdel(K alias) {
+    public RedisFuture<String> ftAliasdel(String alias) {
         return dispatch(searchCommandBuilder.ftAliasdel(alias));
     }
 
     @Override
-    public RedisFuture<String> ftAlter(K index, boolean skipInitialScan, List<FieldArgs<K>> fieldArgs) {
+    public RedisFuture<String> ftAlter(String index, boolean skipInitialScan, List<FieldArgs<K>> fieldArgs) {
         return dispatch(searchCommandBuilder.ftAlter(index, skipInitialScan, fieldArgs));
     }
 
     @Override
-    public RedisFuture<List<V>> ftTagvals(String index, K fieldName) {
+    public RedisFuture<List<V>> ftTagvals(String index, String fieldName) {
         return dispatch(searchCommandBuilder.ftTagvals(index, fieldName));
     }
 
@@ -1595,12 +1595,12 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
     }
 
     @Override
-    public RedisFuture<Long> ftDictadd(K dict, V... terms) {
+    public RedisFuture<Long> ftDictadd(String dict, V... terms) {
         return dispatch(searchCommandBuilder.ftDictadd(dict, terms));
     }
 
     @Override
-    public RedisFuture<Long> ftDictdel(K dict, V... terms) {
+    public RedisFuture<Long> ftDictdel(String dict, V... terms) {
         return dispatch(searchCommandBuilder.ftDictdel(dict, terms));
     }
 
@@ -1630,12 +1630,12 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
     }
 
     @Override
-    public RedisFuture<String> ftSynupdate(K index, V synonymGroupId, V... terms) {
+    public RedisFuture<String> ftSynupdate(String index, V synonymGroupId, V... terms) {
         return dispatch(searchCommandBuilder.ftSynupdate(index, synonymGroupId, terms));
     }
 
     @Override
-    public RedisFuture<String> ftSynupdate(K index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms) {
+    public RedisFuture<String> ftSynupdate(String index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms) {
         return dispatch(searchCommandBuilder.ftSynupdate(index, synonymGroupId, args, terms));
     }
 
@@ -1670,17 +1670,17 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
     }
 
     @Override
-    public RedisFuture<String> ftAlter(K index, List<FieldArgs<K>> fieldArgs) {
+    public RedisFuture<String> ftAlter(String index, List<FieldArgs<K>> fieldArgs) {
         return dispatch(searchCommandBuilder.ftAlter(index, false, fieldArgs));
     }
 
     @Override
-    public RedisFuture<String> ftDropindex(K index, boolean deleteDocumentKeys) {
+    public RedisFuture<String> ftDropindex(String index, boolean deleteDocumentKeys) {
         return dispatch(searchCommandBuilder.ftDropindex(index, deleteDocumentKeys));
     }
 
     @Override
-    public RedisFuture<String> ftDropindex(K index) {
+    public RedisFuture<String> ftDropindex(String index) {
         return dispatch(searchCommandBuilder.ftDropindex(index, false));
     }
 

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -1736,7 +1736,7 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
-    public Mono<String> ftCursordel(K index, long cursorId) {
+    public Mono<String> ftCursordel(String index, long cursorId) {
         return createMono(() -> searchCommandBuilder.ftCursordel(index, cursorId));
     }
 
@@ -1771,12 +1771,12 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
-    public Mono<AggregationReply<K, V>> ftCursorread(K index, long cursorId, int count) {
+    public Mono<AggregationReply<K, V>> ftCursorread(String index, long cursorId, int count) {
         return createMono(() -> searchCommandBuilder.ftCursorread(index, cursorId, count));
     }
 
     @Override
-    public Mono<AggregationReply<K, V>> ftCursorread(K index, long cursorId) {
+    public Mono<AggregationReply<K, V>> ftCursorread(String index, long cursorId) {
         return createMono(() -> searchCommandBuilder.ftCursorread(index, cursorId, -1));
     }
 

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -1641,17 +1641,17 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
-    public Flux<V> ftTagvals(K index, K fieldName) {
+    public Flux<V> ftTagvals(String index, K fieldName) {
         return createDissolvingFlux(() -> searchCommandBuilder.ftTagvals(index, fieldName));
     }
 
     @Override
-    public Mono<SpellCheckResult<V>> ftSpellcheck(K index, V query) {
+    public Mono<SpellCheckResult<V>> ftSpellcheck(String index, V query) {
         return createMono(() -> searchCommandBuilder.ftSpellcheck(index, query));
     }
 
     @Override
-    public Mono<SpellCheckResult<V>> ftSpellcheck(K index, V query, SpellCheckArgs<K, V> args) {
+    public Mono<SpellCheckResult<V>> ftSpellcheck(String index, V query, SpellCheckArgs<K, V> args) {
         return createMono(() -> searchCommandBuilder.ftSpellcheck(index, query, args));
     }
 
@@ -1666,17 +1666,17 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
-    public Flux<V> ftDictdump(K dict) {
+    public Flux<V> ftDictdump(String dict) {
         return createDissolvingFlux(() -> searchCommandBuilder.ftDictdump(dict));
     }
 
     @Override
-    public Mono<String> ftExplain(K index, V query) {
+    public Mono<String> ftExplain(String index, V query) {
         return createMono(() -> searchCommandBuilder.ftExplain(index, query));
     }
 
     @Override
-    public Mono<String> ftExplain(K index, V query, ExplainArgs<K, V> args) {
+    public Mono<String> ftExplain(String index, V query, ExplainArgs<K, V> args) {
         return createMono(() -> searchCommandBuilder.ftExplain(index, query, args));
     }
 
@@ -1686,7 +1686,7 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
-    public Mono<Map<V, List<V>>> ftSyndump(K index) {
+    public Mono<Map<V, List<V>>> ftSyndump(String index) {
         return createMono(() -> searchCommandBuilder.ftSyndump(index));
     }
 
@@ -1751,22 +1751,22 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
-    public Mono<SearchReply<K, V>> ftSearch(K index, V query, SearchArgs<K, V> args) {
+    public Mono<SearchReply<K, V>> ftSearch(String index, V query, SearchArgs<K, V> args) {
         return createMono(() -> searchCommandBuilder.ftSearch(index, query, args));
     }
 
     @Override
-    public Mono<SearchReply<K, V>> ftSearch(K index, V query) {
+    public Mono<SearchReply<K, V>> ftSearch(String index, V query) {
         return createMono(() -> searchCommandBuilder.ftSearch(index, query, SearchArgs.<K, V> builder().build()));
     }
 
     @Override
-    public Mono<AggregationReply<K, V>> ftAggregate(K index, V query, AggregateArgs<K, V> args) {
+    public Mono<AggregationReply<K, V>> ftAggregate(String index, V query, AggregateArgs<K, V> args) {
         return createMono(() -> searchCommandBuilder.ftAggregate(index, query, args));
     }
 
     @Override
-    public Mono<AggregationReply<K, V>> ftAggregate(K index, V query) {
+    public Mono<AggregationReply<K, V>> ftAggregate(String index, V query) {
         return createMono(() -> searchCommandBuilder.ftAggregate(index, query, null));
     }
 

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -1611,37 +1611,37 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
-    public Mono<String> ftCreate(K index, CreateArgs<K, V> options, List<FieldArgs<K>> fieldArgs) {
+    public Mono<String> ftCreate(String index, CreateArgs<K, V> options, List<FieldArgs<K>> fieldArgs) {
         return createMono(() -> searchCommandBuilder.ftCreate(index, options, fieldArgs));
     }
 
     @Override
-    public Mono<String> ftCreate(K index, List<FieldArgs<K>> fieldArgs) {
+    public Mono<String> ftCreate(String index, List<FieldArgs<K>> fieldArgs) {
         return createMono(() -> searchCommandBuilder.ftCreate(index, null, fieldArgs));
     }
 
     @Override
-    public Mono<String> ftAliasadd(K alias, K index) {
+    public Mono<String> ftAliasadd(String alias, String index) {
         return createMono(() -> searchCommandBuilder.ftAliasadd(alias, index));
     }
 
     @Override
-    public Mono<String> ftAliasupdate(K alias, K index) {
+    public Mono<String> ftAliasupdate(String alias, String index) {
         return createMono(() -> searchCommandBuilder.ftAliasupdate(alias, index));
     }
 
     @Override
-    public Mono<String> ftAliasdel(K alias) {
+    public Mono<String> ftAliasdel(String alias) {
         return createMono(() -> searchCommandBuilder.ftAliasdel(alias));
     }
 
     @Override
-    public Mono<String> ftAlter(K index, boolean skipInitialScan, List<FieldArgs<K>> fieldArgs) {
+    public Mono<String> ftAlter(String index, boolean skipInitialScan, List<FieldArgs<K>> fieldArgs) {
         return createMono(() -> searchCommandBuilder.ftAlter(index, skipInitialScan, fieldArgs));
     }
 
     @Override
-    public Flux<V> ftTagvals(String index, K fieldName) {
+    public Flux<V> ftTagvals(String index, String fieldName) {
         return createDissolvingFlux(() -> searchCommandBuilder.ftTagvals(index, fieldName));
     }
 
@@ -1656,12 +1656,12 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
-    public Mono<Long> ftDictadd(K dict, V... terms) {
+    public Mono<Long> ftDictadd(String dict, V... terms) {
         return createMono(() -> searchCommandBuilder.ftDictadd(dict, terms));
     }
 
     @Override
-    public Mono<Long> ftDictdel(K dict, V... terms) {
+    public Mono<Long> ftDictdel(String dict, V... terms) {
         return createMono(() -> searchCommandBuilder.ftDictdel(dict, terms));
     }
 
@@ -1691,12 +1691,12 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
-    public Mono<String> ftSynupdate(K index, V synonymGroupId, V... terms) {
+    public Mono<String> ftSynupdate(String index, V synonymGroupId, V... terms) {
         return createMono(() -> searchCommandBuilder.ftSynupdate(index, synonymGroupId, terms));
     }
 
     @Override
-    public Mono<String> ftSynupdate(K index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms) {
+    public Mono<String> ftSynupdate(String index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms) {
         return createMono(() -> searchCommandBuilder.ftSynupdate(index, synonymGroupId, args, terms));
     }
 
@@ -1731,7 +1731,7 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
-    public Mono<String> ftAlter(K index, List<FieldArgs<K>> fieldArgs) {
+    public Mono<String> ftAlter(String index, List<FieldArgs<K>> fieldArgs) {
         return createMono(() -> searchCommandBuilder.ftAlter(index, false, fieldArgs));
     }
 
@@ -1741,12 +1741,12 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
-    public Mono<String> ftDropindex(K index, boolean deleteDocumentKeys) {
+    public Mono<String> ftDropindex(String index, boolean deleteDocumentKeys) {
         return createMono(() -> searchCommandBuilder.ftDropindex(index, deleteDocumentKeys));
     }
 
     @Override
-    public Mono<String> ftDropindex(K index) {
+    public Mono<String> ftDropindex(String index) {
         return createMono(() -> searchCommandBuilder.ftDropindex(index, false));
     }
 

--- a/src/main/java/io/lettuce/core/RediSearchCommandBuilder.java
+++ b/src/main/java/io/lettuce/core/RediSearchCommandBuilder.java
@@ -94,11 +94,11 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @param searchArgs the search arguments
      * @return the result of the search command
      */
-    public Command<K, V, SearchReply<K, V>> ftSearch(K index, V query, SearchArgs<K, V> searchArgs) {
-        notNullKey(index);
-        notNullKey(query);
+    public Command<K, V, SearchReply<K, V>> ftSearch(String index, V query, SearchArgs<K, V> searchArgs) {
+        LettuceAssert.notNull(index, "Index must not be null");
+        LettuceAssert.notNull(query, "Query must not be null");
 
-        CommandArgs<K, V> args = new CommandArgs<>(codec).addKey(index);
+        CommandArgs<K, V> args = new CommandArgs<>(codec).add(index);
         args.addValue(query);
 
         if (searchArgs != null) {
@@ -116,11 +116,11 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @param aggregateArgs the aggregate arguments
      * @return the result of the aggregate command
      */
-    public Command<K, V, AggregationReply<K, V>> ftAggregate(K index, V query, AggregateArgs<K, V> aggregateArgs) {
-        notNullKey(index);
-        notNullKey(query);
+    public Command<K, V, AggregationReply<K, V>> ftAggregate(String index, V query, AggregateArgs<K, V> aggregateArgs) {
+        LettuceAssert.notNull(index, "Index must not be null");
+        LettuceAssert.notNull(query, "Query must not be null");
 
-        CommandArgs<K, V> args = new CommandArgs<>(codec).addKey(index);
+        CommandArgs<K, V> args = new CommandArgs<>(codec).add(index);
         args.addValue(query);
 
         boolean withCursor = false;
@@ -253,11 +253,11 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @param fieldName the name of a Tag field defined in the schema
      * @return the result of the tagvals command
      */
-    public Command<K, V, List<V>> ftTagvals(K index, K fieldName) {
-        notNullKey(index);
-        notNullKey(fieldName);
+    public Command<K, V, List<V>> ftTagvals(String index, K fieldName) {
+        LettuceAssert.notNull(index, "Index must not be null");
+        LettuceAssert.notNull(fieldName, "Field name must not be null");
 
-        CommandArgs<K, V> args = new CommandArgs<>(codec).addKey(index).addKey(fieldName);
+        CommandArgs<K, V> args = new CommandArgs<>(codec).add(index).addKey(fieldName);
 
         return createCommand(FT_TAGVALS, new ValueListOutput<>(codec), args);
     }
@@ -269,7 +269,7 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @param query the search query
      * @return the result of the spellcheck command
      */
-    public Command<K, V, SpellCheckResult<V>> ftSpellcheck(K index, V query) {
+    public Command<K, V, SpellCheckResult<V>> ftSpellcheck(String index, V query) {
         return ftSpellcheck(index, query, null);
     }
 
@@ -281,11 +281,11 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @param args the spellcheck arguments
      * @return the result of the spellcheck command
      */
-    public Command<K, V, SpellCheckResult<V>> ftSpellcheck(K index, V query, SpellCheckArgs<K, V> args) {
-        notNullKey(index);
+    public Command<K, V, SpellCheckResult<V>> ftSpellcheck(String index, V query, SpellCheckArgs<K, V> args) {
+        LettuceAssert.notNull(index, "Index must not be null");
         LettuceAssert.notNull(query, "Query must not be null");
 
-        CommandArgs<K, V> commandArgs = new CommandArgs<>(codec).addKey(index).addValue(query);
+        CommandArgs<K, V> commandArgs = new CommandArgs<>(codec).add(index).addValue(query);
 
         if (args != null) {
             args.build(commandArgs);
@@ -345,10 +345,10 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @param dict the dictionary name
      * @return the result of the dictdump command
      */
-    public Command<K, V, List<V>> ftDictdump(K dict) {
-        notNullKey(dict);
+    public Command<K, V, List<V>> ftDictdump(String dict) {
+        LettuceAssert.notNull(dict, "Dictionary name must not be null");
 
-        CommandArgs<K, V> commandArgs = new CommandArgs<>(codec).addKey(dict);
+        CommandArgs<K, V> commandArgs = new CommandArgs<>(codec).add(dict);
 
         return createCommand(FT_DICTDUMP, new ValueListOutput<>(codec), commandArgs);
     }
@@ -360,7 +360,7 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @param query the search query
      * @return the execution plan as a string
      */
-    public Command<K, V, String> ftExplain(K index, V query) {
+    public Command<K, V, String> ftExplain(String index, V query) {
         return ftExplain(index, query, null);
     }
 
@@ -372,11 +372,11 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @param args the explain arguments
      * @return the execution plan as a string
      */
-    public Command<K, V, String> ftExplain(K index, V query, ExplainArgs<K, V> args) {
-        notNullKey(index);
+    public Command<K, V, String> ftExplain(String index, V query, ExplainArgs<K, V> args) {
+        LettuceAssert.notNull(index, "Index must not be null");
         LettuceAssert.notNull(query, "Query must not be null");
 
-        CommandArgs<K, V> commandArgs = new CommandArgs<>(codec).addKey(index).addValue(query);
+        CommandArgs<K, V> commandArgs = new CommandArgs<>(codec).add(index).addValue(query);
 
         if (args != null) {
             args.build(commandArgs);
@@ -401,10 +401,10 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @param index the index name
      * @return a map where keys are synonym terms and values are lists of group IDs containing that synonym
      */
-    public Command<K, V, Map<V, List<V>>> ftSyndump(K index) {
-        notNullKey(index);
+    public Command<K, V, Map<V, List<V>>> ftSyndump(String index) {
+        LettuceAssert.notNull(index, "Index must not be null");
 
-        CommandArgs<K, V> commandArgs = new CommandArgs<>(codec).addKey(index);
+        CommandArgs<K, V> commandArgs = new CommandArgs<>(codec).add(index);
 
         return createCommand(FT_SYNDUMP, new EncodedComplexOutput<>(codec, new SynonymMapParser<>(codec)), commandArgs);
     }

--- a/src/main/java/io/lettuce/core/RediSearchCommandBuilder.java
+++ b/src/main/java/io/lettuce/core/RediSearchCommandBuilder.java
@@ -66,11 +66,11 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @param fieldArgs the fieldArgs
      * @return the result of the create command
      */
-    public Command<K, V, String> ftCreate(K index, CreateArgs<K, V> createArgs, List<FieldArgs<K>> fieldArgs) {
-        notNullKey(index);
+    public Command<K, V, String> ftCreate(String index, CreateArgs<K, V> createArgs, List<FieldArgs<K>> fieldArgs) {
+        LettuceAssert.notNull(index, "Index must not be null");
         notEmpty(fieldArgs.toArray());
 
-        CommandArgs<K, V> args = new CommandArgs<>(codec).addKey(index);
+        CommandArgs<K, V> args = new CommandArgs<>(codec).add(index);
 
         if (createArgs != null) {
             createArgs.build(args);
@@ -179,11 +179,11 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @param index the index name
      * @return the result of the alias add command
      */
-    public Command<K, V, String> ftAliasadd(K alias, K index) {
-        notNullKey(alias);
-        notNullKey(index);
+    public Command<K, V, String> ftAliasadd(String alias, String index) {
+        LettuceAssert.notNull(alias, "Alias must not be null");
+        LettuceAssert.notNull(index, "Index must not be null");
 
-        CommandArgs<K, V> args = new CommandArgs<>(codec).addKey(alias).addKey(index);
+        CommandArgs<K, V> args = new CommandArgs<>(codec).add(alias).add(index);
 
         return createCommand(FT_ALIASADD, new StatusOutput<>(codec), args);
     }
@@ -195,11 +195,11 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @param index the index name
      * @return the result of the alias update command
      */
-    public Command<K, V, String> ftAliasupdate(K alias, K index) {
-        notNullKey(alias);
-        notNullKey(index);
+    public Command<K, V, String> ftAliasupdate(String alias, String index) {
+        LettuceAssert.notNull(alias, "Alias must not be null");
+        LettuceAssert.notNull(index, "Index must not be null");
 
-        CommandArgs<K, V> args = new CommandArgs<>(codec).addKey(alias).addKey(index);
+        CommandArgs<K, V> args = new CommandArgs<>(codec).add(alias).add(index);
 
         return createCommand(FT_ALIASUPDATE, new StatusOutput<>(codec), args);
     }
@@ -210,10 +210,10 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @param alias the alias name
      * @return the result of the alias delete command
      */
-    public Command<K, V, String> ftAliasdel(K alias) {
-        notNullKey(alias);
+    public Command<K, V, String> ftAliasdel(String alias) {
+        LettuceAssert.notNull(alias, "Alias must not be null");
 
-        CommandArgs<K, V> args = new CommandArgs<>(codec).addKey(alias);
+        CommandArgs<K, V> args = new CommandArgs<>(codec).add(alias);
 
         return createCommand(FT_ALIASDEL, new StatusOutput<>(codec), args);
     }
@@ -226,11 +226,11 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @param fieldArgs the field arguments for the new attributes to add
      * @return the result of the alter command
      */
-    public Command<K, V, String> ftAlter(K index, boolean skipInitialScan, List<FieldArgs<K>> fieldArgs) {
-        notNullKey(index);
+    public Command<K, V, String> ftAlter(String index, boolean skipInitialScan, List<FieldArgs<K>> fieldArgs) {
+        LettuceAssert.notNull(index, "Index must not be null");
         notEmpty(fieldArgs.toArray());
 
-        CommandArgs<K, V> args = new CommandArgs<>(codec).addKey(index);
+        CommandArgs<K, V> args = new CommandArgs<>(codec).add(index);
 
         if (skipInitialScan) {
             args.add(CommandKeyword.SKIPINITIALSCAN);
@@ -253,11 +253,11 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @param fieldName the name of a Tag field defined in the schema
      * @return the result of the tagvals command
      */
-    public Command<K, V, List<V>> ftTagvals(String index, K fieldName) {
+    public Command<K, V, List<V>> ftTagvals(String index, String fieldName) {
         LettuceAssert.notNull(index, "Index must not be null");
         LettuceAssert.notNull(fieldName, "Field name must not be null");
 
-        CommandArgs<K, V> args = new CommandArgs<>(codec).add(index).addKey(fieldName);
+        CommandArgs<K, V> args = new CommandArgs<>(codec).add(index).add(fieldName);
 
         return createCommand(FT_TAGVALS, new ValueListOutput<>(codec), args);
     }
@@ -303,12 +303,12 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @return the result of the dictadd command
      */
     @SafeVarargs
-    public final Command<K, V, Long> ftDictadd(K dict, V... terms) {
-        notNullKey(dict);
+    public final Command<K, V, Long> ftDictadd(String dict, V... terms) {
+        LettuceAssert.notNull(dict, "Dictionary must not be null");
         LettuceAssert.notNull(terms, "Terms must not be null");
         LettuceAssert.isTrue(terms.length > 0, "At least one term must be provided");
 
-        CommandArgs<K, V> commandArgs = new CommandArgs<>(codec).addKey(dict);
+        CommandArgs<K, V> commandArgs = new CommandArgs<>(codec).add(dict);
         for (V term : terms) {
             LettuceAssert.notNull(term, "Term must not be null");
             commandArgs.addValue(term);
@@ -325,12 +325,12 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @return the result of the dictdel command
      */
     @SafeVarargs
-    public final Command<K, V, Long> ftDictdel(K dict, V... terms) {
-        notNullKey(dict);
+    public final Command<K, V, Long> ftDictdel(String dict, V... terms) {
+        LettuceAssert.notNull(dict, "Dictionary must not be null");
         LettuceAssert.notNull(terms, "Terms must not be null");
         LettuceAssert.isTrue(terms.length > 0, "At least one term must be provided");
 
-        CommandArgs<K, V> commandArgs = new CommandArgs<>(codec).addKey(dict);
+        CommandArgs<K, V> commandArgs = new CommandArgs<>(codec).add(dict);
         for (V term : terms) {
             LettuceAssert.notNull(term, "Term must not be null");
             commandArgs.addValue(term);
@@ -418,7 +418,7 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @return the result of the synupdate command
      */
     @SafeVarargs
-    public final Command<K, V, String> ftSynupdate(K index, V synonymGroupId, V... terms) {
+    public final Command<K, V, String> ftSynupdate(String index, V synonymGroupId, V... terms) {
         return ftSynupdate(index, synonymGroupId, null, terms);
     }
 
@@ -432,13 +432,13 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @return the result of the synupdate command
      */
     @SafeVarargs
-    public final Command<K, V, String> ftSynupdate(K index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms) {
-        notNullKey(index);
+    public final Command<K, V, String> ftSynupdate(String index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms) {
+        LettuceAssert.notNull(index, "Index must not be null");
         LettuceAssert.notNull(synonymGroupId, "Synonym group ID must not be null");
         LettuceAssert.notNull(terms, "Terms must not be null");
         LettuceAssert.isTrue(terms.length > 0, "At least one term must be provided");
 
-        CommandArgs<K, V> commandArgs = new CommandArgs<>(codec).addKey(index).addValue(synonymGroupId);
+        CommandArgs<K, V> commandArgs = new CommandArgs<>(codec).add(index).addValue(synonymGroupId);
 
         if (args != null) {
             args.build(commandArgs);
@@ -561,10 +561,10 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @param deleteDocumentKeys whether to delete the document keys
      * @return the result of the drop command
      */
-    public Command<K, V, String> ftDropindex(K index, boolean deleteDocumentKeys) {
-        notNullKey(index);
+    public Command<K, V, String> ftDropindex(String index, boolean deleteDocumentKeys) {
+        LettuceAssert.notNull(index, "Index must not be null");
 
-        CommandArgs<K, V> args = new CommandArgs<>(codec).addKey(index);
+        CommandArgs<K, V> args = new CommandArgs<>(codec).add(index);
 
         if (deleteDocumentKeys) {
             args.add(CommandKeyword.DD);

--- a/src/main/java/io/lettuce/core/RediSearchCommandBuilder.java
+++ b/src/main/java/io/lettuce/core/RediSearchCommandBuilder.java
@@ -142,10 +142,10 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @param count the number of results to read
      * @return the result of the cursor read command
      */
-    public Command<K, V, AggregationReply<K, V>> ftCursorread(K index, long cursorId, int count) {
-        notNullKey(index);
+    public Command<K, V, AggregationReply<K, V>> ftCursorread(String index, long cursorId, int count) {
+        LettuceAssert.notNull(index, "Index must not be null");
 
-        CommandArgs<K, V> args = new CommandArgs<>(codec).add(CommandKeyword.READ).addKey(index);
+        CommandArgs<K, V> args = new CommandArgs<>(codec).add(CommandKeyword.READ).add(index);
         args.add(cursorId);
 
         if (count >= 0) {
@@ -163,10 +163,10 @@ class RediSearchCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
      * @param cursorId the cursor id
      * @return the result of the cursor delete command
      */
-    public Command<K, V, String> ftCursordel(K index, long cursorId) {
-        notNullKey(index);
+    public Command<K, V, String> ftCursordel(String index, long cursorId) {
+        LettuceAssert.notNull(index, "Index must not be null");
 
-        CommandArgs<K, V> args = new CommandArgs<>(codec).add(CommandKeyword.DEL).addKey(index);
+        CommandArgs<K, V> args = new CommandArgs<>(codec).add(CommandKeyword.DEL).add(index);
         args.add(cursorId);
 
         return createCommand(FT_CURSOR, new StatusOutput<>(codec), args);

--- a/src/main/java/io/lettuce/core/api/async/RediSearchAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RediSearchAsyncCommands.java
@@ -1120,7 +1120,7 @@ public interface RediSearchAsyncCommands<K, V> {
      * @see SearchReply
      * @see AggregateArgs
      * @see #ftAggregate(String, Object)
-     * @see #ftCursorread(Object, long)
+     * @see #ftCursorread(String, long)
      */
     @Experimental
     RedisFuture<AggregationReply<K, V>> ftAggregate(String index, V query, AggregateArgs<K, V> args);
@@ -1143,7 +1143,7 @@ public interface RediSearchAsyncCommands<K, V> {
      * <strong>Time complexity:</strong> O(1)
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param cursorId the cursor id obtained from a previous {@code FT.AGGREGATE} or {@code FT.CURSOR READ} command
      * @param count the number of results to read. This parameter overrides the {@code COUNT} specified in {@code FT.AGGREGATE}
      * @return the result of the cursor read command containing the next batch of results and potentially a new cursor id, see
@@ -1157,7 +1157,7 @@ public interface RediSearchAsyncCommands<K, V> {
      * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
-    RedisFuture<AggregationReply<K, V>> ftCursorread(K index, long cursorId, int count);
+    RedisFuture<AggregationReply<K, V>> ftCursorread(String index, long cursorId, int count);
 
     /**
      * Read next results from an existing cursor using the default batch size.
@@ -1177,7 +1177,7 @@ public interface RediSearchAsyncCommands<K, V> {
      * <strong>Time complexity:</strong> O(1)
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param cursorId the cursor id obtained from a previous {@code FT.AGGREGATE} or {@code FT.CURSOR READ} command
      * @return the result of the cursor read command containing the next batch of results and potentially a new cursor id, see
      *         {@link SearchReply}
@@ -1190,7 +1190,7 @@ public interface RediSearchAsyncCommands<K, V> {
      * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
-    RedisFuture<AggregationReply<K, V>> ftCursorread(K index, long cursorId);
+    RedisFuture<AggregationReply<K, V>> ftCursorread(String index, long cursorId);
 
     /**
      * Delete a cursor and free its associated resources.
@@ -1208,8 +1208,8 @@ public interface RediSearchAsyncCommands<K, V> {
      * </p>
      *
      * <p>
-     * Once a cursor is deleted, any subsequent attempts to read from it using {@link #ftCursorread(Object, long)} or
-     * {@link #ftCursorread(Object, long, int)} will result in an error.
+     * Once a cursor is deleted, any subsequent attempts to read from it using {@link #ftCursorread(String, long)} or
+     * {@link #ftCursorread(String, long, int)} will result in an error.
      * </p>
      *
      * <p>
@@ -1225,10 +1225,10 @@ public interface RediSearchAsyncCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
      * @see #ftAggregate(String, Object, AggregateArgs)
-     * @see #ftCursorread(Object, long)
-     * @see #ftCursorread(Object, long, int)
+     * @see #ftCursorread(String, long)
+     * @see #ftCursorread(String, long, int)
      */
     @Experimental
-    RedisFuture<String> ftCursordel(K index, long cursorId);
+    RedisFuture<String> ftCursordel(String index, long cursorId);
 
 }

--- a/src/main/java/io/lettuce/core/api/async/RediSearchAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RediSearchAsyncCommands.java
@@ -56,11 +56,11 @@ public interface RediSearchAsyncCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.create/">FT.CREATE</a>
      * @see CreateArgs
      * @see FieldArgs
-     * @see #ftCreate(Object, CreateArgs, List)
-     * @see #ftDropindex(Object)
+     * @see #ftCreate(String, CreateArgs, List)
+     * @see #ftDropindex(String)
      */
     @Experimental
-    RedisFuture<String> ftCreate(K index, List<FieldArgs<K>> fieldArgs);
+    RedisFuture<String> ftCreate(String index, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Create a new search index with the given name, custom configuration, and field definitions.
@@ -95,11 +95,11 @@ public interface RediSearchAsyncCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.create/">FT.CREATE</a>
      * @see CreateArgs
      * @see FieldArgs
-     * @see #ftCreate(Object, List)
-     * @see #ftDropindex(Object)
+     * @see #ftCreate(String, List)
+     * @see #ftDropindex(String)
      */
     @Experimental
-    RedisFuture<String> ftCreate(K index, CreateArgs<K, V> arguments, List<FieldArgs<K>> fieldArgs);
+    RedisFuture<String> ftCreate(String index, CreateArgs<K, V> arguments, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Add an alias to a search index.
@@ -127,7 +127,7 @@ public interface RediSearchAsyncCommands<K, V> {
      * <li>An index can have multiple aliases, but an alias can only point to one index</li>
      * <li>Aliases cannot reference other aliases (no alias chaining)</li>
      * <li>If the alias already exists, this command will fail with an error</li>
-     * <li>Use {@link #ftAliasupdate(Object, Object)} to reassign an existing alias</li>
+     * <li>Use {@link #ftAliasupdate(String, String)} to reassign an existing alias</li>
      * </ul>
      *
      * <p>
@@ -139,18 +139,18 @@ public interface RediSearchAsyncCommands<K, V> {
      * @return {@code "OK"} if the alias was successfully created
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.aliasadd/">FT.ALIASADD</a>
-     * @see #ftAliasupdate(Object, Object)
-     * @see #ftAliasdel(Object)
+     * @see #ftAliasupdate(String, String)
+     * @see #ftAliasdel(String)
      */
     @Experimental
-    RedisFuture<String> ftAliasadd(K alias, K index);
+    RedisFuture<String> ftAliasadd(String alias, String index);
 
     /**
      * Update an existing alias to point to a different search index.
      *
      * <p>
      * This command updates an existing alias to point to a different index, or creates the alias if it doesn't exist. Unlike
-     * {@link #ftAliasadd(Object, Object)}, this command will succeed even if the alias already exists, making it useful for
+     * {@link #ftAliasadd(String, String)}, this command will succeed even if the alias already exists, making it useful for
      * atomic alias updates during index migrations.
      * </p>
      *
@@ -183,11 +183,11 @@ public interface RediSearchAsyncCommands<K, V> {
      * @return {@code "OK"} if the alias was successfully updated
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.aliasupdate/">FT.ALIASUPDATE</a>
-     * @see #ftAliasadd(Object, Object)
-     * @see #ftAliasdel(Object)
+     * @see #ftAliasadd(String, String)
+     * @see #ftAliasdel(String)
      */
     @Experimental
-    RedisFuture<String> ftAliasupdate(K alias, K index);
+    RedisFuture<String> ftAliasupdate(String alias, String index);
 
     /**
      * Remove an alias from a search index.
@@ -214,7 +214,7 @@ public interface RediSearchAsyncCommands<K, V> {
      * <li>Only the alias is removed - the target index is not affected</li>
      * <li>If the alias doesn't exist, this command will fail with an error</li>
      * <li>Applications using the alias will receive errors after deletion</li>
-     * <li>Consider using {@link #ftAliasupdate(Object, Object)} to redirect before deletion</li>
+     * <li>Consider using {@link #ftAliasupdate(String, String)} to redirect before deletion</li>
      * </ul>
      *
      * <p>
@@ -225,11 +225,11 @@ public interface RediSearchAsyncCommands<K, V> {
      * @return {@code "OK"} if the alias was successfully removed
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.aliasdel/">FT.ALIASDEL</a>
-     * @see #ftAliasadd(Object, Object)
-     * @see #ftAliasupdate(Object, Object)
+     * @see #ftAliasadd(String, String)
+     * @see #ftAliasupdate(String, String)
      */
     @Experimental
-    RedisFuture<String> ftAliasdel(K alias);
+    RedisFuture<String> ftAliasdel(String alias);
 
     /**
      * Add new attributes to an existing search index.
@@ -272,11 +272,11 @@ public interface RediSearchAsyncCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.alter/">FT.ALTER</a>
      * @see FieldArgs
-     * @see #ftCreate(Object, List)
-     * @see #ftCreate(Object, CreateArgs, List)
+     * @see #ftCreate(String, List)
+     * @see #ftCreate(String, CreateArgs, List)
      */
     @Experimental
-    RedisFuture<String> ftAlter(K index, boolean skipInitialScan, List<FieldArgs<K>> fieldArgs);
+    RedisFuture<String> ftAlter(String index, boolean skipInitialScan, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Add new attributes to an existing search index.
@@ -307,11 +307,11 @@ public interface RediSearchAsyncCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.alter/">FT.ALTER</a>
      * @see FieldArgs
-     * @see #ftCreate(Object, List)
-     * @see #ftCreate(Object, CreateArgs, List)
+     * @see #ftCreate(String, List)
+     * @see #ftCreate(String, CreateArgs, List)
      */
     @Experimental
-    RedisFuture<String> ftAlter(K index, List<FieldArgs<K>> fieldArgs);
+    RedisFuture<String> ftAlter(String index, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Return a distinct set of values indexed in a Tag field.
@@ -363,11 +363,11 @@ public interface RediSearchAsyncCommands<K, V> {
      *         were indexed (lowercase, whitespace removed).
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.tagvals/">FT.TAGVALS</a>
-     * @see #ftCreate(Object, List)
-     * @see #ftCreate(Object, CreateArgs, List)
+     * @see #ftCreate(String, List)
+     * @see #ftCreate(String, CreateArgs, List)
      */
     @Experimental
-    RedisFuture<List<V>> ftTagvals(String index, K fieldName);
+    RedisFuture<List<V>> ftTagvals(String index, String fieldName);
 
     /**
      * Perform spelling correction on a query, returning suggestions for misspelled terms.
@@ -403,8 +403,8 @@ public interface RediSearchAsyncCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
      * @see #ftSpellcheck(String, Object, SpellCheckArgs)
-     * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictadd(String, Object[])
+     * @see #ftDictdel(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
@@ -440,8 +440,8 @@ public interface RediSearchAsyncCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
      * @see #ftSpellcheck(String, Object)
-     * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictadd(String, Object[])
+     * @see #ftDictdel(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
@@ -475,11 +475,11 @@ public interface RediSearchAsyncCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictadd/">FT.DICTADD</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictdel(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
-    RedisFuture<Long> ftDictadd(K dict, V... terms);
+    RedisFuture<Long> ftDictadd(String dict, V... terms);
 
     /**
      * Delete terms from a dictionary.
@@ -498,11 +498,11 @@ public interface RediSearchAsyncCommands<K, V> {
      * @return the number of terms that were deleted
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictdel/">FT.DICTDEL</a>
-     * @see #ftDictadd(Object, Object[])
+     * @see #ftDictadd(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
-    RedisFuture<Long> ftDictdel(K dict, V... terms);
+    RedisFuture<Long> ftDictdel(String dict, V... terms);
 
     /**
      * Dump all terms in a dictionary.
@@ -519,8 +519,8 @@ public interface RediSearchAsyncCommands<K, V> {
      * @return a list of all terms in the dictionary
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictdump/">FT.DICTDUMP</a>
-     * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictadd(String, Object[])
+     * @see #ftDictdel(String, Object[])
      */
     @Experimental
     RedisFuture<List<V>> ftDictdump(String dict);
@@ -619,8 +619,8 @@ public interface RediSearchAsyncCommands<K, V> {
      * @return a list of index names
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft._list/">FT._LIST</a>
-     * @see #ftCreate(Object, CreateArgs, FieldArgs[])
-     * @see #ftDropindex(Object)
+     * @see #ftCreate(String, CreateArgs, FieldArgs[])
+     * @see #ftDropindex(String)
      */
     @Experimental
     RedisFuture<List<V>> ftList();
@@ -651,8 +651,8 @@ public interface RediSearchAsyncCommands<K, V> {
      * @return a map where keys are synonym terms and values are lists of group IDs containing that synonym
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.syndump/">FT.SYNDUMP</a>
-     * @see #ftSynupdate(Object, Object, Object[])
-     * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
+     * @see #ftSynupdate(String, Object, Object[])
+     * @see #ftSynupdate(String, Object, SynUpdateArgs, Object[])
      */
     @Experimental
     RedisFuture<Map<V, List<V>>> ftSyndump(String index);
@@ -685,11 +685,11 @@ public interface RediSearchAsyncCommands<K, V> {
      * @return OK if executed correctly
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
-     * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
+     * @see #ftSynupdate(String, Object, SynUpdateArgs, Object[])
      * @see #ftSyndump(String)
      */
     @Experimental
-    RedisFuture<String> ftSynupdate(K index, V synonymGroupId, V... terms);
+    RedisFuture<String> ftSynupdate(String index, V synonymGroupId, V... terms);
 
     /**
      * Update a synonym group with additional terms and options.
@@ -717,11 +717,11 @@ public interface RediSearchAsyncCommands<K, V> {
      * @return OK if executed correctly
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
-     * @see #ftSynupdate(Object, Object, Object[])
+     * @see #ftSynupdate(String, Object, Object[])
      * @see #ftSyndump(String)
      */
     @Experimental
-    RedisFuture<String> ftSynupdate(K index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms);
+    RedisFuture<String> ftSynupdate(String index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms);
 
     /**
      * Add a suggestion string to an auto-complete suggestion dictionary.
@@ -901,11 +901,11 @@ public interface RediSearchAsyncCommands<K, V> {
      * @return {@code "OK"} if the index was successfully dropped
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dropindex/">FT.DROPINDEX</a>
-     * @see #ftDropindex(Object, boolean)
-     * @see #ftCreate(Object, List)
+     * @see #ftDropindex(String, boolean)
+     * @see #ftCreate(String, List)
      */
     @Experimental
-    RedisFuture<String> ftDropindex(K index);
+    RedisFuture<String> ftDropindex(String index);
 
     /**
      * Drop a search index with optional document deletion.
@@ -917,7 +917,7 @@ public interface RediSearchAsyncCommands<K, V> {
      * </p>
      *
      * <p>
-     * <strong>Asynchronous Behavior:</strong> If an index creation is still running ({@link #ftCreate(Object, List)} is running
+     * <strong>Asynchronous Behavior:</strong> If an index creation is still running ({@link #ftCreate(String, List)} is running
      * asynchronously), only the document hashes that have already been indexed are deleted. Documents that are queued for
      * indexing but not yet processed will remain in the database.
      * </p>
@@ -931,11 +931,11 @@ public interface RediSearchAsyncCommands<K, V> {
      * @return {@code "OK"} if the index was successfully dropped
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dropindex/">FT.DROPINDEX</a>
-     * @see #ftDropindex(Object)
-     * @see #ftCreate(Object, List)
+     * @see #ftDropindex(String)
+     * @see #ftCreate(String, List)
      */
     @Experimental
-    RedisFuture<String> ftDropindex(K index, boolean deleteDocuments);
+    RedisFuture<String> ftDropindex(String index, boolean deleteDocuments);
 
     /**
      * Search the index with a textual query using default search options.

--- a/src/main/java/io/lettuce/core/api/async/RediSearchAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RediSearchAsyncCommands.java
@@ -367,7 +367,7 @@ public interface RediSearchAsyncCommands<K, V> {
      * @see #ftCreate(Object, CreateArgs, List)
      */
     @Experimental
-    RedisFuture<List<V>> ftTagvals(K index, K fieldName);
+    RedisFuture<List<V>> ftTagvals(String index, K fieldName);
 
     /**
      * Perform spelling correction on a query, returning suggestions for misspelled terms.
@@ -402,13 +402,13 @@ public interface RediSearchAsyncCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
-     * @see #ftSpellcheck(Object, Object, SpellCheckArgs)
+     * @see #ftSpellcheck(String, Object, SpellCheckArgs)
      * @see #ftDictadd(Object, Object[])
      * @see #ftDictdel(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
-    RedisFuture<SpellCheckResult<V>> ftSpellcheck(K index, V query);
+    RedisFuture<SpellCheckResult<V>> ftSpellcheck(String index, V query);
 
     /**
      * Perform spelling correction on a query with additional options.
@@ -439,13 +439,13 @@ public interface RediSearchAsyncCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
-     * @see #ftSpellcheck(Object, Object)
+     * @see #ftSpellcheck(String, Object)
      * @see #ftDictadd(Object, Object[])
      * @see #ftDictdel(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
-    RedisFuture<SpellCheckResult<V>> ftSpellcheck(K index, V query, SpellCheckArgs<K, V> args);
+    RedisFuture<SpellCheckResult<V>> ftSpellcheck(String index, V query, SpellCheckArgs<K, V> args);
 
     /**
      * Add terms to a dictionary.
@@ -476,7 +476,7 @@ public interface RediSearchAsyncCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictadd/">FT.DICTADD</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
      * @see #ftDictdel(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
     RedisFuture<Long> ftDictadd(K dict, V... terms);
@@ -499,7 +499,7 @@ public interface RediSearchAsyncCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictdel/">FT.DICTDEL</a>
      * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
     RedisFuture<Long> ftDictdel(K dict, V... terms);
@@ -523,7 +523,7 @@ public interface RediSearchAsyncCommands<K, V> {
      * @see #ftDictdel(Object, Object[])
      */
     @Experimental
-    RedisFuture<List<V>> ftDictdump(K dict);
+    RedisFuture<List<V>> ftDictdump(String dict);
 
     /**
      * Return the execution plan for a complex query.
@@ -552,11 +552,11 @@ public interface RediSearchAsyncCommands<K, V> {
      * @return the execution plan as a string
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.explain/">FT.EXPLAIN</a>
-     * @see #ftExplain(Object, Object, ExplainArgs)
-     * @see #ftSearch(Object, Object)
+     * @see #ftExplain(String, Object, ExplainArgs)
+     * @see #ftSearch(String, Object)
      */
     @Experimental
-    RedisFuture<String> ftExplain(K index, V query);
+    RedisFuture<String> ftExplain(String index, V query);
 
     /**
      * Return the execution plan for a complex query with additional options.
@@ -583,11 +583,11 @@ public interface RediSearchAsyncCommands<K, V> {
      * @return the execution plan as a string
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.explain/">FT.EXPLAIN</a>
-     * @see #ftExplain(Object, Object)
-     * @see #ftSearch(Object, Object)
+     * @see #ftExplain(String, Object)
+     * @see #ftSearch(String, Object)
      */
     @Experimental
-    RedisFuture<String> ftExplain(K index, V query, ExplainArgs<K, V> args);
+    RedisFuture<String> ftExplain(String index, V query, ExplainArgs<K, V> args);
 
     /**
      * Return a list of all existing indexes.
@@ -655,7 +655,7 @@ public interface RediSearchAsyncCommands<K, V> {
      * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
      */
     @Experimental
-    RedisFuture<Map<V, List<V>>> ftSyndump(K index);
+    RedisFuture<Map<V, List<V>>> ftSyndump(String index);
 
     /**
      * Update a synonym group with additional terms.
@@ -686,7 +686,7 @@ public interface RediSearchAsyncCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
      * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
-     * @see #ftSyndump(Object)
+     * @see #ftSyndump(String)
      */
     @Experimental
     RedisFuture<String> ftSynupdate(K index, V synonymGroupId, V... terms);
@@ -718,7 +718,7 @@ public interface RediSearchAsyncCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
      * @see #ftSynupdate(Object, Object, Object[])
-     * @see #ftSyndump(Object)
+     * @see #ftSyndump(String)
      */
     @Experimental
     RedisFuture<String> ftSynupdate(K index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms);
@@ -971,10 +971,10 @@ public interface RediSearchAsyncCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/develop/interact/search-and-query/query/">Query syntax</a>
      * @see SearchReply
      * @see SearchArgs
-     * @see #ftSearch(Object, Object, SearchArgs)
+     * @see #ftSearch(String, Object, SearchArgs)
      */
     @Experimental
-    RedisFuture<SearchReply<K, V>> ftSearch(K index, V query);
+    RedisFuture<SearchReply<K, V>> ftSearch(String index, V query);
 
     /**
      * Search the index with a textual query using advanced search options and filters.
@@ -1022,23 +1022,23 @@ public interface RediSearchAsyncCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/">Advanced concepts</a>
      * @see SearchReply
      * @see SearchArgs
-     * @see #ftSearch(Object, Object)
+     * @see #ftSearch(String, Object)
      */
     @Experimental
-    RedisFuture<SearchReply<K, V>> ftSearch(K index, V query, SearchArgs<K, V> args);
+    RedisFuture<SearchReply<K, V>> ftSearch(String index, V query, SearchArgs<K, V> args);
 
     /**
      * Run a search query on an index and perform basic aggregate transformations using default options.
      *
      * <p>
      * This command executes a search query and applies aggregation operations to transform and analyze the results. Unlike
-     * {@link #ftSearch(Object, Object)}, which returns individual documents, FT.AGGREGATE processes the result set through a
+     * {@link #ftSearch(String, Object)}, which returns individual documents, FT.AGGREGATE processes the result set through a
      * pipeline of transformations to produce analytical insights, summaries, and computed values.
      * </p>
      *
      * <p>
      * This basic variant uses default aggregation behavior without additional pipeline operations. For advanced aggregations
-     * with grouping, sorting, filtering, and custom transformations, use {@link #ftAggregate(Object, Object, AggregateArgs)}.
+     * with grouping, sorting, filtering, and custom transformations, use {@link #ftAggregate(String, Object, AggregateArgs)}.
      * </p>
      *
      * <p>
@@ -1064,10 +1064,10 @@ public interface RediSearchAsyncCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/">Aggregations</a>
      * @see SearchReply
      * @see AggregateArgs
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
-    RedisFuture<AggregationReply<K, V>> ftAggregate(K index, V query);
+    RedisFuture<AggregationReply<K, V>> ftAggregate(String index, V query);
 
     /**
      * Run a search query on an index and perform advanced aggregate transformations with a processing pipeline.
@@ -1119,18 +1119,18 @@ public interface RediSearchAsyncCommands<K, V> {
      *      API</a>
      * @see SearchReply
      * @see AggregateArgs
-     * @see #ftAggregate(Object, Object)
+     * @see #ftAggregate(String, Object)
      * @see #ftCursorread(Object, long)
      */
     @Experimental
-    RedisFuture<AggregationReply<K, V>> ftAggregate(K index, V query, AggregateArgs<K, V> args);
+    RedisFuture<AggregationReply<K, V>> ftAggregate(String index, V query, AggregateArgs<K, V> args);
 
     /**
      * Read next results from an existing cursor.
      *
      * <p>
      * This command is used to read the next batch of results from a cursor created by
-     * {@link #ftAggregate(Object, Object, AggregateArgs)} with the {@code WITHCURSOR} option. Cursors provide an efficient way
+     * {@link #ftAggregate(String, Object, AggregateArgs)} with the {@code WITHCURSOR} option. Cursors provide an efficient way
      * to iterate through large result sets without loading all results into memory at once.
      * </p>
      *
@@ -1154,7 +1154,7 @@ public interface RediSearchAsyncCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
      * @see SearchReply
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
     RedisFuture<AggregationReply<K, V>> ftCursorread(K index, long cursorId, int count);
@@ -1164,7 +1164,7 @@ public interface RediSearchAsyncCommands<K, V> {
      *
      * <p>
      * This command is used to read the next batch of results from a cursor created by
-     * {@link #ftAggregate(Object, Object, AggregateArgs)} with the {@code WITHCURSOR} option. This variant uses the default
+     * {@link #ftAggregate(String, Object, AggregateArgs)} with the {@code WITHCURSOR} option. This variant uses the default
      * batch size that was specified in the original {@code FT.AGGREGATE} command's {@code WITHCURSOR} clause.
      * </p>
      *
@@ -1187,7 +1187,7 @@ public interface RediSearchAsyncCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
      * @see SearchReply
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
     RedisFuture<AggregationReply<K, V>> ftCursorread(K index, long cursorId);
@@ -1196,7 +1196,7 @@ public interface RediSearchAsyncCommands<K, V> {
      * Delete a cursor and free its associated resources.
      *
      * <p>
-     * This command is used to explicitly delete a cursor created by {@link #ftAggregate(Object, Object, AggregateArgs)} with
+     * This command is used to explicitly delete a cursor created by {@link #ftAggregate(String, Object, AggregateArgs)} with
      * the {@code WITHCURSOR} option. Deleting a cursor frees up server resources and should be done when you no longer need to
      * read more results from the cursor.
      * </p>
@@ -1224,7 +1224,7 @@ public interface RediSearchAsyncCommands<K, V> {
      * @see <a href=
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      * @see #ftCursorread(Object, long)
      * @see #ftCursorread(Object, long, int)
      */

--- a/src/main/java/io/lettuce/core/api/async/RediSearchAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RediSearchAsyncCommands.java
@@ -50,7 +50,7 @@ public interface RediSearchAsyncCommands<K, V> {
      * triggered, where N is the number of keys in the keyspace
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param fieldArgs the {@link FieldArgs} list defining the searchable fields and their types
      * @return {@code "OK"} if the index was created successfully
      * @see <a href="https://redis.io/docs/latest/commands/ft.create/">FT.CREATE</a>
@@ -87,7 +87,7 @@ public interface RediSearchAsyncCommands<K, V> {
      * triggered, where N is the number of keys in the keyspace
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param arguments the index {@link CreateArgs} containing configuration options
      * @param fieldArgs the {@link FieldArgs} list defining the searchable fields and their types
      * @return {@code "OK"} if the index was created successfully

--- a/src/main/java/io/lettuce/core/api/reactive/RediSearchReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RediSearchReactiveCommands.java
@@ -58,11 +58,11 @@ public interface RediSearchReactiveCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.create/">FT.CREATE</a>
      * @see CreateArgs
      * @see FieldArgs
-     * @see #ftCreate(Object, CreateArgs, List)
-     * @see #ftDropindex(Object)
+     * @see #ftCreate(String, CreateArgs, List)
+     * @see #ftDropindex(String)
      */
     @Experimental
-    Mono<String> ftCreate(K index, List<FieldArgs<K>> fieldArgs);
+    Mono<String> ftCreate(String index, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Create a new search index with the given name, custom configuration, and field definitions.
@@ -97,11 +97,11 @@ public interface RediSearchReactiveCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.create/">FT.CREATE</a>
      * @see CreateArgs
      * @see FieldArgs
-     * @see #ftCreate(Object, List)
-     * @see #ftDropindex(Object)
+     * @see #ftCreate(String, List)
+     * @see #ftDropindex(String)
      */
     @Experimental
-    Mono<String> ftCreate(K index, CreateArgs<K, V> arguments, List<FieldArgs<K>> fieldArgs);
+    Mono<String> ftCreate(String index, CreateArgs<K, V> arguments, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Add an alias to a search index.
@@ -129,7 +129,7 @@ public interface RediSearchReactiveCommands<K, V> {
      * <li>An index can have multiple aliases, but an alias can only point to one index</li>
      * <li>Aliases cannot reference other aliases (no alias chaining)</li>
      * <li>If the alias already exists, this command will fail with an error</li>
-     * <li>Use {@link #ftAliasupdate(Object, Object)} to reassign an existing alias</li>
+     * <li>Use {@link #ftAliasupdate(String, String)} to reassign an existing alias</li>
      * </ul>
      *
      * <p>
@@ -141,18 +141,18 @@ public interface RediSearchReactiveCommands<K, V> {
      * @return {@code "OK"} if the alias was successfully created
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.aliasadd/">FT.ALIASADD</a>
-     * @see #ftAliasupdate(Object, Object)
-     * @see #ftAliasdel(Object)
+     * @see #ftAliasupdate(String, String)
+     * @see #ftAliasdel(String)
      */
     @Experimental
-    Mono<String> ftAliasadd(K alias, K index);
+    Mono<String> ftAliasadd(String alias, String index);
 
     /**
      * Update an existing alias to point to a different search index.
      *
      * <p>
      * This command updates an existing alias to point to a different index, or creates the alias if it doesn't exist. Unlike
-     * {@link #ftAliasadd(Object, Object)}, this command will succeed even if the alias already exists, making it useful for
+     * {@link #ftAliasadd(String, String)}, this command will succeed even if the alias already exists, making it useful for
      * atomic alias updates during index migrations.
      * </p>
      *
@@ -185,11 +185,11 @@ public interface RediSearchReactiveCommands<K, V> {
      * @return {@code "OK"} if the alias was successfully updated
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.aliasupdate/">FT.ALIASUPDATE</a>
-     * @see #ftAliasadd(Object, Object)
-     * @see #ftAliasdel(Object)
+     * @see #ftAliasadd(String, String)
+     * @see #ftAliasdel(String)
      */
     @Experimental
-    Mono<String> ftAliasupdate(K alias, K index);
+    Mono<String> ftAliasupdate(String alias, String index);
 
     /**
      * Remove an alias from a search index.
@@ -216,7 +216,7 @@ public interface RediSearchReactiveCommands<K, V> {
      * <li>Only the alias is removed - the target index is not affected</li>
      * <li>If the alias doesn't exist, this command will fail with an error</li>
      * <li>Applications using the alias will receive errors after deletion</li>
-     * <li>Consider using {@link #ftAliasupdate(Object, Object)} to redirect before deletion</li>
+     * <li>Consider using {@link #ftAliasupdate(String, String)} to redirect before deletion</li>
      * </ul>
      *
      * <p>
@@ -227,11 +227,11 @@ public interface RediSearchReactiveCommands<K, V> {
      * @return {@code "OK"} if the alias was successfully removed
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.aliasdel/">FT.ALIASDEL</a>
-     * @see #ftAliasadd(Object, Object)
-     * @see #ftAliasupdate(Object, Object)
+     * @see #ftAliasadd(String, String)
+     * @see #ftAliasupdate(String, String)
      */
     @Experimental
-    Mono<String> ftAliasdel(K alias);
+    Mono<String> ftAliasdel(String alias);
 
     /**
      * Add new attributes to an existing search index.
@@ -274,11 +274,11 @@ public interface RediSearchReactiveCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.alter/">FT.ALTER</a>
      * @see FieldArgs
-     * @see #ftCreate(Object, List)
-     * @see #ftCreate(Object, CreateArgs, List)
+     * @see #ftCreate(String, List)
+     * @see #ftCreate(String, CreateArgs, List)
      */
     @Experimental
-    Mono<String> ftAlter(K index, boolean skipInitialScan, List<FieldArgs<K>> fieldArgs);
+    Mono<String> ftAlter(String index, boolean skipInitialScan, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Add new attributes to an existing search index.
@@ -309,11 +309,11 @@ public interface RediSearchReactiveCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.alter/">FT.ALTER</a>
      * @see FieldArgs
-     * @see #ftCreate(Object, List)
-     * @see #ftCreate(Object, CreateArgs, List)
+     * @see #ftCreate(String, List)
+     * @see #ftCreate(String, CreateArgs, List)
      */
     @Experimental
-    Mono<String> ftAlter(K index, List<FieldArgs<K>> fieldArgs);
+    Mono<String> ftAlter(String index, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Return a distinct set of values indexed in a Tag field.
@@ -365,11 +365,11 @@ public interface RediSearchReactiveCommands<K, V> {
      *         were indexed (lowercase, whitespace removed).
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.tagvals/">FT.TAGVALS</a>
-     * @see #ftCreate(Object, List)
-     * @see #ftCreate(Object, CreateArgs, List)
+     * @see #ftCreate(String, List)
+     * @see #ftCreate(String, CreateArgs, List)
      */
     @Experimental
-    Flux<V> ftTagvals(String index, K fieldName);
+    Flux<V> ftTagvals(String index, String fieldName);
 
     /**
      * Perform spelling correction on a query, returning suggestions for misspelled terms.
@@ -405,8 +405,8 @@ public interface RediSearchReactiveCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
      * @see #ftSpellcheck(String, Object, SpellCheckArgs)
-     * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictadd(String, Object[])
+     * @see #ftDictdel(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
@@ -442,8 +442,8 @@ public interface RediSearchReactiveCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
      * @see #ftSpellcheck(String, Object)
-     * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictadd(String, Object[])
+     * @see #ftDictdel(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
@@ -477,11 +477,11 @@ public interface RediSearchReactiveCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictadd/">FT.DICTADD</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictdel(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
-    Mono<Long> ftDictadd(K dict, V... terms);
+    Mono<Long> ftDictadd(String dict, V... terms);
 
     /**
      * Delete terms from a dictionary.
@@ -500,11 +500,11 @@ public interface RediSearchReactiveCommands<K, V> {
      * @return the number of terms that were deleted
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictdel/">FT.DICTDEL</a>
-     * @see #ftDictadd(Object, Object[])
+     * @see #ftDictadd(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
-    Mono<Long> ftDictdel(K dict, V... terms);
+    Mono<Long> ftDictdel(String dict, V... terms);
 
     /**
      * Dump all terms in a dictionary.
@@ -521,8 +521,8 @@ public interface RediSearchReactiveCommands<K, V> {
      * @return a list of all terms in the dictionary
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictdump/">FT.DICTDUMP</a>
-     * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictadd(String, Object[])
+     * @see #ftDictdel(String, Object[])
      */
     @Experimental
     Flux<V> ftDictdump(String dict);
@@ -621,8 +621,8 @@ public interface RediSearchReactiveCommands<K, V> {
      * @return a list of index names
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft._list/">FT._LIST</a>
-     * @see #ftCreate(Object, CreateArgs, FieldArgs[])
-     * @see #ftDropindex(Object)
+     * @see #ftCreate(String, CreateArgs, FieldArgs[])
+     * @see #ftDropindex(String)
      */
     @Experimental
     Flux<V> ftList();
@@ -653,8 +653,8 @@ public interface RediSearchReactiveCommands<K, V> {
      * @return a map where keys are synonym terms and values are lists of group IDs containing that synonym
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.syndump/">FT.SYNDUMP</a>
-     * @see #ftSynupdate(Object, Object, Object[])
-     * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
+     * @see #ftSynupdate(String, Object, Object[])
+     * @see #ftSynupdate(String, Object, SynUpdateArgs, Object[])
      */
     @Experimental
     Mono<Map<V, List<V>>> ftSyndump(String index);
@@ -687,11 +687,11 @@ public interface RediSearchReactiveCommands<K, V> {
      * @return OK if executed correctly
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
-     * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
+     * @see #ftSynupdate(String, Object, SynUpdateArgs, Object[])
      * @see #ftSyndump(String)
      */
     @Experimental
-    Mono<String> ftSynupdate(K index, V synonymGroupId, V... terms);
+    Mono<String> ftSynupdate(String index, V synonymGroupId, V... terms);
 
     /**
      * Update a synonym group with additional terms and options.
@@ -719,11 +719,11 @@ public interface RediSearchReactiveCommands<K, V> {
      * @return OK if executed correctly
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
-     * @see #ftSynupdate(Object, Object, Object[])
+     * @see #ftSynupdate(String, Object, Object[])
      * @see #ftSyndump(String)
      */
     @Experimental
-    Mono<String> ftSynupdate(K index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms);
+    Mono<String> ftSynupdate(String index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms);
 
     /**
      * Add a suggestion string to an auto-complete suggestion dictionary.
@@ -903,11 +903,11 @@ public interface RediSearchReactiveCommands<K, V> {
      * @return {@code "OK"} if the index was successfully dropped
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dropindex/">FT.DROPINDEX</a>
-     * @see #ftDropindex(Object, boolean)
-     * @see #ftCreate(Object, List)
+     * @see #ftDropindex(String, boolean)
+     * @see #ftCreate(String, List)
      */
     @Experimental
-    Mono<String> ftDropindex(K index);
+    Mono<String> ftDropindex(String index);
 
     /**
      * Drop a search index with optional document deletion.
@@ -919,7 +919,7 @@ public interface RediSearchReactiveCommands<K, V> {
      * </p>
      *
      * <p>
-     * <strong>Asynchronous Behavior:</strong> If an index creation is still running ({@link #ftCreate(Object, List)} is running
+     * <strong>Asynchronous Behavior:</strong> If an index creation is still running ({@link #ftCreate(String, List)} is running
      * asynchronously), only the document hashes that have already been indexed are deleted. Documents that are queued for
      * indexing but not yet processed will remain in the database.
      * </p>
@@ -933,11 +933,11 @@ public interface RediSearchReactiveCommands<K, V> {
      * @return {@code "OK"} if the index was successfully dropped
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dropindex/">FT.DROPINDEX</a>
-     * @see #ftDropindex(Object)
-     * @see #ftCreate(Object, List)
+     * @see #ftDropindex(String)
+     * @see #ftCreate(String, List)
      */
     @Experimental
-    Mono<String> ftDropindex(K index, boolean deleteDocuments);
+    Mono<String> ftDropindex(String index, boolean deleteDocuments);
 
     /**
      * Search the index with a textual query using default search options.

--- a/src/main/java/io/lettuce/core/api/reactive/RediSearchReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RediSearchReactiveCommands.java
@@ -369,7 +369,7 @@ public interface RediSearchReactiveCommands<K, V> {
      * @see #ftCreate(Object, CreateArgs, List)
      */
     @Experimental
-    Flux<V> ftTagvals(K index, K fieldName);
+    Flux<V> ftTagvals(String index, K fieldName);
 
     /**
      * Perform spelling correction on a query, returning suggestions for misspelled terms.
@@ -404,13 +404,13 @@ public interface RediSearchReactiveCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
-     * @see #ftSpellcheck(Object, Object, SpellCheckArgs)
+     * @see #ftSpellcheck(String, Object, SpellCheckArgs)
      * @see #ftDictadd(Object, Object[])
      * @see #ftDictdel(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
-    Mono<SpellCheckResult<V>> ftSpellcheck(K index, V query);
+    Mono<SpellCheckResult<V>> ftSpellcheck(String index, V query);
 
     /**
      * Perform spelling correction on a query with additional options.
@@ -441,13 +441,13 @@ public interface RediSearchReactiveCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
-     * @see #ftSpellcheck(Object, Object)
+     * @see #ftSpellcheck(String, Object)
      * @see #ftDictadd(Object, Object[])
      * @see #ftDictdel(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
-    Mono<SpellCheckResult<V>> ftSpellcheck(K index, V query, SpellCheckArgs<K, V> args);
+    Mono<SpellCheckResult<V>> ftSpellcheck(String index, V query, SpellCheckArgs<K, V> args);
 
     /**
      * Add terms to a dictionary.
@@ -478,7 +478,7 @@ public interface RediSearchReactiveCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictadd/">FT.DICTADD</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
      * @see #ftDictdel(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
     Mono<Long> ftDictadd(K dict, V... terms);
@@ -501,7 +501,7 @@ public interface RediSearchReactiveCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictdel/">FT.DICTDEL</a>
      * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
     Mono<Long> ftDictdel(K dict, V... terms);
@@ -525,7 +525,7 @@ public interface RediSearchReactiveCommands<K, V> {
      * @see #ftDictdel(Object, Object[])
      */
     @Experimental
-    Flux<V> ftDictdump(K dict);
+    Flux<V> ftDictdump(String dict);
 
     /**
      * Return the execution plan for a complex query.
@@ -554,11 +554,11 @@ public interface RediSearchReactiveCommands<K, V> {
      * @return the execution plan as a string
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.explain/">FT.EXPLAIN</a>
-     * @see #ftExplain(Object, Object, ExplainArgs)
-     * @see #ftSearch(Object, Object)
+     * @see #ftExplain(String, Object, ExplainArgs)
+     * @see #ftSearch(String, Object)
      */
     @Experimental
-    Mono<String> ftExplain(K index, V query);
+    Mono<String> ftExplain(String index, V query);
 
     /**
      * Return the execution plan for a complex query with additional options.
@@ -585,11 +585,11 @@ public interface RediSearchReactiveCommands<K, V> {
      * @return the execution plan as a string
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.explain/">FT.EXPLAIN</a>
-     * @see #ftExplain(Object, Object)
-     * @see #ftSearch(Object, Object)
+     * @see #ftExplain(String, Object)
+     * @see #ftSearch(String, Object)
      */
     @Experimental
-    Mono<String> ftExplain(K index, V query, ExplainArgs<K, V> args);
+    Mono<String> ftExplain(String index, V query, ExplainArgs<K, V> args);
 
     /**
      * Return a list of all existing indexes.
@@ -657,7 +657,7 @@ public interface RediSearchReactiveCommands<K, V> {
      * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
      */
     @Experimental
-    Mono<Map<V, List<V>>> ftSyndump(K index);
+    Mono<Map<V, List<V>>> ftSyndump(String index);
 
     /**
      * Update a synonym group with additional terms.
@@ -688,7 +688,7 @@ public interface RediSearchReactiveCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
      * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
-     * @see #ftSyndump(Object)
+     * @see #ftSyndump(String)
      */
     @Experimental
     Mono<String> ftSynupdate(K index, V synonymGroupId, V... terms);
@@ -720,7 +720,7 @@ public interface RediSearchReactiveCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
      * @see #ftSynupdate(Object, Object, Object[])
-     * @see #ftSyndump(Object)
+     * @see #ftSyndump(String)
      */
     @Experimental
     Mono<String> ftSynupdate(K index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms);
@@ -973,10 +973,10 @@ public interface RediSearchReactiveCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/develop/interact/search-and-query/query/">Query syntax</a>
      * @see SearchReply
      * @see SearchArgs
-     * @see #ftSearch(Object, Object, SearchArgs)
+     * @see #ftSearch(String, Object, SearchArgs)
      */
     @Experimental
-    Mono<SearchReply<K, V>> ftSearch(K index, V query);
+    Mono<SearchReply<K, V>> ftSearch(String index, V query);
 
     /**
      * Search the index with a textual query using advanced search options and filters.
@@ -1024,23 +1024,23 @@ public interface RediSearchReactiveCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/">Advanced concepts</a>
      * @see SearchReply
      * @see SearchArgs
-     * @see #ftSearch(Object, Object)
+     * @see #ftSearch(String, Object)
      */
     @Experimental
-    Mono<SearchReply<K, V>> ftSearch(K index, V query, SearchArgs<K, V> args);
+    Mono<SearchReply<K, V>> ftSearch(String index, V query, SearchArgs<K, V> args);
 
     /**
      * Run a search query on an index and perform basic aggregate transformations using default options.
      *
      * <p>
      * This command executes a search query and applies aggregation operations to transform and analyze the results. Unlike
-     * {@link #ftSearch(Object, Object)}, which returns individual documents, FT.AGGREGATE processes the result set through a
+     * {@link #ftSearch(String, Object)}, which returns individual documents, FT.AGGREGATE processes the result set through a
      * pipeline of transformations to produce analytical insights, summaries, and computed values.
      * </p>
      *
      * <p>
      * This basic variant uses default aggregation behavior without additional pipeline operations. For advanced aggregations
-     * with grouping, sorting, filtering, and custom transformations, use {@link #ftAggregate(Object, Object, AggregateArgs)}.
+     * with grouping, sorting, filtering, and custom transformations, use {@link #ftAggregate(String, Object, AggregateArgs)}.
      * </p>
      *
      * <p>
@@ -1066,10 +1066,10 @@ public interface RediSearchReactiveCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/">Aggregations</a>
      * @see SearchReply
      * @see AggregateArgs
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
-    Mono<AggregationReply<K, V>> ftAggregate(K index, V query);
+    Mono<AggregationReply<K, V>> ftAggregate(String index, V query);
 
     /**
      * Run a search query on an index and perform advanced aggregate transformations with a processing pipeline.
@@ -1121,18 +1121,18 @@ public interface RediSearchReactiveCommands<K, V> {
      *      API</a>
      * @see SearchReply
      * @see AggregateArgs
-     * @see #ftAggregate(Object, Object)
+     * @see #ftAggregate(String, Object)
      * @see #ftCursorread(Object, long)
      */
     @Experimental
-    Mono<AggregationReply<K, V>> ftAggregate(K index, V query, AggregateArgs<K, V> args);
+    Mono<AggregationReply<K, V>> ftAggregate(String index, V query, AggregateArgs<K, V> args);
 
     /**
      * Read next results from an existing cursor.
      *
      * <p>
      * This command is used to read the next batch of results from a cursor created by
-     * {@link #ftAggregate(Object, Object, AggregateArgs)} with the {@code WITHCURSOR} option. Cursors provide an efficient way
+     * {@link #ftAggregate(String, Object, AggregateArgs)} with the {@code WITHCURSOR} option. Cursors provide an efficient way
      * to iterate through large result sets without loading all results into memory at once.
      * </p>
      *
@@ -1156,7 +1156,7 @@ public interface RediSearchReactiveCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
      * @see SearchReply
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
     Mono<AggregationReply<K, V>> ftCursorread(K index, long cursorId, int count);
@@ -1166,7 +1166,7 @@ public interface RediSearchReactiveCommands<K, V> {
      *
      * <p>
      * This command is used to read the next batch of results from a cursor created by
-     * {@link #ftAggregate(Object, Object, AggregateArgs)} with the {@code WITHCURSOR} option. This variant uses the default
+     * {@link #ftAggregate(String, Object, AggregateArgs)} with the {@code WITHCURSOR} option. This variant uses the default
      * batch size that was specified in the original {@code FT.AGGREGATE} command's {@code WITHCURSOR} clause.
      * </p>
      *
@@ -1189,7 +1189,7 @@ public interface RediSearchReactiveCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
      * @see SearchReply
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
     Mono<AggregationReply<K, V>> ftCursorread(K index, long cursorId);
@@ -1198,7 +1198,7 @@ public interface RediSearchReactiveCommands<K, V> {
      * Delete a cursor and free its associated resources.
      *
      * <p>
-     * This command is used to explicitly delete a cursor created by {@link #ftAggregate(Object, Object, AggregateArgs)} with
+     * This command is used to explicitly delete a cursor created by {@link #ftAggregate(String, Object, AggregateArgs)} with
      * the {@code WITHCURSOR} option. Deleting a cursor frees up server resources and should be done when you no longer need to
      * read more results from the cursor.
      * </p>
@@ -1226,7 +1226,7 @@ public interface RediSearchReactiveCommands<K, V> {
      * @see <a href=
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      * @see #ftCursorread(Object, long)
      * @see #ftCursorread(Object, long, int)
      */

--- a/src/main/java/io/lettuce/core/api/reactive/RediSearchReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RediSearchReactiveCommands.java
@@ -1122,7 +1122,7 @@ public interface RediSearchReactiveCommands<K, V> {
      * @see SearchReply
      * @see AggregateArgs
      * @see #ftAggregate(String, Object)
-     * @see #ftCursorread(Object, long)
+     * @see #ftCursorread(String, long)
      */
     @Experimental
     Mono<AggregationReply<K, V>> ftAggregate(String index, V query, AggregateArgs<K, V> args);
@@ -1145,7 +1145,7 @@ public interface RediSearchReactiveCommands<K, V> {
      * <strong>Time complexity:</strong> O(1)
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param cursorId the cursor id obtained from a previous {@code FT.AGGREGATE} or {@code FT.CURSOR READ} command
      * @param count the number of results to read. This parameter overrides the {@code COUNT} specified in {@code FT.AGGREGATE}
      * @return the result of the cursor read command containing the next batch of results and potentially a new cursor id, see
@@ -1159,7 +1159,7 @@ public interface RediSearchReactiveCommands<K, V> {
      * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
-    Mono<AggregationReply<K, V>> ftCursorread(K index, long cursorId, int count);
+    Mono<AggregationReply<K, V>> ftCursorread(String index, long cursorId, int count);
 
     /**
      * Read next results from an existing cursor using the default batch size.
@@ -1179,7 +1179,7 @@ public interface RediSearchReactiveCommands<K, V> {
      * <strong>Time complexity:</strong> O(1)
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param cursorId the cursor id obtained from a previous {@code FT.AGGREGATE} or {@code FT.CURSOR READ} command
      * @return the result of the cursor read command containing the next batch of results and potentially a new cursor id, see
      *         {@link SearchReply}
@@ -1192,7 +1192,7 @@ public interface RediSearchReactiveCommands<K, V> {
      * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
-    Mono<AggregationReply<K, V>> ftCursorread(K index, long cursorId);
+    Mono<AggregationReply<K, V>> ftCursorread(String index, long cursorId);
 
     /**
      * Delete a cursor and free its associated resources.
@@ -1210,8 +1210,8 @@ public interface RediSearchReactiveCommands<K, V> {
      * </p>
      *
      * <p>
-     * Once a cursor is deleted, any subsequent attempts to read from it using {@link #ftCursorread(Object, long)} or
-     * {@link #ftCursorread(Object, long, int)} will result in an error.
+     * Once a cursor is deleted, any subsequent attempts to read from it using {@link #ftCursorread(String, long)} or
+     * {@link #ftCursorread(String, long, int)} will result in an error.
      * </p>
      *
      * <p>
@@ -1227,10 +1227,10 @@ public interface RediSearchReactiveCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
      * @see #ftAggregate(String, Object, AggregateArgs)
-     * @see #ftCursorread(Object, long)
-     * @see #ftCursorread(Object, long, int)
+     * @see #ftCursorread(String, long)
+     * @see #ftCursorread(String, long, int)
      */
     @Experimental
-    Mono<String> ftCursordel(K index, long cursorId);
+    Mono<String> ftCursordel(String index, long cursorId);
 
 }

--- a/src/main/java/io/lettuce/core/api/reactive/RediSearchReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RediSearchReactiveCommands.java
@@ -52,7 +52,7 @@ public interface RediSearchReactiveCommands<K, V> {
      * triggered, where N is the number of keys in the keyspace
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param fieldArgs the {@link FieldArgs} list defining the searchable fields and their types
      * @return {@code "OK"} if the index was created successfully
      * @see <a href="https://redis.io/docs/latest/commands/ft.create/">FT.CREATE</a>
@@ -89,7 +89,7 @@ public interface RediSearchReactiveCommands<K, V> {
      * triggered, where N is the number of keys in the keyspace
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param arguments the index {@link CreateArgs} containing configuration options
      * @param fieldArgs the {@link FieldArgs} list defining the searchable fields and their types
      * @return {@code "OK"} if the index was created successfully

--- a/src/main/java/io/lettuce/core/api/sync/RediSearchCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RediSearchCommands.java
@@ -56,11 +56,11 @@ public interface RediSearchCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.create/">FT.CREATE</a>
      * @see CreateArgs
      * @see FieldArgs
-     * @see #ftCreate(Object, CreateArgs, List)
-     * @see #ftDropindex(Object)
+     * @see #ftCreate(String, CreateArgs, List)
+     * @see #ftDropindex(String)
      */
     @Experimental
-    String ftCreate(K index, List<FieldArgs<K>> fieldArgs);
+    String ftCreate(String index, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Create a new search index with the given name, custom configuration, and field definitions.
@@ -95,11 +95,11 @@ public interface RediSearchCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.create/">FT.CREATE</a>
      * @see CreateArgs
      * @see FieldArgs
-     * @see #ftCreate(Object, List)
-     * @see #ftDropindex(Object)
+     * @see #ftCreate(String, List)
+     * @see #ftDropindex(String)
      */
     @Experimental
-    String ftCreate(K index, CreateArgs<K, V> arguments, List<FieldArgs<K>> fieldArgs);
+    String ftCreate(String index, CreateArgs<K, V> arguments, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Add an alias to a search index.
@@ -127,7 +127,7 @@ public interface RediSearchCommands<K, V> {
      * <li>An index can have multiple aliases, but an alias can only point to one index</li>
      * <li>Aliases cannot reference other aliases (no alias chaining)</li>
      * <li>If the alias already exists, this command will fail with an error</li>
-     * <li>Use {@link #ftAliasupdate(Object, Object)} to reassign an existing alias</li>
+     * <li>Use {@link #ftAliasupdate(String, String)} to reassign an existing alias</li>
      * </ul>
      *
      * <p>
@@ -139,18 +139,18 @@ public interface RediSearchCommands<K, V> {
      * @return {@code "OK"} if the alias was successfully created
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.aliasadd/">FT.ALIASADD</a>
-     * @see #ftAliasupdate(Object, Object)
-     * @see #ftAliasdel(Object)
+     * @see #ftAliasupdate(String, String)
+     * @see #ftAliasdel(String)
      */
     @Experimental
-    String ftAliasadd(K alias, K index);
+    String ftAliasadd(String alias, String index);
 
     /**
      * Update an existing alias to point to a different search index.
      *
      * <p>
      * This command updates an existing alias to point to a different index, or creates the alias if it doesn't exist. Unlike
-     * {@link #ftAliasadd(Object, Object)}, this command will succeed even if the alias already exists, making it useful for
+     * {@link #ftAliasadd(String, String)}, this command will succeed even if the alias already exists, making it useful for
      * atomic alias updates during index migrations.
      * </p>
      *
@@ -183,11 +183,11 @@ public interface RediSearchCommands<K, V> {
      * @return {@code "OK"} if the alias was successfully updated
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.aliasupdate/">FT.ALIASUPDATE</a>
-     * @see #ftAliasadd(Object, Object)
-     * @see #ftAliasdel(Object)
+     * @see #ftAliasadd(String, String)
+     * @see #ftAliasdel(String)
      */
     @Experimental
-    String ftAliasupdate(K alias, K index);
+    String ftAliasupdate(String alias, String index);
 
     /**
      * Remove an alias from a search index.
@@ -214,7 +214,7 @@ public interface RediSearchCommands<K, V> {
      * <li>Only the alias is removed - the target index is not affected</li>
      * <li>If the alias doesn't exist, this command will fail with an error</li>
      * <li>Applications using the alias will receive errors after deletion</li>
-     * <li>Consider using {@link #ftAliasupdate(Object, Object)} to redirect before deletion</li>
+     * <li>Consider using {@link #ftAliasupdate(String, String)} to redirect before deletion</li>
      * </ul>
      *
      * <p>
@@ -225,11 +225,11 @@ public interface RediSearchCommands<K, V> {
      * @return {@code "OK"} if the alias was successfully removed
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.aliasdel/">FT.ALIASDEL</a>
-     * @see #ftAliasadd(Object, Object)
-     * @see #ftAliasupdate(Object, Object)
+     * @see #ftAliasadd(String, String)
+     * @see #ftAliasupdate(String, String)
      */
     @Experimental
-    String ftAliasdel(K alias);
+    String ftAliasdel(String alias);
 
     /**
      * Add new attributes to an existing search index.
@@ -272,11 +272,11 @@ public interface RediSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.alter/">FT.ALTER</a>
      * @see FieldArgs
-     * @see #ftCreate(Object, List)
-     * @see #ftCreate(Object, CreateArgs, List)
+     * @see #ftCreate(String, List)
+     * @see #ftCreate(String, CreateArgs, List)
      */
     @Experimental
-    String ftAlter(K index, boolean skipInitialScan, List<FieldArgs<K>> fieldArgs);
+    String ftAlter(String index, boolean skipInitialScan, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Add new attributes to an existing search index.
@@ -307,11 +307,11 @@ public interface RediSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.alter/">FT.ALTER</a>
      * @see FieldArgs
-     * @see #ftCreate(Object, List)
-     * @see #ftCreate(Object, CreateArgs, List)
+     * @see #ftCreate(String, List)
+     * @see #ftCreate(String, CreateArgs, List)
      */
     @Experimental
-    String ftAlter(K index, List<FieldArgs<K>> fieldArgs);
+    String ftAlter(String index, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Return a distinct set of values indexed in a Tag field.
@@ -363,11 +363,11 @@ public interface RediSearchCommands<K, V> {
      *         were indexed (lowercase, whitespace removed).
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.tagvals/">FT.TAGVALS</a>
-     * @see #ftCreate(Object, List)
-     * @see #ftCreate(Object, CreateArgs, List)
+     * @see #ftCreate(String, List)
+     * @see #ftCreate(String, CreateArgs, List)
      */
     @Experimental
-    List<V> ftTagvals(String index, K fieldName);
+    List<V> ftTagvals(String index, String fieldName);
 
     /**
      * Perform spelling correction on a query, returning suggestions for misspelled terms.
@@ -403,8 +403,8 @@ public interface RediSearchCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
      * @see #ftSpellcheck(String, Object, SpellCheckArgs)
-     * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictadd(String, Object[])
+     * @see #ftDictdel(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
@@ -440,8 +440,8 @@ public interface RediSearchCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
      * @see #ftSpellcheck(String, Object)
-     * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictadd(String, Object[])
+     * @see #ftDictdel(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
@@ -475,11 +475,11 @@ public interface RediSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictadd/">FT.DICTADD</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictdel(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
-    Long ftDictadd(K dict, V... terms);
+    Long ftDictadd(String dict, V... terms);
 
     /**
      * Delete terms from a dictionary.
@@ -498,11 +498,11 @@ public interface RediSearchCommands<K, V> {
      * @return the number of terms that were deleted
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictdel/">FT.DICTDEL</a>
-     * @see #ftDictadd(Object, Object[])
+     * @see #ftDictadd(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
-    Long ftDictdel(K dict, V... terms);
+    Long ftDictdel(String dict, V... terms);
 
     /**
      * Dump all terms in a dictionary.
@@ -519,8 +519,8 @@ public interface RediSearchCommands<K, V> {
      * @return a list of all terms in the dictionary
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictdump/">FT.DICTDUMP</a>
-     * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictadd(String, Object[])
+     * @see #ftDictdel(String, Object[])
      */
     @Experimental
     List<V> ftDictdump(String dict);
@@ -619,8 +619,8 @@ public interface RediSearchCommands<K, V> {
      * @return a list of index names
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft._list/">FT._LIST</a>
-     * @see #ftCreate(Object, CreateArgs, FieldArgs[])
-     * @see #ftDropindex(Object)
+     * @see #ftCreate(String, CreateArgs, FieldArgs[])
+     * @see #ftDropindex(String)
      */
     @Experimental
     List<V> ftList();
@@ -651,8 +651,8 @@ public interface RediSearchCommands<K, V> {
      * @return a map where keys are synonym terms and values are lists of group IDs containing that synonym
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.syndump/">FT.SYNDUMP</a>
-     * @see #ftSynupdate(Object, Object, Object[])
-     * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
+     * @see #ftSynupdate(String, Object, Object[])
+     * @see #ftSynupdate(String, Object, SynUpdateArgs, Object[])
      */
     @Experimental
     Map<V, List<V>> ftSyndump(String index);
@@ -685,11 +685,11 @@ public interface RediSearchCommands<K, V> {
      * @return OK if executed correctly
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
-     * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
+     * @see #ftSynupdate(String, Object, SynUpdateArgs, Object[])
      * @see #ftSyndump(String)
      */
     @Experimental
-    String ftSynupdate(K index, V synonymGroupId, V... terms);
+    String ftSynupdate(String index, V synonymGroupId, V... terms);
 
     /**
      * Update a synonym group with additional terms and options.
@@ -717,11 +717,11 @@ public interface RediSearchCommands<K, V> {
      * @return OK if executed correctly
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
-     * @see #ftSynupdate(Object, Object, Object[])
+     * @see #ftSynupdate(String, Object, Object[])
      * @see #ftSyndump(String)
      */
     @Experimental
-    String ftSynupdate(K index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms);
+    String ftSynupdate(String index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms);
 
     /**
      * Add a suggestion string to an auto-complete suggestion dictionary.
@@ -901,11 +901,11 @@ public interface RediSearchCommands<K, V> {
      * @return {@code "OK"} if the index was successfully dropped
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dropindex/">FT.DROPINDEX</a>
-     * @see #ftDropindex(Object, boolean)
-     * @see #ftCreate(Object, List)
+     * @see #ftDropindex(String, boolean)
+     * @see #ftCreate(String, List)
      */
     @Experimental
-    String ftDropindex(K index);
+    String ftDropindex(String index);
 
     /**
      * Drop a search index with optional document deletion.
@@ -917,7 +917,7 @@ public interface RediSearchCommands<K, V> {
      * </p>
      *
      * <p>
-     * <strong>Asynchronous Behavior:</strong> If an index creation is still running ({@link #ftCreate(Object, List)} is running
+     * <strong>Asynchronous Behavior:</strong> If an index creation is still running ({@link #ftCreate(String, List)} is running
      * asynchronously), only the document hashes that have already been indexed are deleted. Documents that are queued for
      * indexing but not yet processed will remain in the database.
      * </p>
@@ -931,11 +931,11 @@ public interface RediSearchCommands<K, V> {
      * @return {@code "OK"} if the index was successfully dropped
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dropindex/">FT.DROPINDEX</a>
-     * @see #ftDropindex(Object)
-     * @see #ftCreate(Object, List)
+     * @see #ftDropindex(String)
+     * @see #ftCreate(String, List)
      */
     @Experimental
-    String ftDropindex(K index, boolean deleteDocuments);
+    String ftDropindex(String index, boolean deleteDocuments);
 
     /**
      * Search the index with a textual query using default search options.

--- a/src/main/java/io/lettuce/core/api/sync/RediSearchCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RediSearchCommands.java
@@ -367,7 +367,7 @@ public interface RediSearchCommands<K, V> {
      * @see #ftCreate(Object, CreateArgs, List)
      */
     @Experimental
-    List<V> ftTagvals(K index, K fieldName);
+    List<V> ftTagvals(String index, K fieldName);
 
     /**
      * Perform spelling correction on a query, returning suggestions for misspelled terms.
@@ -402,13 +402,13 @@ public interface RediSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
-     * @see #ftSpellcheck(Object, Object, SpellCheckArgs)
+     * @see #ftSpellcheck(String, Object, SpellCheckArgs)
      * @see #ftDictadd(Object, Object[])
      * @see #ftDictdel(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
-    SpellCheckResult<V> ftSpellcheck(K index, V query);
+    SpellCheckResult<V> ftSpellcheck(String index, V query);
 
     /**
      * Perform spelling correction on a query with additional options.
@@ -439,13 +439,13 @@ public interface RediSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
-     * @see #ftSpellcheck(Object, Object)
+     * @see #ftSpellcheck(String, Object)
      * @see #ftDictadd(Object, Object[])
      * @see #ftDictdel(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
-    SpellCheckResult<V> ftSpellcheck(K index, V query, SpellCheckArgs<K, V> args);
+    SpellCheckResult<V> ftSpellcheck(String index, V query, SpellCheckArgs<K, V> args);
 
     /**
      * Add terms to a dictionary.
@@ -476,7 +476,7 @@ public interface RediSearchCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictadd/">FT.DICTADD</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
      * @see #ftDictdel(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
     Long ftDictadd(K dict, V... terms);
@@ -499,7 +499,7 @@ public interface RediSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictdel/">FT.DICTDEL</a>
      * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
     Long ftDictdel(K dict, V... terms);
@@ -523,7 +523,7 @@ public interface RediSearchCommands<K, V> {
      * @see #ftDictdel(Object, Object[])
      */
     @Experimental
-    List<V> ftDictdump(K dict);
+    List<V> ftDictdump(String dict);
 
     /**
      * Return the execution plan for a complex query.
@@ -552,11 +552,11 @@ public interface RediSearchCommands<K, V> {
      * @return the execution plan as a string
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.explain/">FT.EXPLAIN</a>
-     * @see #ftExplain(Object, Object, ExplainArgs)
-     * @see #ftSearch(Object, Object)
+     * @see #ftExplain(String, Object, ExplainArgs)
+     * @see #ftSearch(String, Object)
      */
     @Experimental
-    String ftExplain(K index, V query);
+    String ftExplain(String index, V query);
 
     /**
      * Return the execution plan for a complex query with additional options.
@@ -583,11 +583,11 @@ public interface RediSearchCommands<K, V> {
      * @return the execution plan as a string
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.explain/">FT.EXPLAIN</a>
-     * @see #ftExplain(Object, Object)
-     * @see #ftSearch(Object, Object)
+     * @see #ftExplain(String, Object)
+     * @see #ftSearch(String, Object)
      */
     @Experimental
-    String ftExplain(K index, V query, ExplainArgs<K, V> args);
+    String ftExplain(String index, V query, ExplainArgs<K, V> args);
 
     /**
      * Return a list of all existing indexes.
@@ -655,7 +655,7 @@ public interface RediSearchCommands<K, V> {
      * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
      */
     @Experimental
-    Map<V, List<V>> ftSyndump(K index);
+    Map<V, List<V>> ftSyndump(String index);
 
     /**
      * Update a synonym group with additional terms.
@@ -686,7 +686,7 @@ public interface RediSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
      * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
-     * @see #ftSyndump(Object)
+     * @see #ftSyndump(String)
      */
     @Experimental
     String ftSynupdate(K index, V synonymGroupId, V... terms);
@@ -718,7 +718,7 @@ public interface RediSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
      * @see #ftSynupdate(Object, Object, Object[])
-     * @see #ftSyndump(Object)
+     * @see #ftSyndump(String)
      */
     @Experimental
     String ftSynupdate(K index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms);
@@ -971,10 +971,10 @@ public interface RediSearchCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/develop/interact/search-and-query/query/">Query syntax</a>
      * @see SearchReply
      * @see SearchArgs
-     * @see #ftSearch(Object, Object, SearchArgs)
+     * @see #ftSearch(String, Object, SearchArgs)
      */
     @Experimental
-    SearchReply<K, V> ftSearch(K index, V query);
+    SearchReply<K, V> ftSearch(String index, V query);
 
     /**
      * Search the index with a textual query using advanced search options and filters.
@@ -1022,23 +1022,23 @@ public interface RediSearchCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/">Advanced concepts</a>
      * @see SearchReply
      * @see SearchArgs
-     * @see #ftSearch(Object, Object)
+     * @see #ftSearch(String, Object)
      */
     @Experimental
-    SearchReply<K, V> ftSearch(K index, V query, SearchArgs<K, V> args);
+    SearchReply<K, V> ftSearch(String index, V query, SearchArgs<K, V> args);
 
     /**
      * Run a search query on an index and perform basic aggregate transformations using default options.
      *
      * <p>
      * This command executes a search query and applies aggregation operations to transform and analyze the results. Unlike
-     * {@link #ftSearch(Object, Object)}, which returns individual documents, FT.AGGREGATE processes the result set through a
+     * {@link #ftSearch(String, Object)}, which returns individual documents, FT.AGGREGATE processes the result set through a
      * pipeline of transformations to produce analytical insights, summaries, and computed values.
      * </p>
      *
      * <p>
      * This basic variant uses default aggregation behavior without additional pipeline operations. For advanced aggregations
-     * with grouping, sorting, filtering, and custom transformations, use {@link #ftAggregate(Object, Object, AggregateArgs)}.
+     * with grouping, sorting, filtering, and custom transformations, use {@link #ftAggregate(String, Object, AggregateArgs)}.
      * </p>
      *
      * <p>
@@ -1064,10 +1064,10 @@ public interface RediSearchCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/">Aggregations</a>
      * @see SearchReply
      * @see AggregateArgs
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
-    AggregationReply<K, V> ftAggregate(K index, V query);
+    AggregationReply<K, V> ftAggregate(String index, V query);
 
     /**
      * Run a search query on an index and perform advanced aggregate transformations with a processing pipeline.
@@ -1119,18 +1119,18 @@ public interface RediSearchCommands<K, V> {
      *      API</a>
      * @see SearchReply
      * @see AggregateArgs
-     * @see #ftAggregate(Object, Object)
+     * @see #ftAggregate(String, Object)
      * @see #ftCursorread(Object, long)
      */
     @Experimental
-    AggregationReply<K, V> ftAggregate(K index, V query, AggregateArgs<K, V> args);
+    AggregationReply<K, V> ftAggregate(String index, V query, AggregateArgs<K, V> args);
 
     /**
      * Read next results from an existing cursor.
      *
      * <p>
      * This command is used to read the next batch of results from a cursor created by
-     * {@link #ftAggregate(Object, Object, AggregateArgs)} with the {@code WITHCURSOR} option. Cursors provide an efficient way
+     * {@link #ftAggregate(String, Object, AggregateArgs)} with the {@code WITHCURSOR} option. Cursors provide an efficient way
      * to iterate through large result sets without loading all results into memory at once.
      * </p>
      *
@@ -1154,7 +1154,7 @@ public interface RediSearchCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
      * @see SearchReply
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
     AggregationReply<K, V> ftCursorread(K index, long cursorId, int count);
@@ -1164,7 +1164,7 @@ public interface RediSearchCommands<K, V> {
      *
      * <p>
      * This command is used to read the next batch of results from a cursor created by
-     * {@link #ftAggregate(Object, Object, AggregateArgs)} with the {@code WITHCURSOR} option. This variant uses the default
+     * {@link #ftAggregate(String, Object, AggregateArgs)} with the {@code WITHCURSOR} option. This variant uses the default
      * batch size that was specified in the original {@code FT.AGGREGATE} command's {@code WITHCURSOR} clause.
      * </p>
      *
@@ -1187,7 +1187,7 @@ public interface RediSearchCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
      * @see SearchReply
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
     AggregationReply<K, V> ftCursorread(K index, long cursorId);
@@ -1196,7 +1196,7 @@ public interface RediSearchCommands<K, V> {
      * Delete a cursor and free its associated resources.
      *
      * <p>
-     * This command is used to explicitly delete a cursor created by {@link #ftAggregate(Object, Object, AggregateArgs)} with
+     * This command is used to explicitly delete a cursor created by {@link #ftAggregate(String, Object, AggregateArgs)} with
      * the {@code WITHCURSOR} option. Deleting a cursor frees up server resources and should be done when you no longer need to
      * read more results from the cursor.
      * </p>
@@ -1224,7 +1224,7 @@ public interface RediSearchCommands<K, V> {
      * @see <a href=
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      * @see #ftCursorread(Object, long)
      * @see #ftCursorread(Object, long, int)
      */

--- a/src/main/java/io/lettuce/core/api/sync/RediSearchCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RediSearchCommands.java
@@ -1120,7 +1120,7 @@ public interface RediSearchCommands<K, V> {
      * @see SearchReply
      * @see AggregateArgs
      * @see #ftAggregate(String, Object)
-     * @see #ftCursorread(Object, long)
+     * @see #ftCursorread(String, long)
      */
     @Experimental
     AggregationReply<K, V> ftAggregate(String index, V query, AggregateArgs<K, V> args);
@@ -1143,7 +1143,7 @@ public interface RediSearchCommands<K, V> {
      * <strong>Time complexity:</strong> O(1)
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param cursorId the cursor id obtained from a previous {@code FT.AGGREGATE} or {@code FT.CURSOR READ} command
      * @param count the number of results to read. This parameter overrides the {@code COUNT} specified in {@code FT.AGGREGATE}
      * @return the result of the cursor read command containing the next batch of results and potentially a new cursor id, see
@@ -1157,7 +1157,7 @@ public interface RediSearchCommands<K, V> {
      * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
-    AggregationReply<K, V> ftCursorread(K index, long cursorId, int count);
+    AggregationReply<K, V> ftCursorread(String index, long cursorId, int count);
 
     /**
      * Read next results from an existing cursor using the default batch size.
@@ -1177,7 +1177,7 @@ public interface RediSearchCommands<K, V> {
      * <strong>Time complexity:</strong> O(1)
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param cursorId the cursor id obtained from a previous {@code FT.AGGREGATE} or {@code FT.CURSOR READ} command
      * @return the result of the cursor read command containing the next batch of results and potentially a new cursor id, see
      *         {@link SearchReply}
@@ -1190,7 +1190,7 @@ public interface RediSearchCommands<K, V> {
      * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
-    AggregationReply<K, V> ftCursorread(K index, long cursorId);
+    AggregationReply<K, V> ftCursorread(String index, long cursorId);
 
     /**
      * Delete a cursor and free its associated resources.
@@ -1208,8 +1208,8 @@ public interface RediSearchCommands<K, V> {
      * </p>
      *
      * <p>
-     * Once a cursor is deleted, any subsequent attempts to read from it using {@link #ftCursorread(Object, long)} or
-     * {@link #ftCursorread(Object, long, int)} will result in an error.
+     * Once a cursor is deleted, any subsequent attempts to read from it using {@link #ftCursorread(String, long)} or
+     * {@link #ftCursorread(String, long, int)} will result in an error.
      * </p>
      *
      * <p>
@@ -1225,10 +1225,10 @@ public interface RediSearchCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
      * @see #ftAggregate(String, Object, AggregateArgs)
-     * @see #ftCursorread(Object, long)
-     * @see #ftCursorread(Object, long, int)
+     * @see #ftCursorread(String, long)
+     * @see #ftCursorread(String, long, int)
      */
     @Experimental
-    String ftCursordel(K index, long cursorId);
+    String ftCursordel(String index, long cursorId);
 
 }

--- a/src/main/java/io/lettuce/core/api/sync/RediSearchCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RediSearchCommands.java
@@ -50,7 +50,7 @@ public interface RediSearchCommands<K, V> {
      * triggered, where N is the number of keys in the keyspace
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param fieldArgs the {@link FieldArgs} list defining the searchable fields and their types
      * @return {@code "OK"} if the index was created successfully
      * @see <a href="https://redis.io/docs/latest/commands/ft.create/">FT.CREATE</a>
@@ -87,7 +87,7 @@ public interface RediSearchCommands<K, V> {
      * triggered, where N is the number of keys in the keyspace
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param arguments the index {@link CreateArgs} containing configuration options
      * @param fieldArgs the {@link FieldArgs} list defining the searchable fields and their types
      * @return {@code "OK"} if the index was created successfully

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionSearchAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionSearchAsyncCommands.java
@@ -367,7 +367,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @see #ftCreate(Object, CreateArgs, List)
      */
     @Experimental
-    AsyncExecutions<List<V>> ftTagvals(K index, K fieldName);
+    AsyncExecutions<List<V>> ftTagvals(String index, K fieldName);
 
     /**
      * Perform spelling correction on a query, returning suggestions for misspelled terms.
@@ -402,13 +402,13 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
-     * @see #ftSpellcheck(Object, Object, SpellCheckArgs)
+     * @see #ftSpellcheck(String, Object, SpellCheckArgs)
      * @see #ftDictadd(Object, Object[])
      * @see #ftDictdel(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
-    AsyncExecutions<SpellCheckResult<V>> ftSpellcheck(K index, V query);
+    AsyncExecutions<SpellCheckResult<V>> ftSpellcheck(String index, V query);
 
     /**
      * Perform spelling correction on a query with additional options.
@@ -439,13 +439,13 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
-     * @see #ftSpellcheck(Object, Object)
+     * @see #ftSpellcheck(String, Object)
      * @see #ftDictadd(Object, Object[])
      * @see #ftDictdel(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
-    AsyncExecutions<SpellCheckResult<V>> ftSpellcheck(K index, V query, SpellCheckArgs<K, V> args);
+    AsyncExecutions<SpellCheckResult<V>> ftSpellcheck(String index, V query, SpellCheckArgs<K, V> args);
 
     /**
      * Add terms to a dictionary.
@@ -476,7 +476,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictadd/">FT.DICTADD</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
      * @see #ftDictdel(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
     AsyncExecutions<Long> ftDictadd(K dict, V... terms);
@@ -499,7 +499,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictdel/">FT.DICTDEL</a>
      * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
     AsyncExecutions<Long> ftDictdel(K dict, V... terms);
@@ -523,7 +523,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @see #ftDictdel(Object, Object[])
      */
     @Experimental
-    AsyncExecutions<List<V>> ftDictdump(K dict);
+    AsyncExecutions<List<V>> ftDictdump(String dict);
 
     /**
      * Return the execution plan for a complex query.
@@ -552,11 +552,11 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @return the execution plan as a string
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.explain/">FT.EXPLAIN</a>
-     * @see #ftExplain(Object, Object, ExplainArgs)
-     * @see #ftSearch(Object, Object)
+     * @see #ftExplain(String, Object, ExplainArgs)
+     * @see #ftSearch(String, Object)
      */
     @Experimental
-    AsyncExecutions<String> ftExplain(K index, V query);
+    AsyncExecutions<String> ftExplain(String index, V query);
 
     /**
      * Return the execution plan for a complex query with additional options.
@@ -583,11 +583,11 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @return the execution plan as a string
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.explain/">FT.EXPLAIN</a>
-     * @see #ftExplain(Object, Object)
-     * @see #ftSearch(Object, Object)
+     * @see #ftExplain(String, Object)
+     * @see #ftSearch(String, Object)
      */
     @Experimental
-    AsyncExecutions<String> ftExplain(K index, V query, ExplainArgs<K, V> args);
+    AsyncExecutions<String> ftExplain(String index, V query, ExplainArgs<K, V> args);
 
     /**
      * Return a list of all existing indexes.
@@ -655,7 +655,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
      */
     @Experimental
-    AsyncExecutions<Map<V, List<V>>> ftSyndump(K index);
+    AsyncExecutions<Map<V, List<V>>> ftSyndump(String index);
 
     /**
      * Update a synonym group with additional terms.
@@ -686,7 +686,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
      * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
-     * @see #ftSyndump(Object)
+     * @see #ftSyndump(String)
      */
     @Experimental
     AsyncExecutions<String> ftSynupdate(K index, V synonymGroupId, V... terms);
@@ -718,7 +718,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
      * @see #ftSynupdate(Object, Object, Object[])
-     * @see #ftSyndump(Object)
+     * @see #ftSyndump(String)
      */
     @Experimental
     AsyncExecutions<String> ftSynupdate(K index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms);
@@ -971,10 +971,10 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/develop/interact/search-and-query/query/">Query syntax</a>
      * @see SearchReply
      * @see SearchArgs
-     * @see #ftSearch(Object, Object, SearchArgs)
+     * @see #ftSearch(String, Object, SearchArgs)
      */
     @Experimental
-    AsyncExecutions<SearchReply<K, V>> ftSearch(K index, V query);
+    AsyncExecutions<SearchReply<K, V>> ftSearch(String index, V query);
 
     /**
      * Search the index with a textual query using advanced search options and filters.
@@ -1022,23 +1022,23 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/">Advanced concepts</a>
      * @see SearchReply
      * @see SearchArgs
-     * @see #ftSearch(Object, Object)
+     * @see #ftSearch(String, Object)
      */
     @Experimental
-    AsyncExecutions<SearchReply<K, V>> ftSearch(K index, V query, SearchArgs<K, V> args);
+    AsyncExecutions<SearchReply<K, V>> ftSearch(String index, V query, SearchArgs<K, V> args);
 
     /**
      * Run a search query on an index and perform basic aggregate transformations using default options.
      *
      * <p>
      * This command executes a search query and applies aggregation operations to transform and analyze the results. Unlike
-     * {@link #ftSearch(Object, Object)}, which returns individual documents, FT.AGGREGATE processes the result set through a
+     * {@link #ftSearch(String, Object)}, which returns individual documents, FT.AGGREGATE processes the result set through a
      * pipeline of transformations to produce analytical insights, summaries, and computed values.
      * </p>
      *
      * <p>
      * This basic variant uses default aggregation behavior without additional pipeline operations. For advanced aggregations
-     * with grouping, sorting, filtering, and custom transformations, use {@link #ftAggregate(Object, Object, AggregateArgs)}.
+     * with grouping, sorting, filtering, and custom transformations, use {@link #ftAggregate(String, Object, AggregateArgs)}.
      * </p>
      *
      * <p>
@@ -1064,10 +1064,10 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/">Aggregations</a>
      * @see SearchReply
      * @see AggregateArgs
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
-    AsyncExecutions<AggregationReply<K, V>> ftAggregate(K index, V query);
+    AsyncExecutions<AggregationReply<K, V>> ftAggregate(String index, V query);
 
     /**
      * Run a search query on an index and perform advanced aggregate transformations with a processing pipeline.
@@ -1119,18 +1119,18 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      *      API</a>
      * @see SearchReply
      * @see AggregateArgs
-     * @see #ftAggregate(Object, Object)
+     * @see #ftAggregate(String, Object)
      * @see #ftCursorread(Object, long)
      */
     @Experimental
-    AsyncExecutions<AggregationReply<K, V>> ftAggregate(K index, V query, AggregateArgs<K, V> args);
+    AsyncExecutions<AggregationReply<K, V>> ftAggregate(String index, V query, AggregateArgs<K, V> args);
 
     /**
      * Read next results from an existing cursor.
      *
      * <p>
      * This command is used to read the next batch of results from a cursor created by
-     * {@link #ftAggregate(Object, Object, AggregateArgs)} with the {@code WITHCURSOR} option. Cursors provide an efficient way
+     * {@link #ftAggregate(String, Object, AggregateArgs)} with the {@code WITHCURSOR} option. Cursors provide an efficient way
      * to iterate through large result sets without loading all results into memory at once.
      * </p>
      *
@@ -1154,7 +1154,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
      * @see SearchReply
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
     AsyncExecutions<AggregationReply<K, V>> ftCursorread(K index, long cursorId, int count);
@@ -1164,7 +1164,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      *
      * <p>
      * This command is used to read the next batch of results from a cursor created by
-     * {@link #ftAggregate(Object, Object, AggregateArgs)} with the {@code WITHCURSOR} option. This variant uses the default
+     * {@link #ftAggregate(String, Object, AggregateArgs)} with the {@code WITHCURSOR} option. This variant uses the default
      * batch size that was specified in the original {@code FT.AGGREGATE} command's {@code WITHCURSOR} clause.
      * </p>
      *
@@ -1187,7 +1187,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
      * @see SearchReply
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
     AsyncExecutions<AggregationReply<K, V>> ftCursorread(K index, long cursorId);
@@ -1196,7 +1196,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * Delete a cursor and free its associated resources.
      *
      * <p>
-     * This command is used to explicitly delete a cursor created by {@link #ftAggregate(Object, Object, AggregateArgs)} with
+     * This command is used to explicitly delete a cursor created by {@link #ftAggregate(String, Object, AggregateArgs)} with
      * the {@code WITHCURSOR} option. Deleting a cursor frees up server resources and should be done when you no longer need to
      * read more results from the cursor.
      * </p>
@@ -1224,7 +1224,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @see <a href=
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      * @see #ftCursorread(Object, long)
      * @see #ftCursorread(Object, long, int)
      */

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionSearchAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionSearchAsyncCommands.java
@@ -50,7 +50,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * triggered, where N is the number of keys in the keyspace
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param fieldArgs the {@link FieldArgs} list defining the searchable fields and their types
      * @return {@code "OK"} if the index was created successfully
      * @see <a href="https://redis.io/docs/latest/commands/ft.create/">FT.CREATE</a>
@@ -87,7 +87,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * triggered, where N is the number of keys in the keyspace
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param arguments the index {@link CreateArgs} containing configuration options
      * @param fieldArgs the {@link FieldArgs} list defining the searchable fields and their types
      * @return {@code "OK"} if the index was created successfully

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionSearchAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionSearchAsyncCommands.java
@@ -1120,7 +1120,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @see SearchReply
      * @see AggregateArgs
      * @see #ftAggregate(String, Object)
-     * @see #ftCursorread(Object, long)
+     * @see #ftCursorread(String, long)
      */
     @Experimental
     AsyncExecutions<AggregationReply<K, V>> ftAggregate(String index, V query, AggregateArgs<K, V> args);
@@ -1143,7 +1143,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * <strong>Time complexity:</strong> O(1)
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param cursorId the cursor id obtained from a previous {@code FT.AGGREGATE} or {@code FT.CURSOR READ} command
      * @param count the number of results to read. This parameter overrides the {@code COUNT} specified in {@code FT.AGGREGATE}
      * @return the result of the cursor read command containing the next batch of results and potentially a new cursor id, see
@@ -1157,7 +1157,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
-    AsyncExecutions<AggregationReply<K, V>> ftCursorread(K index, long cursorId, int count);
+    AsyncExecutions<AggregationReply<K, V>> ftCursorread(String index, long cursorId, int count);
 
     /**
      * Read next results from an existing cursor using the default batch size.
@@ -1177,7 +1177,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * <strong>Time complexity:</strong> O(1)
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param cursorId the cursor id obtained from a previous {@code FT.AGGREGATE} or {@code FT.CURSOR READ} command
      * @return the result of the cursor read command containing the next batch of results and potentially a new cursor id, see
      *         {@link SearchReply}
@@ -1190,7 +1190,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
-    AsyncExecutions<AggregationReply<K, V>> ftCursorread(K index, long cursorId);
+    AsyncExecutions<AggregationReply<K, V>> ftCursorread(String index, long cursorId);
 
     /**
      * Delete a cursor and free its associated resources.
@@ -1208,8 +1208,8 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * </p>
      *
      * <p>
-     * Once a cursor is deleted, any subsequent attempts to read from it using {@link #ftCursorread(Object, long)} or
-     * {@link #ftCursorread(Object, long, int)} will result in an error.
+     * Once a cursor is deleted, any subsequent attempts to read from it using {@link #ftCursorread(String, long)} or
+     * {@link #ftCursorread(String, long, int)} will result in an error.
      * </p>
      *
      * <p>
@@ -1225,10 +1225,10 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
      * @see #ftAggregate(String, Object, AggregateArgs)
-     * @see #ftCursorread(Object, long)
-     * @see #ftCursorread(Object, long, int)
+     * @see #ftCursorread(String, long)
+     * @see #ftCursorread(String, long, int)
      */
     @Experimental
-    AsyncExecutions<String> ftCursordel(K index, long cursorId);
+    AsyncExecutions<String> ftCursordel(String index, long cursorId);
 
 }

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionSearchAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionSearchAsyncCommands.java
@@ -56,11 +56,11 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.create/">FT.CREATE</a>
      * @see CreateArgs
      * @see FieldArgs
-     * @see #ftCreate(Object, CreateArgs, List)
-     * @see #ftDropindex(Object)
+     * @see #ftCreate(String, CreateArgs, List)
+     * @see #ftDropindex(String)
      */
     @Experimental
-    AsyncExecutions<String> ftCreate(K index, List<FieldArgs<K>> fieldArgs);
+    AsyncExecutions<String> ftCreate(String index, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Create a new search index with the given name, custom configuration, and field definitions.
@@ -95,11 +95,11 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.create/">FT.CREATE</a>
      * @see CreateArgs
      * @see FieldArgs
-     * @see #ftCreate(Object, List)
-     * @see #ftDropindex(Object)
+     * @see #ftCreate(String, List)
+     * @see #ftDropindex(String)
      */
     @Experimental
-    AsyncExecutions<String> ftCreate(K index, CreateArgs<K, V> arguments, List<FieldArgs<K>> fieldArgs);
+    AsyncExecutions<String> ftCreate(String index, CreateArgs<K, V> arguments, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Add an alias to a search index.
@@ -127,7 +127,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * <li>An index can have multiple aliases, but an alias can only point to one index</li>
      * <li>Aliases cannot reference other aliases (no alias chaining)</li>
      * <li>If the alias already exists, this command will fail with an error</li>
-     * <li>Use {@link #ftAliasupdate(Object, Object)} to reassign an existing alias</li>
+     * <li>Use {@link #ftAliasupdate(String, String)} to reassign an existing alias</li>
      * </ul>
      *
      * <p>
@@ -139,18 +139,18 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @return {@code "OK"} if the alias was successfully created
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.aliasadd/">FT.ALIASADD</a>
-     * @see #ftAliasupdate(Object, Object)
-     * @see #ftAliasdel(Object)
+     * @see #ftAliasupdate(String, String)
+     * @see #ftAliasdel(String)
      */
     @Experimental
-    AsyncExecutions<String> ftAliasadd(K alias, K index);
+    AsyncExecutions<String> ftAliasadd(String alias, String index);
 
     /**
      * Update an existing alias to point to a different search index.
      *
      * <p>
      * This command updates an existing alias to point to a different index, or creates the alias if it doesn't exist. Unlike
-     * {@link #ftAliasadd(Object, Object)}, this command will succeed even if the alias already exists, making it useful for
+     * {@link #ftAliasadd(String, String)}, this command will succeed even if the alias already exists, making it useful for
      * atomic alias updates during index migrations.
      * </p>
      *
@@ -183,11 +183,11 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @return {@code "OK"} if the alias was successfully updated
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.aliasupdate/">FT.ALIASUPDATE</a>
-     * @see #ftAliasadd(Object, Object)
-     * @see #ftAliasdel(Object)
+     * @see #ftAliasadd(String, String)
+     * @see #ftAliasdel(String)
      */
     @Experimental
-    AsyncExecutions<String> ftAliasupdate(K alias, K index);
+    AsyncExecutions<String> ftAliasupdate(String alias, String index);
 
     /**
      * Remove an alias from a search index.
@@ -214,7 +214,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * <li>Only the alias is removed - the target index is not affected</li>
      * <li>If the alias doesn't exist, this command will fail with an error</li>
      * <li>Applications using the alias will receive errors after deletion</li>
-     * <li>Consider using {@link #ftAliasupdate(Object, Object)} to redirect before deletion</li>
+     * <li>Consider using {@link #ftAliasupdate(String, String)} to redirect before deletion</li>
      * </ul>
      *
      * <p>
@@ -225,11 +225,11 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @return {@code "OK"} if the alias was successfully removed
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.aliasdel/">FT.ALIASDEL</a>
-     * @see #ftAliasadd(Object, Object)
-     * @see #ftAliasupdate(Object, Object)
+     * @see #ftAliasadd(String, String)
+     * @see #ftAliasupdate(String, String)
      */
     @Experimental
-    AsyncExecutions<String> ftAliasdel(K alias);
+    AsyncExecutions<String> ftAliasdel(String alias);
 
     /**
      * Add new attributes to an existing search index.
@@ -272,11 +272,11 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.alter/">FT.ALTER</a>
      * @see FieldArgs
-     * @see #ftCreate(Object, List)
-     * @see #ftCreate(Object, CreateArgs, List)
+     * @see #ftCreate(String, List)
+     * @see #ftCreate(String, CreateArgs, List)
      */
     @Experimental
-    AsyncExecutions<String> ftAlter(K index, boolean skipInitialScan, List<FieldArgs<K>> fieldArgs);
+    AsyncExecutions<String> ftAlter(String index, boolean skipInitialScan, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Add new attributes to an existing search index.
@@ -307,11 +307,11 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.alter/">FT.ALTER</a>
      * @see FieldArgs
-     * @see #ftCreate(Object, List)
-     * @see #ftCreate(Object, CreateArgs, List)
+     * @see #ftCreate(String, List)
+     * @see #ftCreate(String, CreateArgs, List)
      */
     @Experimental
-    AsyncExecutions<String> ftAlter(K index, List<FieldArgs<K>> fieldArgs);
+    AsyncExecutions<String> ftAlter(String index, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Return a distinct set of values indexed in a Tag field.
@@ -363,11 +363,11 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      *         were indexed (lowercase, whitespace removed).
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.tagvals/">FT.TAGVALS</a>
-     * @see #ftCreate(Object, List)
-     * @see #ftCreate(Object, CreateArgs, List)
+     * @see #ftCreate(String, List)
+     * @see #ftCreate(String, CreateArgs, List)
      */
     @Experimental
-    AsyncExecutions<List<V>> ftTagvals(String index, K fieldName);
+    AsyncExecutions<List<V>> ftTagvals(String index, String fieldName);
 
     /**
      * Perform spelling correction on a query, returning suggestions for misspelled terms.
@@ -403,8 +403,8 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
      * @see #ftSpellcheck(String, Object, SpellCheckArgs)
-     * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictadd(String, Object[])
+     * @see #ftDictdel(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
@@ -440,8 +440,8 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
      * @see #ftSpellcheck(String, Object)
-     * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictadd(String, Object[])
+     * @see #ftDictdel(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
@@ -475,11 +475,11 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictadd/">FT.DICTADD</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictdel(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
-    AsyncExecutions<Long> ftDictadd(K dict, V... terms);
+    AsyncExecutions<Long> ftDictadd(String dict, V... terms);
 
     /**
      * Delete terms from a dictionary.
@@ -498,11 +498,11 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @return the number of terms that were deleted
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictdel/">FT.DICTDEL</a>
-     * @see #ftDictadd(Object, Object[])
+     * @see #ftDictadd(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
-    AsyncExecutions<Long> ftDictdel(K dict, V... terms);
+    AsyncExecutions<Long> ftDictdel(String dict, V... terms);
 
     /**
      * Dump all terms in a dictionary.
@@ -519,8 +519,8 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @return a list of all terms in the dictionary
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictdump/">FT.DICTDUMP</a>
-     * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictadd(String, Object[])
+     * @see #ftDictdel(String, Object[])
      */
     @Experimental
     AsyncExecutions<List<V>> ftDictdump(String dict);
@@ -619,8 +619,8 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @return a list of index names
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft._list/">FT._LIST</a>
-     * @see #ftCreate(Object, CreateArgs, FieldArgs[])
-     * @see #ftDropindex(Object)
+     * @see #ftCreate(String, CreateArgs, FieldArgs[])
+     * @see #ftDropindex(String)
      */
     @Experimental
     AsyncExecutions<List<V>> ftList();
@@ -651,8 +651,8 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @return a map where keys are synonym terms and values are lists of group IDs containing that synonym
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.syndump/">FT.SYNDUMP</a>
-     * @see #ftSynupdate(Object, Object, Object[])
-     * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
+     * @see #ftSynupdate(String, Object, Object[])
+     * @see #ftSynupdate(String, Object, SynUpdateArgs, Object[])
      */
     @Experimental
     AsyncExecutions<Map<V, List<V>>> ftSyndump(String index);
@@ -685,11 +685,11 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @return OK if executed correctly
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
-     * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
+     * @see #ftSynupdate(String, Object, SynUpdateArgs, Object[])
      * @see #ftSyndump(String)
      */
     @Experimental
-    AsyncExecutions<String> ftSynupdate(K index, V synonymGroupId, V... terms);
+    AsyncExecutions<String> ftSynupdate(String index, V synonymGroupId, V... terms);
 
     /**
      * Update a synonym group with additional terms and options.
@@ -717,11 +717,11 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @return OK if executed correctly
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
-     * @see #ftSynupdate(Object, Object, Object[])
+     * @see #ftSynupdate(String, Object, Object[])
      * @see #ftSyndump(String)
      */
     @Experimental
-    AsyncExecutions<String> ftSynupdate(K index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms);
+    AsyncExecutions<String> ftSynupdate(String index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms);
 
     /**
      * Add a suggestion string to an auto-complete suggestion dictionary.
@@ -901,11 +901,11 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @return {@code "OK"} if the index was successfully dropped
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dropindex/">FT.DROPINDEX</a>
-     * @see #ftDropindex(Object, boolean)
-     * @see #ftCreate(Object, List)
+     * @see #ftDropindex(String, boolean)
+     * @see #ftCreate(String, List)
      */
     @Experimental
-    AsyncExecutions<String> ftDropindex(K index);
+    AsyncExecutions<String> ftDropindex(String index);
 
     /**
      * Drop a search index with optional document deletion.
@@ -917,7 +917,7 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * </p>
      *
      * <p>
-     * <strong>Asynchronous Behavior:</strong> If an index creation is still running ({@link #ftCreate(Object, List)} is running
+     * <strong>Asynchronous Behavior:</strong> If an index creation is still running ({@link #ftCreate(String, List)} is running
      * asynchronously), only the document hashes that have already been indexed are deleted. Documents that are queued for
      * indexing but not yet processed will remain in the database.
      * </p>
@@ -931,11 +931,11 @@ public interface NodeSelectionSearchAsyncCommands<K, V> {
      * @return {@code "OK"} if the index was successfully dropped
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dropindex/">FT.DROPINDEX</a>
-     * @see #ftDropindex(Object)
-     * @see #ftCreate(Object, List)
+     * @see #ftDropindex(String)
+     * @see #ftCreate(String, List)
      */
     @Experimental
-    AsyncExecutions<String> ftDropindex(K index, boolean deleteDocuments);
+    AsyncExecutions<String> ftDropindex(String index, boolean deleteDocuments);
 
     /**
      * Search the index with a textual query using default search options.

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionSearchCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionSearchCommands.java
@@ -367,7 +367,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @see #ftCreate(Object, CreateArgs, List)
      */
     @Experimental
-    Executions<List<V>> ftTagvals(K index, K fieldName);
+    Executions<List<V>> ftTagvals(String index, K fieldName);
 
     /**
      * Perform spelling correction on a query, returning suggestions for misspelled terms.
@@ -402,13 +402,13 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
-     * @see #ftSpellcheck(Object, Object, SpellCheckArgs)
+     * @see #ftSpellcheck(String, Object, SpellCheckArgs)
      * @see #ftDictadd(Object, Object[])
      * @see #ftDictdel(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
-    Executions<SpellCheckResult<V>> ftSpellcheck(K index, V query);
+    Executions<SpellCheckResult<V>> ftSpellcheck(String index, V query);
 
     /**
      * Perform spelling correction on a query with additional options.
@@ -439,13 +439,13 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
-     * @see #ftSpellcheck(Object, Object)
+     * @see #ftSpellcheck(String, Object)
      * @see #ftDictadd(Object, Object[])
      * @see #ftDictdel(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
-    Executions<SpellCheckResult<V>> ftSpellcheck(K index, V query, SpellCheckArgs<K, V> args);
+    Executions<SpellCheckResult<V>> ftSpellcheck(String index, V query, SpellCheckArgs<K, V> args);
 
     /**
      * Add terms to a dictionary.
@@ -476,7 +476,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictadd/">FT.DICTADD</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
      * @see #ftDictdel(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
     Executions<Long> ftDictadd(K dict, V... terms);
@@ -499,7 +499,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictdel/">FT.DICTDEL</a>
      * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
     Executions<Long> ftDictdel(K dict, V... terms);
@@ -523,7 +523,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @see #ftDictdel(Object, Object[])
      */
     @Experimental
-    Executions<List<V>> ftDictdump(K dict);
+    Executions<List<V>> ftDictdump(String dict);
 
     /**
      * Return the execution plan for a complex query.
@@ -552,11 +552,11 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @return the execution plan as a string
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.explain/">FT.EXPLAIN</a>
-     * @see #ftExplain(Object, Object, ExplainArgs)
-     * @see #ftSearch(Object, Object)
+     * @see #ftExplain(String, Object, ExplainArgs)
+     * @see #ftSearch(String, Object)
      */
     @Experimental
-    Executions<String> ftExplain(K index, V query);
+    Executions<String> ftExplain(String index, V query);
 
     /**
      * Return the execution plan for a complex query with additional options.
@@ -583,11 +583,11 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @return the execution plan as a string
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.explain/">FT.EXPLAIN</a>
-     * @see #ftExplain(Object, Object)
-     * @see #ftSearch(Object, Object)
+     * @see #ftExplain(String, Object)
+     * @see #ftSearch(String, Object)
      */
     @Experimental
-    Executions<String> ftExplain(K index, V query, ExplainArgs<K, V> args);
+    Executions<String> ftExplain(String index, V query, ExplainArgs<K, V> args);
 
     /**
      * Return a list of all existing indexes.
@@ -655,7 +655,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
      */
     @Experimental
-    Executions<Map<V, List<V>>> ftSyndump(K index);
+    Executions<Map<V, List<V>>> ftSyndump(String index);
 
     /**
      * Update a synonym group with additional terms.
@@ -686,7 +686,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
      * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
-     * @see #ftSyndump(Object)
+     * @see #ftSyndump(String)
      */
     @Experimental
     Executions<String> ftSynupdate(K index, V synonymGroupId, V... terms);
@@ -718,7 +718,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
      * @see #ftSynupdate(Object, Object, Object[])
-     * @see #ftSyndump(Object)
+     * @see #ftSyndump(String)
      */
     @Experimental
     Executions<String> ftSynupdate(K index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms);
@@ -971,10 +971,10 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/develop/interact/search-and-query/query/">Query syntax</a>
      * @see SearchReply
      * @see SearchArgs
-     * @see #ftSearch(Object, Object, SearchArgs)
+     * @see #ftSearch(String, Object, SearchArgs)
      */
     @Experimental
-    Executions<SearchReply<K, V>> ftSearch(K index, V query);
+    Executions<SearchReply<K, V>> ftSearch(String index, V query);
 
     /**
      * Search the index with a textual query using advanced search options and filters.
@@ -1022,23 +1022,23 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/">Advanced concepts</a>
      * @see SearchReply
      * @see SearchArgs
-     * @see #ftSearch(Object, Object)
+     * @see #ftSearch(String, Object)
      */
     @Experimental
-    Executions<SearchReply<K, V>> ftSearch(K index, V query, SearchArgs<K, V> args);
+    Executions<SearchReply<K, V>> ftSearch(String index, V query, SearchArgs<K, V> args);
 
     /**
      * Run a search query on an index and perform basic aggregate transformations using default options.
      *
      * <p>
      * This command executes a search query and applies aggregation operations to transform and analyze the results. Unlike
-     * {@link #ftSearch(Object, Object)}, which returns individual documents, FT.AGGREGATE processes the result set through a
+     * {@link #ftSearch(String, Object)}, which returns individual documents, FT.AGGREGATE processes the result set through a
      * pipeline of transformations to produce analytical insights, summaries, and computed values.
      * </p>
      *
      * <p>
      * This basic variant uses default aggregation behavior without additional pipeline operations. For advanced aggregations
-     * with grouping, sorting, filtering, and custom transformations, use {@link #ftAggregate(Object, Object, AggregateArgs)}.
+     * with grouping, sorting, filtering, and custom transformations, use {@link #ftAggregate(String, Object, AggregateArgs)}.
      * </p>
      *
      * <p>
@@ -1064,10 +1064,10 @@ public interface NodeSelectionSearchCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/">Aggregations</a>
      * @see SearchReply
      * @see AggregateArgs
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
-    Executions<AggregationReply<K, V>> ftAggregate(K index, V query);
+    Executions<AggregationReply<K, V>> ftAggregate(String index, V query);
 
     /**
      * Run a search query on an index and perform advanced aggregate transformations with a processing pipeline.
@@ -1119,18 +1119,18 @@ public interface NodeSelectionSearchCommands<K, V> {
      *      API</a>
      * @see SearchReply
      * @see AggregateArgs
-     * @see #ftAggregate(Object, Object)
+     * @see #ftAggregate(String, Object)
      * @see #ftCursorread(Object, long)
      */
     @Experimental
-    Executions<AggregationReply<K, V>> ftAggregate(K index, V query, AggregateArgs<K, V> args);
+    Executions<AggregationReply<K, V>> ftAggregate(String index, V query, AggregateArgs<K, V> args);
 
     /**
      * Read next results from an existing cursor.
      *
      * <p>
      * This command is used to read the next batch of results from a cursor created by
-     * {@link #ftAggregate(Object, Object, AggregateArgs)} with the {@code WITHCURSOR} option. Cursors provide an efficient way
+     * {@link #ftAggregate(String, Object, AggregateArgs)} with the {@code WITHCURSOR} option. Cursors provide an efficient way
      * to iterate through large result sets without loading all results into memory at once.
      * </p>
      *
@@ -1154,7 +1154,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
      * @see SearchReply
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
     Executions<AggregationReply<K, V>> ftCursorread(K index, long cursorId, int count);
@@ -1164,7 +1164,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      *
      * <p>
      * This command is used to read the next batch of results from a cursor created by
-     * {@link #ftAggregate(Object, Object, AggregateArgs)} with the {@code WITHCURSOR} option. This variant uses the default
+     * {@link #ftAggregate(String, Object, AggregateArgs)} with the {@code WITHCURSOR} option. This variant uses the default
      * batch size that was specified in the original {@code FT.AGGREGATE} command's {@code WITHCURSOR} clause.
      * </p>
      *
@@ -1187,7 +1187,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
      * @see SearchReply
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
     Executions<AggregationReply<K, V>> ftCursorread(K index, long cursorId);
@@ -1196,7 +1196,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      * Delete a cursor and free its associated resources.
      *
      * <p>
-     * This command is used to explicitly delete a cursor created by {@link #ftAggregate(Object, Object, AggregateArgs)} with
+     * This command is used to explicitly delete a cursor created by {@link #ftAggregate(String, Object, AggregateArgs)} with
      * the {@code WITHCURSOR} option. Deleting a cursor frees up server resources and should be done when you no longer need to
      * read more results from the cursor.
      * </p>
@@ -1224,7 +1224,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @see <a href=
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      * @see #ftCursorread(Object, long)
      * @see #ftCursorread(Object, long, int)
      */

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionSearchCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionSearchCommands.java
@@ -1120,7 +1120,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @see SearchReply
      * @see AggregateArgs
      * @see #ftAggregate(String, Object)
-     * @see #ftCursorread(Object, long)
+     * @see #ftCursorread(String, long)
      */
     @Experimental
     Executions<AggregationReply<K, V>> ftAggregate(String index, V query, AggregateArgs<K, V> args);
@@ -1143,7 +1143,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      * <strong>Time complexity:</strong> O(1)
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param cursorId the cursor id obtained from a previous {@code FT.AGGREGATE} or {@code FT.CURSOR READ} command
      * @param count the number of results to read. This parameter overrides the {@code COUNT} specified in {@code FT.AGGREGATE}
      * @return the result of the cursor read command containing the next batch of results and potentially a new cursor id, see
@@ -1157,7 +1157,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
-    Executions<AggregationReply<K, V>> ftCursorread(K index, long cursorId, int count);
+    Executions<AggregationReply<K, V>> ftCursorread(String index, long cursorId, int count);
 
     /**
      * Read next results from an existing cursor using the default batch size.
@@ -1177,7 +1177,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      * <strong>Time complexity:</strong> O(1)
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param cursorId the cursor id obtained from a previous {@code FT.AGGREGATE} or {@code FT.CURSOR READ} command
      * @return the result of the cursor read command containing the next batch of results and potentially a new cursor id, see
      *         {@link SearchReply}
@@ -1190,7 +1190,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
-    Executions<AggregationReply<K, V>> ftCursorread(K index, long cursorId);
+    Executions<AggregationReply<K, V>> ftCursorread(String index, long cursorId);
 
     /**
      * Delete a cursor and free its associated resources.
@@ -1208,8 +1208,8 @@ public interface NodeSelectionSearchCommands<K, V> {
      * </p>
      *
      * <p>
-     * Once a cursor is deleted, any subsequent attempts to read from it using {@link #ftCursorread(Object, long)} or
-     * {@link #ftCursorread(Object, long, int)} will result in an error.
+     * Once a cursor is deleted, any subsequent attempts to read from it using {@link #ftCursorread(String, long)} or
+     * {@link #ftCursorread(String, long, int)} will result in an error.
      * </p>
      *
      * <p>
@@ -1225,10 +1225,10 @@ public interface NodeSelectionSearchCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
      * @see #ftAggregate(String, Object, AggregateArgs)
-     * @see #ftCursorread(Object, long)
-     * @see #ftCursorread(Object, long, int)
+     * @see #ftCursorread(String, long)
+     * @see #ftCursorread(String, long, int)
      */
     @Experimental
-    Executions<String> ftCursordel(K index, long cursorId);
+    Executions<String> ftCursordel(String index, long cursorId);
 
 }

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionSearchCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionSearchCommands.java
@@ -50,7 +50,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      * triggered, where N is the number of keys in the keyspace
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param fieldArgs the {@link FieldArgs} list defining the searchable fields and their types
      * @return {@code "OK"} if the index was created successfully
      * @see <a href="https://redis.io/docs/latest/commands/ft.create/">FT.CREATE</a>
@@ -87,7 +87,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      * triggered, where N is the number of keys in the keyspace
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param arguments the index {@link CreateArgs} containing configuration options
      * @param fieldArgs the {@link FieldArgs} list defining the searchable fields and their types
      * @return {@code "OK"} if the index was created successfully

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionSearchCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionSearchCommands.java
@@ -56,11 +56,11 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.create/">FT.CREATE</a>
      * @see CreateArgs
      * @see FieldArgs
-     * @see #ftCreate(Object, CreateArgs, List)
-     * @see #ftDropindex(Object)
+     * @see #ftCreate(String, CreateArgs, List)
+     * @see #ftDropindex(String)
      */
     @Experimental
-    Executions<String> ftCreate(K index, List<FieldArgs<K>> fieldArgs);
+    Executions<String> ftCreate(String index, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Create a new search index with the given name, custom configuration, and field definitions.
@@ -95,11 +95,11 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.create/">FT.CREATE</a>
      * @see CreateArgs
      * @see FieldArgs
-     * @see #ftCreate(Object, List)
-     * @see #ftDropindex(Object)
+     * @see #ftCreate(String, List)
+     * @see #ftDropindex(String)
      */
     @Experimental
-    Executions<String> ftCreate(K index, CreateArgs<K, V> arguments, List<FieldArgs<K>> fieldArgs);
+    Executions<String> ftCreate(String index, CreateArgs<K, V> arguments, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Add an alias to a search index.
@@ -127,7 +127,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      * <li>An index can have multiple aliases, but an alias can only point to one index</li>
      * <li>Aliases cannot reference other aliases (no alias chaining)</li>
      * <li>If the alias already exists, this command will fail with an error</li>
-     * <li>Use {@link #ftAliasupdate(Object, Object)} to reassign an existing alias</li>
+     * <li>Use {@link #ftAliasupdate(String, String)} to reassign an existing alias</li>
      * </ul>
      *
      * <p>
@@ -139,18 +139,18 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @return {@code "OK"} if the alias was successfully created
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.aliasadd/">FT.ALIASADD</a>
-     * @see #ftAliasupdate(Object, Object)
-     * @see #ftAliasdel(Object)
+     * @see #ftAliasupdate(String, String)
+     * @see #ftAliasdel(String)
      */
     @Experimental
-    Executions<String> ftAliasadd(K alias, K index);
+    Executions<String> ftAliasadd(String alias, String index);
 
     /**
      * Update an existing alias to point to a different search index.
      *
      * <p>
      * This command updates an existing alias to point to a different index, or creates the alias if it doesn't exist. Unlike
-     * {@link #ftAliasadd(Object, Object)}, this command will succeed even if the alias already exists, making it useful for
+     * {@link #ftAliasadd(String, String)}, this command will succeed even if the alias already exists, making it useful for
      * atomic alias updates during index migrations.
      * </p>
      *
@@ -183,11 +183,11 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @return {@code "OK"} if the alias was successfully updated
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.aliasupdate/">FT.ALIASUPDATE</a>
-     * @see #ftAliasadd(Object, Object)
-     * @see #ftAliasdel(Object)
+     * @see #ftAliasadd(String, String)
+     * @see #ftAliasdel(String)
      */
     @Experimental
-    Executions<String> ftAliasupdate(K alias, K index);
+    Executions<String> ftAliasupdate(String alias, String index);
 
     /**
      * Remove an alias from a search index.
@@ -214,7 +214,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      * <li>Only the alias is removed - the target index is not affected</li>
      * <li>If the alias doesn't exist, this command will fail with an error</li>
      * <li>Applications using the alias will receive errors after deletion</li>
-     * <li>Consider using {@link #ftAliasupdate(Object, Object)} to redirect before deletion</li>
+     * <li>Consider using {@link #ftAliasupdate(String, String)} to redirect before deletion</li>
      * </ul>
      *
      * <p>
@@ -225,11 +225,11 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @return {@code "OK"} if the alias was successfully removed
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.aliasdel/">FT.ALIASDEL</a>
-     * @see #ftAliasadd(Object, Object)
-     * @see #ftAliasupdate(Object, Object)
+     * @see #ftAliasadd(String, String)
+     * @see #ftAliasupdate(String, String)
      */
     @Experimental
-    Executions<String> ftAliasdel(K alias);
+    Executions<String> ftAliasdel(String alias);
 
     /**
      * Add new attributes to an existing search index.
@@ -272,11 +272,11 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.alter/">FT.ALTER</a>
      * @see FieldArgs
-     * @see #ftCreate(Object, List)
-     * @see #ftCreate(Object, CreateArgs, List)
+     * @see #ftCreate(String, List)
+     * @see #ftCreate(String, CreateArgs, List)
      */
     @Experimental
-    Executions<String> ftAlter(K index, boolean skipInitialScan, List<FieldArgs<K>> fieldArgs);
+    Executions<String> ftAlter(String index, boolean skipInitialScan, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Add new attributes to an existing search index.
@@ -307,11 +307,11 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.alter/">FT.ALTER</a>
      * @see FieldArgs
-     * @see #ftCreate(Object, List)
-     * @see #ftCreate(Object, CreateArgs, List)
+     * @see #ftCreate(String, List)
+     * @see #ftCreate(String, CreateArgs, List)
      */
     @Experimental
-    Executions<String> ftAlter(K index, List<FieldArgs<K>> fieldArgs);
+    Executions<String> ftAlter(String index, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Return a distinct set of values indexed in a Tag field.
@@ -363,11 +363,11 @@ public interface NodeSelectionSearchCommands<K, V> {
      *         were indexed (lowercase, whitespace removed).
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.tagvals/">FT.TAGVALS</a>
-     * @see #ftCreate(Object, List)
-     * @see #ftCreate(Object, CreateArgs, List)
+     * @see #ftCreate(String, List)
+     * @see #ftCreate(String, CreateArgs, List)
      */
     @Experimental
-    Executions<List<V>> ftTagvals(String index, K fieldName);
+    Executions<List<V>> ftTagvals(String index, String fieldName);
 
     /**
      * Perform spelling correction on a query, returning suggestions for misspelled terms.
@@ -403,8 +403,8 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
      * @see #ftSpellcheck(String, Object, SpellCheckArgs)
-     * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictadd(String, Object[])
+     * @see #ftDictdel(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
@@ -440,8 +440,8 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
      * @see #ftSpellcheck(String, Object)
-     * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictadd(String, Object[])
+     * @see #ftDictdel(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
@@ -475,11 +475,11 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictadd/">FT.DICTADD</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictdel(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
-    Executions<Long> ftDictadd(K dict, V... terms);
+    Executions<Long> ftDictadd(String dict, V... terms);
 
     /**
      * Delete terms from a dictionary.
@@ -498,11 +498,11 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @return the number of terms that were deleted
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictdel/">FT.DICTDEL</a>
-     * @see #ftDictadd(Object, Object[])
+     * @see #ftDictadd(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
-    Executions<Long> ftDictdel(K dict, V... terms);
+    Executions<Long> ftDictdel(String dict, V... terms);
 
     /**
      * Dump all terms in a dictionary.
@@ -519,8 +519,8 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @return a list of all terms in the dictionary
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictdump/">FT.DICTDUMP</a>
-     * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictadd(String, Object[])
+     * @see #ftDictdel(String, Object[])
      */
     @Experimental
     Executions<List<V>> ftDictdump(String dict);
@@ -619,8 +619,8 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @return a list of index names
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft._list/">FT._LIST</a>
-     * @see #ftCreate(Object, CreateArgs, FieldArgs[])
-     * @see #ftDropindex(Object)
+     * @see #ftCreate(String, CreateArgs, FieldArgs[])
+     * @see #ftDropindex(String)
      */
     @Experimental
     Executions<List<V>> ftList();
@@ -651,8 +651,8 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @return a map where keys are synonym terms and values are lists of group IDs containing that synonym
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.syndump/">FT.SYNDUMP</a>
-     * @see #ftSynupdate(Object, Object, Object[])
-     * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
+     * @see #ftSynupdate(String, Object, Object[])
+     * @see #ftSynupdate(String, Object, SynUpdateArgs, Object[])
      */
     @Experimental
     Executions<Map<V, List<V>>> ftSyndump(String index);
@@ -685,11 +685,11 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @return OK if executed correctly
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
-     * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
+     * @see #ftSynupdate(String, Object, SynUpdateArgs, Object[])
      * @see #ftSyndump(String)
      */
     @Experimental
-    Executions<String> ftSynupdate(K index, V synonymGroupId, V... terms);
+    Executions<String> ftSynupdate(String index, V synonymGroupId, V... terms);
 
     /**
      * Update a synonym group with additional terms and options.
@@ -717,11 +717,11 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @return OK if executed correctly
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
-     * @see #ftSynupdate(Object, Object, Object[])
+     * @see #ftSynupdate(String, Object, Object[])
      * @see #ftSyndump(String)
      */
     @Experimental
-    Executions<String> ftSynupdate(K index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms);
+    Executions<String> ftSynupdate(String index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms);
 
     /**
      * Add a suggestion string to an auto-complete suggestion dictionary.
@@ -901,11 +901,11 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @return {@code "OK"} if the index was successfully dropped
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dropindex/">FT.DROPINDEX</a>
-     * @see #ftDropindex(Object, boolean)
-     * @see #ftCreate(Object, List)
+     * @see #ftDropindex(String, boolean)
+     * @see #ftCreate(String, List)
      */
     @Experimental
-    Executions<String> ftDropindex(K index);
+    Executions<String> ftDropindex(String index);
 
     /**
      * Drop a search index with optional document deletion.
@@ -917,7 +917,7 @@ public interface NodeSelectionSearchCommands<K, V> {
      * </p>
      *
      * <p>
-     * <strong>Asynchronous Behavior:</strong> If an index creation is still running ({@link #ftCreate(Object, List)} is running
+     * <strong>Asynchronous Behavior:</strong> If an index creation is still running ({@link #ftCreate(String, List)} is running
      * asynchronously), only the document hashes that have already been indexed are deleted. Documents that are queued for
      * indexing but not yet processed will remain in the database.
      * </p>
@@ -931,11 +931,11 @@ public interface NodeSelectionSearchCommands<K, V> {
      * @return {@code "OK"} if the index was successfully dropped
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dropindex/">FT.DROPINDEX</a>
-     * @see #ftDropindex(Object)
-     * @see #ftCreate(Object, List)
+     * @see #ftDropindex(String)
+     * @see #ftCreate(String, List)
      */
     @Experimental
-    Executions<String> ftDropindex(K index, boolean deleteDocuments);
+    Executions<String> ftDropindex(String index, boolean deleteDocuments);
 
     /**
      * Search the index with a textual query using default search options.

--- a/src/main/java/io/lettuce/core/search/arguments/AggregateArgs.java
+++ b/src/main/java/io/lettuce/core/search/arguments/AggregateArgs.java
@@ -495,10 +495,10 @@ public class AggregateArgs<K, V> {
                 }
                 args.add(argCount);
                 for (LoadField<K> loadField : loadFields) {
-                    args.addKey(loadField.field);
+                    args.add(loadField.field.toString());
                     if (loadField.alias != null) {
                         args.add(CommandKeyword.AS);
-                        args.addKey(loadField.alias);
+                        args.add(loadField.alias.toString());
                     }
                 }
             }
@@ -534,7 +534,7 @@ public class AggregateArgs<K, V> {
             args.add(CommandKeyword.PARAMS);
             args.add(params.size() * 2L);
             params.forEach((key, value) -> {
-                args.addKey(key);
+                args.add(key.toString());
                 args.addValue(value);
             });
         }
@@ -713,7 +713,7 @@ public class AggregateArgs<K, V> {
                 if (!propertyStr.startsWith("@")) {
                     args.add("@" + propertyStr);
                 } else {
-                    args.addKey(property);
+                    args.add(propertyStr);
                 }
             }
 
@@ -820,7 +820,7 @@ public class AggregateArgs<K, V> {
                 if (!propertyStr.startsWith("@")) {
                     args.add("@" + propertyStr);
                 } else {
-                    args.addKey(property.property);
+                    args.add(propertyStr);
                 }
                 args.add(property.direction.name());
             }
@@ -896,7 +896,7 @@ public class AggregateArgs<K, V> {
             args.add(CommandKeyword.APPLY);
             args.addValue(expression);
             args.add(CommandKeyword.AS);
-            args.addKey(name);
+            args.add(name.toString());
         }
 
         /**
@@ -1060,7 +1060,7 @@ public class AggregateArgs<K, V> {
 
             alias.ifPresent(a -> {
                 args.add(CommandKeyword.AS);
-                args.addKey(a);
+                args.add(a.toString());
             });
         }
 

--- a/src/main/java/io/lettuce/core/search/arguments/CreateArgs.java
+++ b/src/main/java/io/lettuce/core/search/arguments/CreateArgs.java
@@ -494,7 +494,7 @@ public class CreateArgs<K, V> {
         on.ifPresent(targetType -> args.add(ON).add(targetType.name()));
         if (!prefixes.isEmpty()) {
             args.add(PREFIX).add(prefixes.size());
-            prefixes.forEach(args::addKey);
+            prefixes.forEach(p -> args.add(p.toString()));
         }
         filter.ifPresent(filter -> args.add(FILTER).addValue(filter));
         defaultLanguage.ifPresent(language -> args.add(LANGUAGE).add(language.toString()));

--- a/src/main/java/io/lettuce/core/search/arguments/FieldArgs.java
+++ b/src/main/java/io/lettuce/core/search/arguments/FieldArgs.java
@@ -119,8 +119,8 @@ public abstract class FieldArgs<K> {
      * @param args the command arguments to modify
      */
     public final void build(CommandArgs<K, ?> args) {
-        args.addKey(name);
-        as.ifPresent(a -> args.add(AS).addKey(a));
+        args.add(name.toString());
+        as.ifPresent(a -> args.add(AS).add(a.toString()));
         args.add(getFieldType());
 
         // Add type-specific arguments

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RediSearchCoroutinesCommands.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RediSearchCoroutinesCommands.kt
@@ -368,7 +368,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @see #ftCreate(Any, CreateArgs, List)
      */
     @Experimental
-    suspend fun ftTagvals(index: K, fieldName: K): List<V>
+    suspend fun ftTagvals(index: String, fieldName: K): List<V>
 
     /**
      * Perform spelling correction on a query, returning suggestions for misspelled terms.
@@ -403,13 +403,13 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
-     * @see #ftSpellcheck(Any, Any, SpellCheckArgs)
+     * @see #ftSpellcheck(String, Any, SpellCheckArgs)
      * @see #ftDictadd(Any, Any[])
      * @see #ftDictdel(Any, Any[])
-     * @see #ftDictdump(Any)
+     * @see #ftDictdump(String)
      */
     @Experimental
-    suspend fun ftSpellcheck(index: K, query: V): SpellCheckResult<V>?
+    suspend fun ftSpellcheck(index: String, query: V): SpellCheckResult<V>?
 
     /**
      * Perform spelling correction on a query with additional options.
@@ -440,13 +440,13 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
-     * @see #ftSpellcheck(Any, Any)
+     * @see #ftSpellcheck(String, Any)
      * @see #ftDictadd(Any, Any[])
      * @see #ftDictdel(Any, Any[])
-     * @see #ftDictdump(Any)
+     * @see #ftDictdump(String)
      */
     @Experimental
-    suspend fun ftSpellcheck(index: K, query: V, args: SpellCheckArgs<K, V>): SpellCheckResult<V>?
+    suspend fun ftSpellcheck(index: String, query: V, args: SpellCheckArgs<K, V>): SpellCheckResult<V>?
 
     /**
      * Add terms to a dictionary.
@@ -477,7 +477,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictadd/">FT.DICTADD</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
      * @see #ftDictdel(Any, Any[])
-     * @see #ftDictdump(Any)
+     * @see #ftDictdump(String)
      */
     @Experimental
     suspend fun ftDictadd(dict: K, vararg terms: V): Long?
@@ -500,7 +500,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictdel/">FT.DICTDEL</a>
      * @see #ftDictadd(Any, Any[])
-     * @see #ftDictdump(Any)
+     * @see #ftDictdump(String)
      */
     @Experimental
     suspend fun ftDictdel(dict: K, vararg terms: V): Long?
@@ -524,7 +524,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @see #ftDictdel(Any, Any[])
      */
     @Experimental
-    suspend fun ftDictdump(dict: K): List<V>
+    suspend fun ftDictdump(dict: String): List<V>
 
     /**
      * Return the execution plan for a complex query.
@@ -553,11 +553,11 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @return the execution plan as a string
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.explain/">FT.EXPLAIN</a>
-     * @see #ftExplain(Any, Any, ExplainArgs)
-     * @see #ftSearch(Any, Any)
+     * @see #ftExplain(String, Any, ExplainArgs)
+     * @see #ftSearch(String, Any)
      */
     @Experimental
-    suspend fun ftExplain(index: K, query: V): String?
+    suspend fun ftExplain(index: String, query: V): String?
 
     /**
      * Return the execution plan for a complex query with additional options.
@@ -584,11 +584,11 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @return the execution plan as a string
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.explain/">FT.EXPLAIN</a>
-     * @see #ftExplain(Any, Any)
-     * @see #ftSearch(Any, Any)
+     * @see #ftExplain(String, Any)
+     * @see #ftSearch(String, Any)
      */
     @Experimental
-    suspend fun ftExplain(index: K, query: V, args: ExplainArgs<K, V>): String?
+    suspend fun ftExplain(index: String, query: V, args: ExplainArgs<K, V>): String?
 
     /**
      * Return a list of all existing indexes.
@@ -656,7 +656,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @see #ftSynupdate(Any, Any, SynUpdateArgs, Any[])
      */
     @Experimental
-    suspend fun ftSyndump(index: K): Map<V, List<V>>?
+    suspend fun ftSyndump(index: String): Map<V, List<V>>?
 
     /**
      * Update a synonym group with additional terms.
@@ -687,7 +687,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
      * @see #ftSynupdate(Any, Any, SynUpdateArgs, Any[])
-     * @see #ftSyndump(Any)
+     * @see #ftSyndump(String)
      */
     @Experimental
     suspend fun ftSynupdate(index: K, synonymGroupId: V, vararg terms: V): String?
@@ -719,7 +719,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
      * @see #ftSynupdate(Any, Any, Any[])
-     * @see #ftSyndump(Any)
+     * @see #ftSyndump(String)
      */
     @Experimental
     suspend fun ftSynupdate(index: K, synonymGroupId: V, args: SynUpdateArgs<K, V>, vararg terms: V): String?
@@ -972,10 +972,10 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @see <a href="https://redis.io/docs/latest/develop/interact/search-and-query/query/">Query syntax</a>
      * @see SearchReply
      * @see SearchArgs
-     * @see #ftSearch(Any, Any, SearchArgs)
+     * @see #ftSearch(String, Any, SearchArgs)
      */
     @Experimental
-    suspend fun ftSearch(index: K, query: V): SearchReply<K, V>?
+    suspend fun ftSearch(index: String, query: V): SearchReply<K, V>?
 
     /**
      * Search the index with a textual query using advanced search options and filters.
@@ -1023,23 +1023,23 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @see <a href="https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/">Advanced concepts</a>
      * @see SearchReply
      * @see SearchArgs
-     * @see #ftSearch(Any, Any)
+     * @see #ftSearch(String, Any)
      */
     @Experimental
-    suspend fun ftSearch(index: K, query: V, args: SearchArgs<K, V>): SearchReply<K, V>?
+    suspend fun ftSearch(index: String, query: V, args: SearchArgs<K, V>): SearchReply<K, V>?
 
     /**
      * Run a search query on an index and perform basic aggregate transformations using default options.
      *
      * <p>
      * This command executes a search query and applies aggregation operations to transform and analyze the results. Unlike
-     * [ftSearch(Any, Any)], which returns individual documents, FT.AGGREGATE processes the result set through a
+     * [ftSearch(String, Any)], which returns individual documents, FT.AGGREGATE processes the result set through a
      * pipeline of transformations to produce analytical insights, summaries, and computed values.
      * </p>
      *
      * <p>
      * This basic variant uses default aggregation behavior without additional pipeline operations. For advanced aggregations
-     * with grouping, sorting, filtering, and custom transformations, use [ftAggregate(Any, Any, AggregateArgs)].
+     * with grouping, sorting, filtering, and custom transformations, use [ftAggregate(String, Any, AggregateArgs)].
      * </p>
      *
      * <p>
@@ -1065,10 +1065,10 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/">Aggregations</a>
      * @see SearchReply
      * @see AggregateArgs
-     * @see #ftAggregate(Any, Any, AggregateArgs)
+     * @see #ftAggregate(String, Any, AggregateArgs)
      */
     @Experimental
-    suspend fun ftAggregate(index: K, query: V): AggregationReply<K, V>?
+    suspend fun ftAggregate(index: String, query: V): AggregationReply<K, V>?
 
     /**
      * Run a search query on an index and perform advanced aggregate transformations with a processing pipeline.
@@ -1120,18 +1120,18 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      *      API</a>
      * @see SearchReply
      * @see AggregateArgs
-     * @see #ftAggregate(Any, Any)
+     * @see #ftAggregate(String, Any)
      * @see #ftCursorread(Any, long)
      */
     @Experimental
-    suspend fun ftAggregate(index: K, query: V, args: AggregateArgs<K, V>): AggregationReply<K, V>?
+    suspend fun ftAggregate(index: String, query: V, args: AggregateArgs<K, V>): AggregationReply<K, V>?
 
     /**
      * Read next results from an existing cursor.
      *
      * <p>
      * This command is used to read the next batch of results from a cursor created by
-     * [ftAggregate(Any, Any, AggregateArgs)] with the `WITHCURSOR` option. Cursors provide an efficient way
+     * [ftAggregate(String, Any, AggregateArgs)] with the `WITHCURSOR` option. Cursors provide an efficient way
      * to iterate through large result sets without loading all results into memory at once.
      * </p>
      *
@@ -1155,7 +1155,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
      * @see SearchReply
-     * @see #ftAggregate(Any, Any, AggregateArgs)
+     * @see #ftAggregate(String, Any, AggregateArgs)
      */
     @Experimental
     suspend fun ftCursorread(index: K, cursorId: Long, count: Int): AggregationReply<K, V>?
@@ -1188,7 +1188,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
      * @see SearchReply
-     * @see #ftAggregate(Any, Any, AggregateArgs)
+     * @see #ftAggregate(String, Any, AggregateArgs)
      */
     @Experimental
     suspend fun ftCursorread(index: K, cursorId: Long): AggregationReply<K, V>?
@@ -1197,7 +1197,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * Delete a cursor and free its associated resources.
      *
      * <p>
-     * This command is used to explicitly delete a cursor created by [ftAggregate(Any, Any, AggregateArgs)] with
+     * This command is used to explicitly delete a cursor created by [ftAggregate(String, Any, AggregateArgs)] with
      * the `WITHCURSOR` option. Deleting a cursor frees up server resources and should be done when you no longer need to
      * read more results from the cursor.
      * </p>
@@ -1225,7 +1225,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @see <a href=
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
-     * @see #ftAggregate(Any, Any, AggregateArgs)
+     * @see #ftAggregate(String, Any, AggregateArgs)
      * @see #ftCursorread(Any, long)
      * @see #ftCursorread(Any, long, Integer)
      */

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RediSearchCoroutinesCommands.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RediSearchCoroutinesCommands.kt
@@ -1144,7 +1144,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * <strong>Time complexity:</strong> O(1)
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param cursorId the cursor id obtained from a previous `FT.AGGREGATE` or `FT.CURSOR READ` command
      * @param count the number of results to read. This parameter overrides the `COUNT` specified in `FT.AGGREGATE`
      * @return the result of the cursor read command containing the next batch of results and potentially a new cursor id, see
@@ -1158,14 +1158,14 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @see #ftAggregate(String, Any, AggregateArgs)
      */
     @Experimental
-    suspend fun ftCursorread(index: K, cursorId: Long, count: Int): AggregationReply<K, V>?
+    suspend fun ftCursorread(index: String, cursorId: Long, count: Int): AggregationReply<K, V>?
 
     /**
      * Read next results from an existing cursor using the default batch size.
      *
      * <p>
      * This command is used to read the next batch of results from a cursor created by
-     * [ftAggregate(Any, Any, AggregateArgs)] with the `WITHCURSOR` option. This variant uses the default
+     * [ftAggregate(String, Any, AggregateArgs)] with the `WITHCURSOR` option. This variant uses the default
      * batch size that was specified in the original `FT.AGGREGATE` command's `WITHCURSOR` clause.
      * </p>
      *
@@ -1178,7 +1178,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * <strong>Time complexity:</strong> O(1)
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param cursorId the cursor id obtained from a previous `FT.AGGREGATE` or `FT.CURSOR READ` command
      * @return the result of the cursor read command containing the next batch of results and potentially a new cursor id, see
      *         [SearchReply]
@@ -1191,7 +1191,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @see #ftAggregate(String, Any, AggregateArgs)
      */
     @Experimental
-    suspend fun ftCursorread(index: K, cursorId: Long): AggregationReply<K, V>?
+    suspend fun ftCursorread(index: String, cursorId: Long): AggregationReply<K, V>?
 
     /**
      * Delete a cursor and free its associated resources.
@@ -1209,8 +1209,8 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * </p>
      *
      * <p>
-     * Once a cursor is deleted, any subsequent attempts to read from it using [ftCursorread(Any, long)] or
-     * [ftCursorread(Any, long, Integer)] will result in an error.
+     * Once a cursor is deleted, any subsequent attempts to read from it using [ftCursorread(String, long)] or
+     * [ftCursorread(String, long, Integer)] will result in an error.
      * </p>
      *
      * <p>
@@ -1226,11 +1226,11 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
      * @see #ftAggregate(String, Any, AggregateArgs)
-     * @see #ftCursorread(Any, long)
-     * @see #ftCursorread(Any, long, Integer)
+     * @see #ftCursorread(String, long)
+     * @see #ftCursorread(String, long, Integer)
      */
     @Experimental
-    suspend fun ftCursordel(index: K, cursorId: Long): String?
+    suspend fun ftCursordel(index: String, cursorId: Long): String?
 
 }
 

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RediSearchCoroutinesCommands.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RediSearchCoroutinesCommands.kt
@@ -8,7 +8,6 @@
 package io.lettuce.core.api.coroutines
 
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
-import kotlinx.coroutines.flow.Flow
 import io.lettuce.core.annotations.Experimental
 import io.lettuce.core.search.AggregationReply
 import io.lettuce.core.search.SearchReply
@@ -57,11 +56,11 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.create/">FT.CREATE</a>
      * @see CreateArgs
      * @see FieldArgs
-     * @see #ftCreate(Any, CreateArgs, List)
-     * @see #ftDropindex(Any)
+     * @see #ftCreate(String, CreateArgs, List)
+     * @see #ftDropindex(String)
      */
     @Experimental
-    suspend fun ftCreate(index: K, fieldArgs: List<FieldArgs<K>>): String?
+    suspend fun ftCreate(index: String, fieldArgs: List<FieldArgs<K>>): String?
 
     /**
      * Create a new search index with the given name, custom configuration, and field definitions.
@@ -96,11 +95,11 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.create/">FT.CREATE</a>
      * @see CreateArgs
      * @see FieldArgs
-     * @see #ftCreate(Any, List)
-     * @see #ftDropindex(Any)
+     * @see #ftCreate(String, List)
+     * @see #ftDropindex(String)
      */
     @Experimental
-    suspend fun ftCreate(index: K, arguments: CreateArgs<K, V>, fieldArgs: List<FieldArgs<K>>): String?
+    suspend fun ftCreate(index: String, arguments: CreateArgs<K, V>, fieldArgs: List<FieldArgs<K>>): String?
 
     /**
      * Add an alias to a search index.
@@ -128,7 +127,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * <li>An index can have multiple aliases, but an alias can only point to one index</li>
      * <li>Aliases cannot reference other aliases (no alias chaining)</li>
      * <li>If the alias already exists, this command will fail with an error</li>
-     * <li>Use [ftAliasupdate(Any, Any)] to reassign an existing alias</li>
+     * <li>Use [ftAliasupdate(String, String)] to reassign an existing alias</li>
      * </ul>
      *
      * <p>
@@ -140,18 +139,18 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @return @code "OK"} if the alias was successfully created
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.aliasadd/">FT.ALIASADD</a>
-     * @see #ftAliasupdate(Any, Any)
-     * @see #ftAliasdel(Any)
+     * @see #ftAliasupdate(String, String)
+     * @see #ftAliasdel(String)
      */
     @Experimental
-    suspend fun ftAliasadd(alias: K, index: K): String?
+    suspend fun ftAliasadd(alias: String, index: String): String?
 
     /**
      * Update an existing alias to point to a different search index.
      *
      * <p>
      * This command updates an existing alias to point to a different index, or creates the alias if it doesn't exist. Unlike
-     * [ftAliasadd(Any, Any)], this command will succeed even if the alias already exists, making it useful for
+     * [ftAliasadd(String, String)], this command will succeed even if the alias already exists, making it useful for
      * atomic alias updates during index migrations.
      * </p>
      *
@@ -184,11 +183,11 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @return @code "OK"} if the alias was successfully updated
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.aliasupdate/">FT.ALIASUPDATE</a>
-     * @see #ftAliasadd(Any, Any)
-     * @see #ftAliasdel(Any)
+     * @see #ftAliasadd(String, String)
+     * @see #ftAliasdel(String)
      */
     @Experimental
-    suspend fun ftAliasupdate(alias: K, index: K): String?
+    suspend fun ftAliasupdate(alias: String, index: String): String?
 
     /**
      * Remove an alias from a search index.
@@ -215,7 +214,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * <li>Only the alias is removed - the target index is not affected</li>
      * <li>If the alias doesn't exist, this command will fail with an error</li>
      * <li>Applications using the alias will receive errors after deletion</li>
-     * <li>Consider using [ftAliasupdate(Any, Any)] to redirect before deletion</li>
+     * <li>Consider using [ftAliasupdate(String, String)] to redirect before deletion</li>
      * </ul>
      *
      * <p>
@@ -226,11 +225,11 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @return @code "OK"} if the alias was successfully removed
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.aliasdel/">FT.ALIASDEL</a>
-     * @see #ftAliasadd(Any, Any)
-     * @see #ftAliasupdate(Any, Any)
+     * @see #ftAliasadd(String, String)
+     * @see #ftAliasupdate(String, String)
      */
     @Experimental
-    suspend fun ftAliasdel(alias: K): String?
+    suspend fun ftAliasdel(alias: String): String?
 
     /**
      * Add new attributes to an existing search index.
@@ -273,11 +272,11 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.alter/">FT.ALTER</a>
      * @see FieldArgs
-     * @see #ftCreate(Any, List)
-     * @see #ftCreate(Any, CreateArgs, List)
+     * @see #ftCreate(String, List)
+     * @see #ftCreate(String, CreateArgs, List)
      */
     @Experimental
-    suspend fun ftAlter(index: K, skipInitialScan: Boolean, fieldArgs: List<FieldArgs<K>>): String?
+    suspend fun ftAlter(index: String, skipInitialScan: Boolean, fieldArgs: List<FieldArgs<K>>): String?
 
     /**
      * Add new attributes to an existing search index.
@@ -308,11 +307,11 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.alter/">FT.ALTER</a>
      * @see FieldArgs
-     * @see #ftCreate(Any, List)
-     * @see #ftCreate(Any, CreateArgs, List)
+     * @see #ftCreate(String, List)
+     * @see #ftCreate(String, CreateArgs, List)
      */
     @Experimental
-    suspend fun ftAlter(index: K, fieldArgs: List<FieldArgs<K>>): String?
+    suspend fun ftAlter(index: String, fieldArgs: List<FieldArgs<K>>): String?
 
     /**
      * Return a distinct set of values indexed in a Tag field.
@@ -364,11 +363,11 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      *         were indexed (lowercase, whitespace removed).
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.tagvals/">FT.TAGVALS</a>
-     * @see #ftCreate(Any, List)
-     * @see #ftCreate(Any, CreateArgs, List)
+     * @see #ftCreate(String, List)
+     * @see #ftCreate(String, CreateArgs, List)
      */
     @Experimental
-    suspend fun ftTagvals(index: String, fieldName: K): List<V>
+    suspend fun ftTagvals(index: String, fieldName: String): List<V>
 
     /**
      * Perform spelling correction on a query, returning suggestions for misspelled terms.
@@ -404,8 +403,8 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
      * @see #ftSpellcheck(String, Any, SpellCheckArgs)
-     * @see #ftDictadd(Any, Any[])
-     * @see #ftDictdel(Any, Any[])
+     * @see #ftDictadd(String, Any[])
+     * @see #ftDictdel(String, Any[])
      * @see #ftDictdump(String)
      */
     @Experimental
@@ -441,8 +440,8 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
      * @see #ftSpellcheck(String, Any)
-     * @see #ftDictadd(Any, Any[])
-     * @see #ftDictdel(Any, Any[])
+     * @see #ftDictadd(String, Any[])
+     * @see #ftDictdel(String, Any[])
      * @see #ftDictdump(String)
      */
     @Experimental
@@ -476,11 +475,11 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictadd/">FT.DICTADD</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
-     * @see #ftDictdel(Any, Any[])
+     * @see #ftDictdel(String, Any[])
      * @see #ftDictdump(String)
      */
     @Experimental
-    suspend fun ftDictadd(dict: K, vararg terms: V): Long?
+    suspend fun ftDictadd(dict: String, vararg terms: V): Long?
 
     /**
      * Delete terms from a dictionary.
@@ -499,11 +498,11 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @return the number of terms that were deleted
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictdel/">FT.DICTDEL</a>
-     * @see #ftDictadd(Any, Any[])
+     * @see #ftDictadd(String, Any[])
      * @see #ftDictdump(String)
      */
     @Experimental
-    suspend fun ftDictdel(dict: K, vararg terms: V): Long?
+    suspend fun ftDictdel(dict: String, vararg terms: V): Long?
 
     /**
      * Dump all terms in a dictionary.
@@ -520,8 +519,8 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @return a list of all terms in the dictionary
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictdump/">FT.DICTDUMP</a>
-     * @see #ftDictadd(Any, Any[])
-     * @see #ftDictdel(Any, Any[])
+     * @see #ftDictadd(String, Any[])
+     * @see #ftDictdel(String, Any[])
      */
     @Experimental
     suspend fun ftDictdump(dict: String): List<V>
@@ -620,8 +619,8 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @return a list of index names
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft._list/">FT._LIST</a>
-     * @see #ftCreate(Any, CreateArgs, FieldArgs[])
-     * @see #ftDropindex(Any)
+     * @see #ftCreate(String, CreateArgs, FieldArgs[])
+     * @see #ftDropindex(String)
      */
     @Experimental
     suspend fun ftList(): List<V>
@@ -652,8 +651,8 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @return a map where keys are synonym terms and values are lists of group IDs containing that synonym
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.syndump/">FT.SYNDUMP</a>
-     * @see #ftSynupdate(Any, Any, Any[])
-     * @see #ftSynupdate(Any, Any, SynUpdateArgs, Any[])
+     * @see #ftSynupdate(String, Any, Any[])
+     * @see #ftSynupdate(String, Any, SynUpdateArgs, Any[])
      */
     @Experimental
     suspend fun ftSyndump(index: String): Map<V, List<V>>?
@@ -686,11 +685,11 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @return OK if executed correctly
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
-     * @see #ftSynupdate(Any, Any, SynUpdateArgs, Any[])
+     * @see #ftSynupdate(String, Any, SynUpdateArgs, Any[])
      * @see #ftSyndump(String)
      */
     @Experimental
-    suspend fun ftSynupdate(index: K, synonymGroupId: V, vararg terms: V): String?
+    suspend fun ftSynupdate(index: String, synonymGroupId: V, vararg terms: V): String?
 
     /**
      * Update a synonym group with additional terms and options.
@@ -718,11 +717,11 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @return OK if executed correctly
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
-     * @see #ftSynupdate(Any, Any, Any[])
+     * @see #ftSynupdate(String, Any, Any[])
      * @see #ftSyndump(String)
      */
     @Experimental
-    suspend fun ftSynupdate(index: K, synonymGroupId: V, args: SynUpdateArgs<K, V>, vararg terms: V): String?
+    suspend fun ftSynupdate(index: String, synonymGroupId: V, args: SynUpdateArgs<K, V>, vararg terms: V): String?
 
     /**
      * Add a suggestion string to an auto-complete suggestion dictionary.
@@ -902,11 +901,11 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @return @code "OK"} if the index was successfully dropped
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dropindex/">FT.DROPINDEX</a>
-     * @see #ftDropindex(Any, boolean)
-     * @see #ftCreate(Any, List)
+     * @see #ftDropindex(String, boolean)
+     * @see #ftCreate(String, List)
      */
     @Experimental
-    suspend fun ftDropindex(index: K): String?
+    suspend fun ftDropindex(index: String): String?
 
     /**
      * Drop a search index with optional document deletion.
@@ -918,7 +917,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * </p>
      *
      * <p>
-     * <strong>Asynchronous Behavior:</strong> If an index creation is still running ([ftCreate(Any, List)] is running
+     * <strong>Asynchronous Behavior:</strong> If an index creation is still running ([ftCreate(String, List)] is running
      * asynchronously), only the document hashes that have already been indexed are deleted. Documents that are queued for
      * indexing but not yet processed will remain in the database.
      * </p>
@@ -932,11 +931,11 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @return @code "OK"} if the index was successfully dropped
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dropindex/">FT.DROPINDEX</a>
-     * @see #ftDropindex(Any)
-     * @see #ftCreate(Any, List)
+     * @see #ftDropindex(String)
+     * @see #ftCreate(String, List)
      */
     @Experimental
-    suspend fun ftDropindex(index: K, deleteDocuments: Boolean): String?
+    suspend fun ftDropindex(index: String, deleteDocuments: Boolean): String?
 
     /**
      * Search the index with a textual query using default search options.
@@ -1121,7 +1120,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * @see SearchReply
      * @see AggregateArgs
      * @see #ftAggregate(String, Any)
-     * @see #ftCursorread(Any, long)
+     * @see #ftCursorread(String, long)
      */
     @Experimental
     suspend fun ftAggregate(index: String, query: V, args: AggregateArgs<K, V>): AggregationReply<K, V>?

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RediSearchCoroutinesCommands.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RediSearchCoroutinesCommands.kt
@@ -50,7 +50,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * triggered, where N is the number of keys in the keyspace
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param fieldArgs the [FieldArgs] list defining the searchable fields and their types
      * @return @code "OK"} if the index was created successfully
      * @see <a href="https://redis.io/docs/latest/commands/ft.create/">FT.CREATE</a>
@@ -87,7 +87,7 @@ interface RediSearchCoroutinesCommands<K : Any, V : Any> {
      * triggered, where N is the number of keys in the keyspace
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param arguments the index [CreateArgs] containing configuration options
      * @param fieldArgs the [FieldArgs] list defining the searchable fields and their types
      * @return @code "OK"} if the index was created successfully

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RediSearchCoroutinesCommandsImpl.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RediSearchCoroutinesCommandsImpl.kt
@@ -56,7 +56,7 @@ open class RediSearchCoroutinesCommandsImpl<K : Any, V : Any>(internal val ops: 
     override suspend fun ftAlter(index: K, skipInitialScan: Boolean, fieldArgs: List<FieldArgs<K>>): String? =
         ops.ftAlter(index, skipInitialScan, fieldArgs).awaitFirstOrNull()
 
-     override suspend fun ftTagvals(index: K, fieldName: K): List<V> =
+     override suspend fun ftTagvals(index: String, fieldName: K): List<V> =
          ops.ftTagvals(index, fieldName).asFlow().toList()
 
     override suspend fun ftAlter(index: K, fieldArgs: List<FieldArgs<K>>): String? =
@@ -68,16 +68,16 @@ open class RediSearchCoroutinesCommandsImpl<K : Any, V : Any>(internal val ops: 
     override suspend fun ftDropindex(index: K): String? =
         ops.ftDropindex(index).awaitFirstOrNull()
 
-    override suspend fun ftSearch(index: K, query: V): SearchReply<K, V>? =
+    override suspend fun ftSearch(index: String, query: V): SearchReply<K, V>? =
         ops.ftSearch(index, query).awaitFirstOrNull()
 
-    override suspend fun ftSearch(index: K, query: V, args: SearchArgs<K, V>): SearchReply<K, V>? =
+    override suspend fun ftSearch(index: String, query: V, args: SearchArgs<K, V>): SearchReply<K, V>? =
         ops.ftSearch(index, query, args).awaitFirstOrNull()
 
-    override suspend fun ftAggregate(index: K, query: V, args: AggregateArgs<K, V>): AggregationReply<K, V>? =
+    override suspend fun ftAggregate(index: String, query: V, args: AggregateArgs<K, V>): AggregationReply<K, V>? =
         ops.ftAggregate(index, query, args).awaitFirstOrNull()
 
-    override suspend fun ftAggregate(index: K, query: V): AggregationReply<K, V>? =
+    override suspend fun ftAggregate(index: String, query: V): AggregationReply<K, V>? =
         ops.ftAggregate(index, query).awaitFirstOrNull()
 
     override suspend fun ftCursorread(index: K, cursorId: Long): AggregationReply<K, V>? =
@@ -96,13 +96,13 @@ open class RediSearchCoroutinesCommandsImpl<K : Any, V : Any>(internal val ops: 
     override suspend fun ftDictdel(dict: K, vararg terms: V): Long? =
         ops.ftDictdel(dict, *terms).awaitFirstOrNull()
 
-    override suspend fun ftDictdump(dict: K): List<V> =
+    override suspend fun ftDictdump(dict: String): List<V> =
         ops.ftDictdump(dict).asFlow().toList()
 
-    override suspend fun ftSpellcheck(index: K, query: V): SpellCheckResult<V>? =
+    override suspend fun ftSpellcheck(index: String, query: V): SpellCheckResult<V>? =
         ops.ftSpellcheck(index, query).awaitFirstOrNull()
 
-    override suspend fun ftSpellcheck(index: K, query: V, args: SpellCheckArgs<K, V>): SpellCheckResult<V>? =
+    override suspend fun ftSpellcheck(index: String, query: V, args: SpellCheckArgs<K, V>): SpellCheckResult<V>? =
         ops.ftSpellcheck(index, query, args).awaitFirstOrNull()
 
     override suspend fun ftSugadd(key: K, suggestion: V, score: Double): Long? =
@@ -129,13 +129,13 @@ open class RediSearchCoroutinesCommandsImpl<K : Any, V : Any>(internal val ops: 
     override suspend fun ftSynupdate(index: K, synonymGroupId: V, args: SynUpdateArgs<K, V>, vararg terms: V): String? =
         ops.ftSynupdate(index, synonymGroupId, args, *terms).awaitFirstOrNull()
 
-    override suspend fun ftSyndump(index: K): Map<V, List<V>> =
-        ops.ftSyndump(index).awaitFirstOrNull()!!
+    override suspend fun ftSyndump(index: String): Map<V, List<V>>? =
+        ops.ftSyndump(index).awaitFirstOrNull()
 
-    override suspend fun ftExplain(index: K, query: V): String? =
+    override suspend fun ftExplain(index: String, query: V): String? =
         ops.ftExplain(index, query).awaitFirstOrNull()
 
-    override suspend fun ftExplain(index: K, query: V, args: ExplainArgs<K, V>): String? =
+    override suspend fun ftExplain(index: String, query: V, args: ExplainArgs<K, V>): String? =
         ops.ftExplain(index, query, args).awaitFirstOrNull()
 
     override suspend fun ftList(): List<V> =

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RediSearchCoroutinesCommandsImpl.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RediSearchCoroutinesCommandsImpl.kt
@@ -38,34 +38,34 @@ import kotlinx.coroutines.reactive.awaitFirstOrNull
 open class RediSearchCoroutinesCommandsImpl<K : Any, V : Any>(internal val ops: RediSearchReactiveCommands<K, V>) :
     RediSearchCoroutinesCommands<K, V> {
 
-    override suspend fun ftCreate(index: K, arguments: CreateArgs<K, V>, fieldArgs: List<FieldArgs<K>>): String? =
+    override suspend fun ftCreate(index: String, arguments: CreateArgs<K, V>, fieldArgs: List<FieldArgs<K>>): String? =
         ops.ftCreate(index, arguments, fieldArgs).awaitFirstOrNull()
 
-    override suspend fun ftCreate(index: K, fieldArgs: List<FieldArgs<K>>): String? =
+    override suspend fun ftCreate(index: String, fieldArgs: List<FieldArgs<K>>): String? =
         ops.ftCreate(index, fieldArgs).awaitFirstOrNull()
 
-    override suspend fun ftAliasadd(alias: K, index: K): String? =
+    override suspend fun ftAliasadd(alias: String, index: String): String? =
         ops.ftAliasadd(alias, index).awaitFirstOrNull()
 
-    override suspend fun ftAliasupdate(alias: K, index: K): String? =
+    override suspend fun ftAliasupdate(alias: String, index: String): String? =
         ops.ftAliasupdate(alias, index).awaitFirstOrNull()
 
-    override suspend fun ftAliasdel(alias: K): String? =
+    override suspend fun ftAliasdel(alias: String): String? =
         ops.ftAliasdel(alias).awaitFirstOrNull()
 
-    override suspend fun ftAlter(index: K, skipInitialScan: Boolean, fieldArgs: List<FieldArgs<K>>): String? =
+    override suspend fun ftAlter(index: String, skipInitialScan: Boolean, fieldArgs: List<FieldArgs<K>>): String? =
         ops.ftAlter(index, skipInitialScan, fieldArgs).awaitFirstOrNull()
 
-     override suspend fun ftTagvals(index: String, fieldName: K): List<V> =
+     override suspend fun ftTagvals(index: String, fieldName: String): List<V> =
          ops.ftTagvals(index, fieldName).asFlow().toList()
 
-    override suspend fun ftAlter(index: K, fieldArgs: List<FieldArgs<K>>): String? =
+    override suspend fun ftAlter(index: String, fieldArgs: List<FieldArgs<K>>): String? =
         ops.ftAlter(index, fieldArgs).awaitFirstOrNull()
 
-    override suspend fun ftDropindex(index: K, deleteDocuments: Boolean): String? =
+    override suspend fun ftDropindex(index: String, deleteDocuments: Boolean): String? =
         ops.ftDropindex(index, deleteDocuments).awaitFirstOrNull()
 
-    override suspend fun ftDropindex(index: K): String? =
+    override suspend fun ftDropindex(index: String): String? =
         ops.ftDropindex(index).awaitFirstOrNull()
 
     override suspend fun ftSearch(index: String, query: V): SearchReply<K, V>? =
@@ -90,10 +90,10 @@ open class RediSearchCoroutinesCommandsImpl<K : Any, V : Any>(internal val ops: 
         return ops.ftCursordel(index, cursorId).awaitFirstOrNull()
     }
 
-    override suspend fun ftDictadd(dict: K, vararg terms: V): Long? =
+    override suspend fun ftDictadd(dict: String, vararg terms: V): Long? =
         ops.ftDictadd(dict, *terms).awaitFirstOrNull()
 
-    override suspend fun ftDictdel(dict: K, vararg terms: V): Long? =
+    override suspend fun ftDictdel(dict: String, vararg terms: V): Long? =
         ops.ftDictdel(dict, *terms).awaitFirstOrNull()
 
     override suspend fun ftDictdump(dict: String): List<V> =
@@ -123,10 +123,10 @@ open class RediSearchCoroutinesCommandsImpl<K : Any, V : Any>(internal val ops: 
     override suspend fun ftSuglen(key: K): Long? =
         ops.ftSuglen(key).awaitFirstOrNull()
 
-    override suspend fun ftSynupdate(index: K, synonymGroupId: V, vararg terms: V): String? =
+    override suspend fun ftSynupdate(index: String, synonymGroupId: V, vararg terms: V): String? =
         ops.ftSynupdate(index, synonymGroupId, *terms).awaitFirstOrNull()
 
-    override suspend fun ftSynupdate(index: K, synonymGroupId: V, args: SynUpdateArgs<K, V>, vararg terms: V): String? =
+    override suspend fun ftSynupdate(index: String, synonymGroupId: V, args: SynUpdateArgs<K, V>, vararg terms: V): String? =
         ops.ftSynupdate(index, synonymGroupId, args, *terms).awaitFirstOrNull()
 
     override suspend fun ftSyndump(index: String): Map<V, List<V>>? =

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RediSearchCoroutinesCommandsImpl.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RediSearchCoroutinesCommandsImpl.kt
@@ -80,13 +80,13 @@ open class RediSearchCoroutinesCommandsImpl<K : Any, V : Any>(internal val ops: 
     override suspend fun ftAggregate(index: String, query: V): AggregationReply<K, V>? =
         ops.ftAggregate(index, query).awaitFirstOrNull()
 
-    override suspend fun ftCursorread(index: K, cursorId: Long): AggregationReply<K, V>? =
+    override suspend fun ftCursorread(index: String, cursorId: Long): AggregationReply<K, V>? =
         ops.ftCursorread(index, cursorId).awaitFirstOrNull()
 
-    override suspend fun ftCursorread(index: K, cursorId: Long, count: Int): AggregationReply<K, V>? =
+    override suspend fun ftCursorread(index: String, cursorId: Long, count: Int): AggregationReply<K, V>? =
         ops.ftCursorread(index, cursorId, count).awaitFirstOrNull()
 
-    override suspend fun ftCursordel(index: K, cursorId: Long): String? {
+    override suspend fun ftCursordel(index: String, cursorId: Long): String? {
         return ops.ftCursordel(index, cursorId).awaitFirstOrNull()
     }
 

--- a/src/main/templates/io/lettuce/core/api/RediSearchCommands.java
+++ b/src/main/templates/io/lettuce/core/api/RediSearchCommands.java
@@ -55,11 +55,11 @@ public interface RediSearchCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.create/">FT.CREATE</a>
      * @see CreateArgs
      * @see FieldArgs
-     * @see #ftCreate(Object, CreateArgs, List)
-     * @see #ftDropindex(Object)
+     * @see #ftCreate(String, CreateArgs, List)
+     * @see #ftDropindex(String)
      */
     @Experimental
-    String ftCreate(K index, List<FieldArgs<K>> fieldArgs);
+    String ftCreate(String index, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Create a new search index with the given name, custom configuration, and field definitions.
@@ -94,11 +94,11 @@ public interface RediSearchCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.create/">FT.CREATE</a>
      * @see CreateArgs
      * @see FieldArgs
-     * @see #ftCreate(Object, List)
-     * @see #ftDropindex(Object)
+     * @see #ftCreate(String, List)
+     * @see #ftDropindex(String)
      */
     @Experimental
-    String ftCreate(K index, CreateArgs<K, V> arguments, List<FieldArgs<K>> fieldArgs);
+    String ftCreate(String index, CreateArgs<K, V> arguments, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Add an alias to a search index.
@@ -126,7 +126,7 @@ public interface RediSearchCommands<K, V> {
      * <li>An index can have multiple aliases, but an alias can only point to one index</li>
      * <li>Aliases cannot reference other aliases (no alias chaining)</li>
      * <li>If the alias already exists, this command will fail with an error</li>
-     * <li>Use {@link #ftAliasupdate(Object, Object)} to reassign an existing alias</li>
+     * <li>Use {@link #ftAliasupdate(String, String)} to reassign an existing alias</li>
      * </ul>
      *
      * <p>
@@ -138,18 +138,18 @@ public interface RediSearchCommands<K, V> {
      * @return {@code "OK"} if the alias was successfully created
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.aliasadd/">FT.ALIASADD</a>
-     * @see #ftAliasupdate(Object, Object)
-     * @see #ftAliasdel(Object)
+     * @see #ftAliasupdate(String, String)
+     * @see #ftAliasdel(String)
      */
     @Experimental
-    String ftAliasadd(K alias, K index);
+    String ftAliasadd(String alias, String index);
 
     /**
      * Update an existing alias to point to a different search index.
      *
      * <p>
      * This command updates an existing alias to point to a different index, or creates the alias if it doesn't exist. Unlike
-     * {@link #ftAliasadd(Object, Object)}, this command will succeed even if the alias already exists, making it useful for
+     * {@link #ftAliasadd(String, String)}, this command will succeed even if the alias already exists, making it useful for
      * atomic alias updates during index migrations.
      * </p>
      *
@@ -182,11 +182,11 @@ public interface RediSearchCommands<K, V> {
      * @return {@code "OK"} if the alias was successfully updated
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.aliasupdate/">FT.ALIASUPDATE</a>
-     * @see #ftAliasadd(Object, Object)
-     * @see #ftAliasdel(Object)
+     * @see #ftAliasadd(String, String)
+     * @see #ftAliasdel(String)
      */
     @Experimental
-    String ftAliasupdate(K alias, K index);
+    String ftAliasupdate(String alias, String index);
 
     /**
      * Remove an alias from a search index.
@@ -213,7 +213,7 @@ public interface RediSearchCommands<K, V> {
      * <li>Only the alias is removed - the target index is not affected</li>
      * <li>If the alias doesn't exist, this command will fail with an error</li>
      * <li>Applications using the alias will receive errors after deletion</li>
-     * <li>Consider using {@link #ftAliasupdate(Object, Object)} to redirect before deletion</li>
+     * <li>Consider using {@link #ftAliasupdate(String, String)} to redirect before deletion</li>
      * </ul>
      *
      * <p>
@@ -224,11 +224,11 @@ public interface RediSearchCommands<K, V> {
      * @return {@code "OK"} if the alias was successfully removed
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.aliasdel/">FT.ALIASDEL</a>
-     * @see #ftAliasadd(Object, Object)
-     * @see #ftAliasupdate(Object, Object)
+     * @see #ftAliasadd(String, String)
+     * @see #ftAliasupdate(String, String)
      */
     @Experimental
-    String ftAliasdel(K alias);
+    String ftAliasdel(String alias);
 
     /**
      * Add new attributes to an existing search index.
@@ -271,11 +271,11 @@ public interface RediSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.alter/">FT.ALTER</a>
      * @see FieldArgs
-     * @see #ftCreate(Object, List)
-     * @see #ftCreate(Object, CreateArgs, List)
+     * @see #ftCreate(String, List)
+     * @see #ftCreate(String, CreateArgs, List)
      */
     @Experimental
-    String ftAlter(K index, boolean skipInitialScan, List<FieldArgs<K>> fieldArgs);
+    String ftAlter(String index, boolean skipInitialScan, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Add new attributes to an existing search index.
@@ -306,11 +306,11 @@ public interface RediSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.alter/">FT.ALTER</a>
      * @see FieldArgs
-     * @see #ftCreate(Object, List)
-     * @see #ftCreate(Object, CreateArgs, List)
+     * @see #ftCreate(String, List)
+     * @see #ftCreate(String, CreateArgs, List)
      */
     @Experimental
-    String ftAlter(K index, List<FieldArgs<K>> fieldArgs);
+    String ftAlter(String index, List<FieldArgs<K>> fieldArgs);
 
     /**
      * Return a distinct set of values indexed in a Tag field.
@@ -362,11 +362,11 @@ public interface RediSearchCommands<K, V> {
      *         were indexed (lowercase, whitespace removed).
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.tagvals/">FT.TAGVALS</a>
-     * @see #ftCreate(Object, List)
-     * @see #ftCreate(Object, CreateArgs, List)
+     * @see #ftCreate(String, List)
+     * @see #ftCreate(String, CreateArgs, List)
      */
     @Experimental
-    List<V> ftTagvals(String index, K fieldName);
+    List<V> ftTagvals(String index, String fieldName);
 
     /**
      * Perform spelling correction on a query, returning suggestions for misspelled terms.
@@ -402,8 +402,8 @@ public interface RediSearchCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
      * @see #ftSpellcheck(String, Object, SpellCheckArgs)
-     * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictadd(String, Object[])
+     * @see #ftDictdel(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
@@ -439,8 +439,8 @@ public interface RediSearchCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
      * @see #ftSpellcheck(String, Object)
-     * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictadd(String, Object[])
+     * @see #ftDictdel(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
@@ -474,11 +474,11 @@ public interface RediSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictadd/">FT.DICTADD</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictdel(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
-    Long ftDictadd(K dict, V... terms);
+    Long ftDictadd(String dict, V... terms);
 
     /**
      * Delete terms from a dictionary.
@@ -497,11 +497,11 @@ public interface RediSearchCommands<K, V> {
      * @return the number of terms that were deleted
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictdel/">FT.DICTDEL</a>
-     * @see #ftDictadd(Object, Object[])
+     * @see #ftDictadd(String, Object[])
      * @see #ftDictdump(String)
      */
     @Experimental
-    Long ftDictdel(K dict, V... terms);
+    Long ftDictdel(String dict, V... terms);
 
     /**
      * Dump all terms in a dictionary.
@@ -518,8 +518,8 @@ public interface RediSearchCommands<K, V> {
      * @return a list of all terms in the dictionary
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictdump/">FT.DICTDUMP</a>
-     * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdel(Object, Object[])
+     * @see #ftDictadd(String, Object[])
+     * @see #ftDictdel(String, Object[])
      */
     @Experimental
     List<V> ftDictdump(String dict);
@@ -618,8 +618,8 @@ public interface RediSearchCommands<K, V> {
      * @return a list of index names
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft._list/">FT._LIST</a>
-     * @see #ftCreate(Object, CreateArgs, FieldArgs[])
-     * @see #ftDropindex(Object)
+     * @see #ftCreate(String, CreateArgs, FieldArgs[])
+     * @see #ftDropindex(String)
      */
     @Experimental
     List<V> ftList();
@@ -650,8 +650,8 @@ public interface RediSearchCommands<K, V> {
      * @return a map where keys are synonym terms and values are lists of group IDs containing that synonym
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.syndump/">FT.SYNDUMP</a>
-     * @see #ftSynupdate(Object, Object, Object[])
-     * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
+     * @see #ftSynupdate(String, Object, Object[])
+     * @see #ftSynupdate(String, Object, SynUpdateArgs, Object[])
      */
     @Experimental
     Map<V, List<V>> ftSyndump(String index);
@@ -684,11 +684,11 @@ public interface RediSearchCommands<K, V> {
      * @return OK if executed correctly
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
-     * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
+     * @see #ftSynupdate(String, Object, SynUpdateArgs, Object[])
      * @see #ftSyndump(String)
      */
     @Experimental
-    String ftSynupdate(K index, V synonymGroupId, V... terms);
+    String ftSynupdate(String index, V synonymGroupId, V... terms);
 
     /**
      * Update a synonym group with additional terms and options.
@@ -716,11 +716,11 @@ public interface RediSearchCommands<K, V> {
      * @return OK if executed correctly
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
-     * @see #ftSynupdate(Object, Object, Object[])
+     * @see #ftSynupdate(String, Object, Object[])
      * @see #ftSyndump(String)
      */
     @Experimental
-    String ftSynupdate(K index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms);
+    String ftSynupdate(String index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms);
 
     /**
      * Add a suggestion string to an auto-complete suggestion dictionary.
@@ -900,11 +900,11 @@ public interface RediSearchCommands<K, V> {
      * @return {@code "OK"} if the index was successfully dropped
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dropindex/">FT.DROPINDEX</a>
-     * @see #ftDropindex(Object, boolean)
-     * @see #ftCreate(Object, List)
+     * @see #ftDropindex(String, boolean)
+     * @see #ftCreate(String, List)
      */
     @Experimental
-    String ftDropindex(K index);
+    String ftDropindex(String index);
 
     /**
      * Drop a search index with optional document deletion.
@@ -916,7 +916,7 @@ public interface RediSearchCommands<K, V> {
      * </p>
      *
      * <p>
-     * <strong>Asynchronous Behavior:</strong> If an index creation is still running ({@link #ftCreate(Object, List)} is running
+     * <strong>Asynchronous Behavior:</strong> If an index creation is still running ({@link #ftCreate(String, List)} is running
      * asynchronously), only the document hashes that have already been indexed are deleted. Documents that are queued for
      * indexing but not yet processed will remain in the database.
      * </p>
@@ -930,11 +930,11 @@ public interface RediSearchCommands<K, V> {
      * @return {@code "OK"} if the index was successfully dropped
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dropindex/">FT.DROPINDEX</a>
-     * @see #ftDropindex(Object)
-     * @see #ftCreate(Object, List)
+     * @see #ftDropindex(String)
+     * @see #ftCreate(String, List)
      */
     @Experimental
-    String ftDropindex(K index, boolean deleteDocuments);
+    String ftDropindex(String index, boolean deleteDocuments);
 
     /**
      * Search the index with a textual query using default search options.

--- a/src/main/templates/io/lettuce/core/api/RediSearchCommands.java
+++ b/src/main/templates/io/lettuce/core/api/RediSearchCommands.java
@@ -49,7 +49,7 @@ public interface RediSearchCommands<K, V> {
      * triggered, where N is the number of keys in the keyspace
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param fieldArgs the {@link FieldArgs} list defining the searchable fields and their types
      * @return {@code "OK"} if the index was created successfully
      * @see <a href="https://redis.io/docs/latest/commands/ft.create/">FT.CREATE</a>
@@ -86,7 +86,7 @@ public interface RediSearchCommands<K, V> {
      * triggered, where N is the number of keys in the keyspace
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param arguments the index {@link CreateArgs} containing configuration options
      * @param fieldArgs the {@link FieldArgs} list defining the searchable fields and their types
      * @return {@code "OK"} if the index was created successfully

--- a/src/main/templates/io/lettuce/core/api/RediSearchCommands.java
+++ b/src/main/templates/io/lettuce/core/api/RediSearchCommands.java
@@ -366,7 +366,7 @@ public interface RediSearchCommands<K, V> {
      * @see #ftCreate(Object, CreateArgs, List)
      */
     @Experimental
-    List<V> ftTagvals(K index, K fieldName);
+    List<V> ftTagvals(String index, K fieldName);
 
     /**
      * Perform spelling correction on a query, returning suggestions for misspelled terms.
@@ -401,13 +401,13 @@ public interface RediSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
-     * @see #ftSpellcheck(Object, Object, SpellCheckArgs)
+     * @see #ftSpellcheck(String, Object, SpellCheckArgs)
      * @see #ftDictadd(Object, Object[])
      * @see #ftDictdel(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
-    SpellCheckResult<V> ftSpellcheck(K index, V query);
+    SpellCheckResult<V> ftSpellcheck(String index, V query);
 
     /**
      * Perform spelling correction on a query with additional options.
@@ -438,13 +438,13 @@ public interface RediSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.spellcheck/">FT.SPELLCHECK</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
-     * @see #ftSpellcheck(Object, Object)
+     * @see #ftSpellcheck(String, Object)
      * @see #ftDictadd(Object, Object[])
      * @see #ftDictdel(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
-    SpellCheckResult<V> ftSpellcheck(K index, V query, SpellCheckArgs<K, V> args);
+    SpellCheckResult<V> ftSpellcheck(String index, V query, SpellCheckArgs<K, V> args);
 
     /**
      * Add terms to a dictionary.
@@ -475,7 +475,7 @@ public interface RediSearchCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictadd/">FT.DICTADD</a>
      * @see <a href="https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/spellcheck/">Spellchecking</a>
      * @see #ftDictdel(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
     Long ftDictadd(K dict, V... terms);
@@ -498,7 +498,7 @@ public interface RediSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.dictdel/">FT.DICTDEL</a>
      * @see #ftDictadd(Object, Object[])
-     * @see #ftDictdump(Object)
+     * @see #ftDictdump(String)
      */
     @Experimental
     Long ftDictdel(K dict, V... terms);
@@ -522,7 +522,7 @@ public interface RediSearchCommands<K, V> {
      * @see #ftDictdel(Object, Object[])
      */
     @Experimental
-    List<V> ftDictdump(K dict);
+    List<V> ftDictdump(String dict);
 
     /**
      * Return the execution plan for a complex query.
@@ -551,11 +551,11 @@ public interface RediSearchCommands<K, V> {
      * @return the execution plan as a string
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.explain/">FT.EXPLAIN</a>
-     * @see #ftExplain(Object, Object, ExplainArgs)
-     * @see #ftSearch(Object, Object)
+     * @see #ftExplain(String, Object, ExplainArgs)
+     * @see #ftSearch(String, Object)
      */
     @Experimental
-    String ftExplain(K index, V query);
+    String ftExplain(String index, V query);
 
     /**
      * Return the execution plan for a complex query with additional options.
@@ -582,11 +582,11 @@ public interface RediSearchCommands<K, V> {
      * @return the execution plan as a string
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.explain/">FT.EXPLAIN</a>
-     * @see #ftExplain(Object, Object)
-     * @see #ftSearch(Object, Object)
+     * @see #ftExplain(String, Object)
+     * @see #ftSearch(String, Object)
      */
     @Experimental
-    String ftExplain(K index, V query, ExplainArgs<K, V> args);
+    String ftExplain(String index, V query, ExplainArgs<K, V> args);
 
     /**
      * Return a list of all existing indexes.
@@ -654,7 +654,7 @@ public interface RediSearchCommands<K, V> {
      * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
      */
     @Experimental
-    Map<V, List<V>> ftSyndump(K index);
+    Map<V, List<V>> ftSyndump(String index);
 
     /**
      * Update a synonym group with additional terms.
@@ -685,7 +685,7 @@ public interface RediSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
      * @see #ftSynupdate(Object, Object, SynUpdateArgs, Object[])
-     * @see #ftSyndump(Object)
+     * @see #ftSyndump(String)
      */
     @Experimental
     String ftSynupdate(K index, V synonymGroupId, V... terms);
@@ -717,7 +717,7 @@ public interface RediSearchCommands<K, V> {
      * @since 6.8
      * @see <a href="https://redis.io/docs/latest/commands/ft.synupdate/">FT.SYNUPDATE</a>
      * @see #ftSynupdate(Object, Object, Object[])
-     * @see #ftSyndump(Object)
+     * @see #ftSyndump(String)
      */
     @Experimental
     String ftSynupdate(K index, V synonymGroupId, SynUpdateArgs<K, V> args, V... terms);
@@ -970,10 +970,10 @@ public interface RediSearchCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/develop/interact/search-and-query/query/">Query syntax</a>
      * @see SearchReply
      * @see SearchArgs
-     * @see #ftSearch(Object, Object, SearchArgs)
+     * @see #ftSearch(String, Object, SearchArgs)
      */
     @Experimental
-    SearchReply<K, V> ftSearch(K index, V query);
+    SearchReply<K, V> ftSearch(String index, V query);
 
     /**
      * Search the index with a textual query using advanced search options and filters.
@@ -1021,23 +1021,23 @@ public interface RediSearchCommands<K, V> {
      * @see <a href="https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/">Advanced concepts</a>
      * @see SearchReply
      * @see SearchArgs
-     * @see #ftSearch(Object, Object)
+     * @see #ftSearch(String, Object)
      */
     @Experimental
-    SearchReply<K, V> ftSearch(K index, V query, SearchArgs<K, V> args);
+    SearchReply<K, V> ftSearch(String index, V query, SearchArgs<K, V> args);
 
     /**
      * Run a search query on an index and perform basic aggregate transformations using default options.
      *
      * <p>
      * This command executes a search query and applies aggregation operations to transform and analyze the results. Unlike
-     * {@link #ftSearch(Object, Object)}, which returns individual documents, FT.AGGREGATE processes the result set through a
+     * {@link #ftSearch(String, Object)}, which returns individual documents, FT.AGGREGATE processes the result set through a
      * pipeline of transformations to produce analytical insights, summaries, and computed values.
      * </p>
      *
      * <p>
      * This basic variant uses default aggregation behavior without additional pipeline operations. For advanced aggregations
-     * with grouping, sorting, filtering, and custom transformations, use {@link #ftAggregate(Object, Object, AggregateArgs)}.
+     * with grouping, sorting, filtering, and custom transformations, use {@link #ftAggregate(String, Object, AggregateArgs)}.
      * </p>
      *
      * <p>
@@ -1063,10 +1063,10 @@ public interface RediSearchCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/">Aggregations</a>
      * @see SearchReply
      * @see AggregateArgs
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
-    AggregationReply<K, V> ftAggregate(K index, V query);
+    AggregationReply<K, V> ftAggregate(String index, V query);
 
     /**
      * Run a search query on an index and perform advanced aggregate transformations with a processing pipeline.
@@ -1118,18 +1118,18 @@ public interface RediSearchCommands<K, V> {
      *      API</a>
      * @see SearchReply
      * @see AggregateArgs
-     * @see #ftAggregate(Object, Object)
+     * @see #ftAggregate(String, Object)
      * @see #ftCursorread(Object, long)
      */
     @Experimental
-    AggregationReply<K, V> ftAggregate(K index, V query, AggregateArgs<K, V> args);
+    AggregationReply<K, V> ftAggregate(String index, V query, AggregateArgs<K, V> args);
 
     /**
      * Read next results from an existing cursor.
      *
      * <p>
      * This command is used to read the next batch of results from a cursor created by
-     * {@link #ftAggregate(Object, Object, AggregateArgs)} with the {@code WITHCURSOR} option. Cursors provide an efficient way
+     * {@link #ftAggregate(String, Object, AggregateArgs)} with the {@code WITHCURSOR} option. Cursors provide an efficient way
      * to iterate through large result sets without loading all results into memory at once.
      * </p>
      *
@@ -1153,7 +1153,7 @@ public interface RediSearchCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
      * @see SearchReply
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
     AggregationReply<K, V> ftCursorread(K index, long cursorId, int count);
@@ -1163,7 +1163,7 @@ public interface RediSearchCommands<K, V> {
      *
      * <p>
      * This command is used to read the next batch of results from a cursor created by
-     * {@link #ftAggregate(Object, Object, AggregateArgs)} with the {@code WITHCURSOR} option. This variant uses the default
+     * {@link #ftAggregate(String, Object, AggregateArgs)} with the {@code WITHCURSOR} option. This variant uses the default
      * batch size that was specified in the original {@code FT.AGGREGATE} command's {@code WITHCURSOR} clause.
      * </p>
      *
@@ -1186,7 +1186,7 @@ public interface RediSearchCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
      * @see SearchReply
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
     AggregationReply<K, V> ftCursorread(K index, long cursorId);
@@ -1195,7 +1195,7 @@ public interface RediSearchCommands<K, V> {
      * Delete a cursor and free its associated resources.
      *
      * <p>
-     * This command is used to explicitly delete a cursor created by {@link #ftAggregate(Object, Object, AggregateArgs)} with
+     * This command is used to explicitly delete a cursor created by {@link #ftAggregate(String, Object, AggregateArgs)} with
      * the {@code WITHCURSOR} option. Deleting a cursor frees up server resources and should be done when you no longer need to
      * read more results from the cursor.
      * </p>
@@ -1223,7 +1223,7 @@ public interface RediSearchCommands<K, V> {
      * @see <a href=
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
-     * @see #ftAggregate(Object, Object, AggregateArgs)
+     * @see #ftAggregate(String, Object, AggregateArgs)
      * @see #ftCursorread(Object, long)
      * @see #ftCursorread(Object, long, int)
      */

--- a/src/main/templates/io/lettuce/core/api/RediSearchCommands.java
+++ b/src/main/templates/io/lettuce/core/api/RediSearchCommands.java
@@ -1119,7 +1119,7 @@ public interface RediSearchCommands<K, V> {
      * @see SearchReply
      * @see AggregateArgs
      * @see #ftAggregate(String, Object)
-     * @see #ftCursorread(Object, long)
+     * @see #ftCursorread(String, long)
      */
     @Experimental
     AggregationReply<K, V> ftAggregate(String index, V query, AggregateArgs<K, V> args);
@@ -1142,7 +1142,7 @@ public interface RediSearchCommands<K, V> {
      * <strong>Time complexity:</strong> O(1)
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param cursorId the cursor id obtained from a previous {@code FT.AGGREGATE} or {@code FT.CURSOR READ} command
      * @param count the number of results to read. This parameter overrides the {@code COUNT} specified in {@code FT.AGGREGATE}
      * @return the result of the cursor read command containing the next batch of results and potentially a new cursor id, see
@@ -1156,7 +1156,7 @@ public interface RediSearchCommands<K, V> {
      * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
-    AggregationReply<K, V> ftCursorread(K index, long cursorId, int count);
+    AggregationReply<K, V> ftCursorread(String index, long cursorId, int count);
 
     /**
      * Read next results from an existing cursor using the default batch size.
@@ -1176,7 +1176,7 @@ public interface RediSearchCommands<K, V> {
      * <strong>Time complexity:</strong> O(1)
      * </p>
      *
-     * @param index the index name, as a key
+     * @param index the index name
      * @param cursorId the cursor id obtained from a previous {@code FT.AGGREGATE} or {@code FT.CURSOR READ} command
      * @return the result of the cursor read command containing the next batch of results and potentially a new cursor id, see
      *         {@link SearchReply}
@@ -1189,7 +1189,7 @@ public interface RediSearchCommands<K, V> {
      * @see #ftAggregate(String, Object, AggregateArgs)
      */
     @Experimental
-    AggregationReply<K, V> ftCursorread(K index, long cursorId);
+    AggregationReply<K, V> ftCursorread(String index, long cursorId);
 
     /**
      * Delete a cursor and free its associated resources.
@@ -1207,8 +1207,8 @@ public interface RediSearchCommands<K, V> {
      * </p>
      *
      * <p>
-     * Once a cursor is deleted, any subsequent attempts to read from it using {@link #ftCursorread(Object, long)} or
-     * {@link #ftCursorread(Object, long, int)} will result in an error.
+     * Once a cursor is deleted, any subsequent attempts to read from it using {@link #ftCursorread(String, long)} or
+     * {@link #ftCursorread(String, long, int)} will result in an error.
      * </p>
      *
      * <p>
@@ -1224,10 +1224,10 @@ public interface RediSearchCommands<K, V> {
      *      "https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/aggregations/#cursor-api">Cursor
      *      API</a>
      * @see #ftAggregate(String, Object, AggregateArgs)
-     * @see #ftCursorread(Object, long)
-     * @see #ftCursorread(Object, long, int)
+     * @see #ftCursorread(String, long)
+     * @see #ftCursorread(String, long, int)
      */
     @Experimental
-    String ftCursordel(K index, long cursorId);
+    String ftCursordel(String index, long cursorId);
 
 }

--- a/src/test/java/io/lettuce/core/search/RediSearchVectorIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/search/RediSearchVectorIntegrationTests.java
@@ -153,9 +153,8 @@ public class RediSearchVectorIntegrationTests {
         SearchArgs<ByteBuffer, ByteBuffer> searchArgs = SearchArgs.<ByteBuffer, ByteBuffer> builder()
                 .param(blobKey, queryVector).build();
 
-        ByteBuffer indexKey = ByteBuffer.wrap(indexName.getBytes());
         ByteBuffer queryString = ByteBuffer.wrap("*=>[KNN 2 @embedding $query_vec]".getBytes());
-        SearchReply<ByteBuffer, ByteBuffer> searchResult = redisBinary.ftSearch(indexKey, queryString, searchArgs);
+        SearchReply<ByteBuffer, ByteBuffer> searchResult = redisBinary.ftSearch(indexName, queryString, searchArgs);
 
         // Verify results
         assertThat(searchResult.getCount()).isEqualTo(2);
@@ -222,9 +221,8 @@ public class RediSearchVectorIntegrationTests {
         SearchArgs<ByteBuffer, ByteBuffer> searchArgs = SearchArgs.<ByteBuffer, ByteBuffer> builder()
                 .param(blobKey, queryVector).build();
 
-        ByteBuffer indexKey = ByteBuffer.wrap(indexName.getBytes());
         ByteBuffer queryString = ByteBuffer.wrap("(@category:{electronics})=>[KNN 2 @embedding $query_vec]".getBytes());
-        SearchReply<ByteBuffer, ByteBuffer> searchResult = redisBinary.ftSearch(indexKey, queryString, searchArgs);
+        SearchReply<ByteBuffer, ByteBuffer> searchResult = redisBinary.ftSearch(indexName, queryString, searchArgs);
 
         // Verify results - should find electronics products only
         assertThat(searchResult.getCount()).isEqualTo(2);
@@ -362,9 +360,8 @@ public class RediSearchVectorIntegrationTests {
             SearchArgs<ByteBuffer, ByteBuffer> searchArgs = SearchArgs.<ByteBuffer, ByteBuffer> builder()
                     .param(blobKey, queryVector).build();
 
-            ByteBuffer indexKey = ByteBuffer.wrap(indexName.getBytes());
             ByteBuffer queryString = ByteBuffer.wrap("*=>[KNN 3 @embedding $query_vec]".getBytes());
-            SearchReply<ByteBuffer, ByteBuffer> searchResult = redisBinary.ftSearch(indexKey, queryString, searchArgs);
+            SearchReply<ByteBuffer, ByteBuffer> searchResult = redisBinary.ftSearch(indexName, queryString, searchArgs);
 
             // Verify we get results
             assertThat(searchResult.getCount()).isEqualTo(3);
@@ -469,11 +466,10 @@ public class RediSearchVectorIntegrationTests {
         SearchArgs<ByteBuffer, ByteBuffer> knnArgs = SearchArgs.<ByteBuffer, ByteBuffer> builder()
                 .param(blobKey, queryVectorBuffer).limit(0, 2).build();
 
-        ByteBuffer indexKey = ByteBuffer.wrap(DOCUMENTS_INDEX.getBytes(StandardCharsets.UTF_8));
         ByteBuffer queryString = ByteBuffer
                 .wrap("*=>[KNN 2 @doc_embedding $BLOB AS vector_score]".getBytes(StandardCharsets.UTF_8));
 
-        SearchReply<ByteBuffer, ByteBuffer> results = redisBinary.ftSearch(indexKey, queryString, knnArgs);
+        SearchReply<ByteBuffer, ByteBuffer> results = redisBinary.ftSearch(DOCUMENTS_INDEX, queryString, knnArgs);
 
         assertThat(results.getCount()).isEqualTo(2);
         assertThat(results.getResults()).hasSize(2);
@@ -564,12 +560,11 @@ public class RediSearchVectorIntegrationTests {
         SearchArgs<ByteBuffer, ByteBuffer> filterArgs = SearchArgs.<ByteBuffer, ByteBuffer> builder()
                 .param(blobKey, queryVectorBuffer).limit(0, 10).build();
 
-        ByteBuffer indexKey = ByteBuffer.wrap(MOVIES_INDEX.getBytes(StandardCharsets.UTF_8));
         ByteBuffer queryString = ByteBuffer
                 .wrap("(@genre:{action})=>[KNN 3 @movie_embedding $BLOB AS movie_distance]".getBytes(StandardCharsets.UTF_8));
 
         // Search for action movies with vector similarity
-        SearchReply<ByteBuffer, ByteBuffer> results = redisBinary.ftSearch(indexKey, queryString, filterArgs);
+        SearchReply<ByteBuffer, ByteBuffer> results = redisBinary.ftSearch(MOVIES_INDEX, queryString, filterArgs);
 
         assertThat(results.getCount()).isEqualTo(2); // The Matrix and Heat have action genre
         ByteBuffer genreFieldKey = ByteBuffer.wrap("genre".getBytes(StandardCharsets.UTF_8));
@@ -584,7 +579,7 @@ public class RediSearchVectorIntegrationTests {
 
         ByteBuffer yearQueryString = ByteBuffer
                 .wrap("(@year:[1990 2000])=>[KNN 2 @movie_embedding $BLOB AS movie_distance]".getBytes(StandardCharsets.UTF_8));
-        results = redisBinary.ftSearch(indexKey, yearQueryString, yearFilterArgs);
+        results = redisBinary.ftSearch(MOVIES_INDEX, yearQueryString, yearFilterArgs);
 
         assertThat(results.getCount()).isEqualTo(2); // The Matrix (1999) and Heat (1995)
 
@@ -596,7 +591,7 @@ public class RediSearchVectorIntegrationTests {
 
         ByteBuffer efQueryString = ByteBuffer
                 .wrap("*=>[KNN 3 @movie_embedding $BLOB EF_RUNTIME $EF AS movie_distance]".getBytes(StandardCharsets.UTF_8));
-        results = redisBinary.ftSearch(indexKey, efQueryString, efArgs);
+        results = redisBinary.ftSearch(MOVIES_INDEX, efQueryString, efArgs);
 
         assertThat(results.getCount()).isEqualTo(3);
 
@@ -667,10 +662,9 @@ public class RediSearchVectorIntegrationTests {
         SearchArgs<ByteBuffer, ByteBuffer> rangeArgs = SearchArgs.<ByteBuffer, ByteBuffer> builder()
                 .param(blobKey, queryVectorBuffer).limit(0, 100).build();
 
-        ByteBuffer indexKey = ByteBuffer.wrap(PRODUCTS_INDEX.getBytes(StandardCharsets.UTF_8));
         ByteBuffer queryString = ByteBuffer
                 .wrap("@description_vector:[VECTOR_RANGE 0.5 $BLOB]".getBytes(StandardCharsets.UTF_8));
-        SearchReply<ByteBuffer, ByteBuffer> results = redisBinary.ftSearch(indexKey, queryString, rangeArgs);
+        SearchReply<ByteBuffer, ByteBuffer> results = redisBinary.ftSearch(PRODUCTS_INDEX, queryString, rangeArgs);
 
         // Should find electronics products and smart watch (mixed vector)
         assertThat(results.getCount()).isGreaterThanOrEqualTo(1);
@@ -687,7 +681,7 @@ public class RediSearchVectorIntegrationTests {
         ByteBuffer sortedQueryString = ByteBuffer
                 .wrap("@description_vector:[VECTOR_RANGE 1.0 $BLOB]=>{$YIELD_DISTANCE_AS: vector_distance}"
                         .getBytes(StandardCharsets.UTF_8));
-        results = redisBinary.ftSearch(indexKey, sortedQueryString, sortedRangeArgs);
+        results = redisBinary.ftSearch(PRODUCTS_INDEX, sortedQueryString, sortedRangeArgs);
 
         assertThat(results.getCount()).isGreaterThanOrEqualTo(2);
 
@@ -697,7 +691,7 @@ public class RediSearchVectorIntegrationTests {
 
         ByteBuffer combinedQueryString = ByteBuffer
                 .wrap("(@price:[200 1000]) | @description_vector:[VECTOR_RANGE 0.8 $BLOB]".getBytes(StandardCharsets.UTF_8));
-        results = redisBinary.ftSearch(indexKey, combinedQueryString, combinedArgs);
+        results = redisBinary.ftSearch(PRODUCTS_INDEX, combinedQueryString, combinedArgs);
 
         assertThat(results.getCount()).isGreaterThanOrEqualTo(1);
 
@@ -749,10 +743,9 @@ public class RediSearchVectorIntegrationTests {
             SearchArgs<ByteBuffer, ByteBuffer> searchArgs = SearchArgs.<ByteBuffer, ByteBuffer> builder()
                     .param(blobKey, queryVectorBuffer).limit(0, 2).build();
 
-            ByteBuffer indexKey = ByteBuffer.wrap(indexName.getBytes(StandardCharsets.UTF_8));
             ByteBuffer queryString = ByteBuffer
                     .wrap("*=>[KNN 2 @embedding $BLOB AS distance]".getBytes(StandardCharsets.UTF_8));
-            SearchReply<ByteBuffer, ByteBuffer> results = redisBinary.ftSearch(indexKey, queryString, searchArgs);
+            SearchReply<ByteBuffer, ByteBuffer> results = redisBinary.ftSearch(indexName, queryString, searchArgs);
 
             assertThat(results.getCount()).isEqualTo(2);
             assertThat(results.getResults()).hasSize(2);
@@ -806,9 +799,8 @@ public class RediSearchVectorIntegrationTests {
         SearchArgs<ByteBuffer, ByteBuffer> adhocArgs = SearchArgs.<ByteBuffer, ByteBuffer> builder()
                 .param(blobKey, queryVectorBuffer).limit(0, 3).build();
 
-        ByteBuffer indexKey = ByteBuffer.wrap("json-vector-idx".getBytes(StandardCharsets.UTF_8));
         ByteBuffer queryString = ByteBuffer.wrap("*=>[KNN 3 @vector $BLOB]".getBytes(StandardCharsets.UTF_8));
-        SearchReply<ByteBuffer, ByteBuffer> results = redisBinary.ftSearch(indexKey, queryString, adhocArgs);
+        SearchReply<ByteBuffer, ByteBuffer> results = redisBinary.ftSearch("json-vector-idx", queryString, adhocArgs);
 
         assertThat(results.getCount()).isEqualTo(3);
         assertThat(results.getResults()).hasSize(3);
@@ -819,7 +811,7 @@ public class RediSearchVectorIntegrationTests {
 
         ByteBuffer filterQueryString = ByteBuffer
                 .wrap("(@category:{tech})=>[KNN 2 @vector $BLOB]".getBytes(StandardCharsets.UTF_8));
-        results = redisBinary.ftSearch(indexKey, filterQueryString, filterArgs);
+        results = redisBinary.ftSearch("json-vector-idx", filterQueryString, filterArgs);
 
         assertThat(results.getCount()).isEqualTo(2); // Only tech category documents
 
@@ -868,11 +860,10 @@ public class RediSearchVectorIntegrationTests {
         SearchArgs<ByteBuffer, ByteBuffer> adhocArgs = SearchArgs.<ByteBuffer, ByteBuffer> builder()
                 .param(blobKey, queryVectorBuffer).limit(0, 5).build();
 
-        ByteBuffer indexKey = ByteBuffer.wrap("tasks-idx".getBytes(StandardCharsets.UTF_8));
         ByteBuffer queryString = ByteBuffer
                 .wrap("(@status:{active})=>[KNN 5 @content_vector $BLOB HYBRID_POLICY ADHOC_BF AS task_score]"
                         .getBytes(StandardCharsets.UTF_8));
-        SearchReply<ByteBuffer, ByteBuffer> results = redisBinary.ftSearch(indexKey, queryString, adhocArgs);
+        SearchReply<ByteBuffer, ByteBuffer> results = redisBinary.ftSearch("tasks-idx", queryString, adhocArgs);
 
         assertThat(results.getCount()).isGreaterThanOrEqualTo(1);
 
@@ -885,7 +876,7 @@ public class RediSearchVectorIntegrationTests {
         ByteBuffer batchQueryString = ByteBuffer.wrap(
                 "(@status:{active})=>[KNN 5 @content_vector $BLOB HYBRID_POLICY BATCHES BATCH_SIZE $BATCH_SIZE AS task_score]"
                         .getBytes(StandardCharsets.UTF_8));
-        results = redisBinary.ftSearch(indexKey, batchQueryString, batchArgs);
+        results = redisBinary.ftSearch("tasks-idx", batchQueryString, batchArgs);
 
         assertThat(results.getCount()).isGreaterThanOrEqualTo(1);
 
@@ -897,7 +888,7 @@ public class RediSearchVectorIntegrationTests {
 
         ByteBuffer efQueryString = ByteBuffer
                 .wrap("*=>[KNN 3 @content_vector $BLOB EF_RUNTIME $EF AS task_score]".getBytes(StandardCharsets.UTF_8));
-        results = redisBinary.ftSearch(indexKey, efQueryString, efArgs);
+        results = redisBinary.ftSearch("tasks-idx", efQueryString, efArgs);
 
         assertThat(results.getCount()).isEqualTo(3);
 
@@ -908,7 +899,7 @@ public class RediSearchVectorIntegrationTests {
         ByteBuffer complexQueryString = ByteBuffer
                 .wrap("((@status:{active}) (@priority:[3 5]))=>[KNN 5 @content_vector $BLOB AS task_score]"
                         .getBytes(StandardCharsets.UTF_8));
-        results = redisBinary.ftSearch(indexKey, complexQueryString, complexArgs);
+        results = redisBinary.ftSearch("tasks-idx", complexQueryString, complexArgs);
 
         // Verify all results match the filter criteria
         ByteBuffer statusKey = ByteBuffer.wrap("status".getBytes(StandardCharsets.UTF_8));
@@ -927,7 +918,7 @@ public class RediSearchVectorIntegrationTests {
 
         ByteBuffer timeoutQueryString = ByteBuffer
                 .wrap("*=>[KNN 5 @content_vector $BLOB AS task_score]".getBytes(StandardCharsets.UTF_8));
-        results = redisBinary.ftSearch(indexKey, timeoutQueryString, timeoutArgs);
+        results = redisBinary.ftSearch("tasks-idx", timeoutQueryString, timeoutArgs);
 
         assertThat(results.getCount()).isEqualTo(5);
 
@@ -991,10 +982,9 @@ public class RediSearchVectorIntegrationTests {
         SearchArgs<ByteBuffer, ByteBuffer> precisionArgs = SearchArgs.<ByteBuffer, ByteBuffer> builder()
                 .param(blobKey, queryBuffer).limit(0, 2).build();
 
-        ByteBuffer indexKey = ByteBuffer.wrap("precision-idx".getBytes(StandardCharsets.UTF_8));
         ByteBuffer queryString = ByteBuffer
                 .wrap("*=>[KNN 2 @embedding_f64 $BLOB AS distance]".getBytes(StandardCharsets.UTF_8));
-        SearchReply<ByteBuffer, ByteBuffer> results = redisBinary.ftSearch(indexKey, queryString, precisionArgs);
+        SearchReply<ByteBuffer, ByteBuffer> results = redisBinary.ftSearch("precision-idx", queryString, precisionArgs);
 
         assertThat(results.getCount()).isEqualTo(2);
         assertThat(results.getResults()).hasSize(2);
@@ -1042,9 +1032,8 @@ public class RediSearchVectorIntegrationTests {
         SearchArgs<ByteBuffer, ByteBuffer> validArgs = SearchArgs.<ByteBuffer, ByteBuffer> builder()
                 .param(blobKey, queryVectorBuffer).limit(0, 1).build();
 
-        ByteBuffer indexKey = ByteBuffer.wrap("error-test-idx".getBytes(StandardCharsets.UTF_8));
         ByteBuffer queryString = ByteBuffer.wrap("*=>[KNN 1 @test_vector $BLOB]".getBytes(StandardCharsets.UTF_8));
-        SearchReply<ByteBuffer, ByteBuffer> results = redisBinary.ftSearch(indexKey, queryString, validArgs);
+        SearchReply<ByteBuffer, ByteBuffer> results = redisBinary.ftSearch("error-test-idx", queryString, validArgs);
 
         assertThat(results.getCount()).isEqualTo(1);
 
@@ -1056,7 +1045,7 @@ public class RediSearchVectorIntegrationTests {
                 .wrap("(@nonexistent_field:value)=>[KNN 5 @test_vector $BLOB]".getBytes(StandardCharsets.UTF_8));
 
         // This should throw an exception because the field doesn't exist
-        assertThatThrownBy(() -> redisBinary.ftSearch(indexKey, noResultsQueryString, noResultsArgs))
+        assertThatThrownBy(() -> redisBinary.ftSearch("error-test-idx", noResultsQueryString, noResultsArgs))
                 .isInstanceOf(RedisCommandExecutionException.class).hasMessageContaining("Unknown field");
 
         // Cleanup


### PR DESCRIPTION
As part of #3455 

List of commands changed:
``` java
FT.SEARCH (ftSearch)
FT.AGGREGATE (ftAggregate)
FT.TAGVALS (ftTagvals) -
FT.SPELLCHECK (ftSpellcheck)
FT.DICTDUMP (ftDictdump)
FT.EXPLAIN (ftExplain)
FT.SYNDUMP (ftSyndump)
FT.CURSOR READ (ftCursorread)
FT.CURSOR DEL (ftCursordel)
FT.CREATE (ftCreate)
FT.ALIASADD (ftAliasadd)
FT.ALIASUPDATE (ftAliasupdate)
FT.ALIASDEL (ftAliasdel)
FT.ALTER (ftAlter)
FT.DROPINDEX (ftDropindex)
FT.DICTADD (ftDictadd)
FT.DICTDEL (ftDictdel)
FT.SYNUPDATE (ftSynupdate)
```
