### PR TITLE
fix consistency with get(int) that returns wrapped DelegateJsonObject/DelegateJsonArray for nested structures

### DIFF
--- a/src/main/java/io/lettuce/core/json/DelegateJsonArray.java
+++ b/src/main/java/io/lettuce/core/json/DelegateJsonArray.java
@@ -59,7 +59,7 @@ class DelegateJsonArray extends DelegateJsonValue implements JsonArray {
         List<JsonValue> result = new ArrayList<>();
 
         for (JsonNode jsonNode : node) {
-            result.add(new DelegateJsonValue(jsonNode, objectMapper));
+            result.add(wrap(jsonNode, objectMapper));
         }
 
         return result;

--- a/src/test/java/io/lettuce/core/json/DelegateJsonArrayUnitTests.java
+++ b/src/test/java/io/lettuce/core/json/DelegateJsonArrayUnitTests.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
+import java.util.List;
 
 import static io.lettuce.TestTags.UNIT_TEST;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -185,6 +186,70 @@ class DelegateJsonArrayUnitTests {
         assertThat(underTest.asJsonObject()).isNull();
         assertThat(underTest.asString()).isNull();
         assertThat(underTest.asNumber()).isNull();
+    }
+
+    @Test
+    void asListWithNestedObjects() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        DefaultJsonParser parser = new DefaultJsonParser(objectMapper);
+
+        // Create an array containing nested objects
+        DelegateJsonArray underTest = new DelegateJsonArray(objectMapper);
+        underTest.add(parser.createJsonValue("{\"name\": \"Alice\", \"age\": 30}"));
+        underTest.add(parser.createJsonValue("{\"name\": \"Bob\", \"age\": 25}"));
+
+        // Test that asList() returns proper DelegateJsonObject instances for nested objects
+        List<JsonValue> list = underTest.asList();
+        assertThat(list).hasSize(2);
+
+        // Verify that elements from asList() behave consistently with get()
+        for (int i = 0; i < list.size(); i++) {
+            JsonValue listElement = list.get(i);
+            JsonValue getElement = underTest.get(i);
+
+            // Both should be DelegateJsonObject instances
+            assertThat(listElement.isJsonObject()).isTrue();
+            assertThat(getElement.isJsonObject()).isTrue();
+
+            // Both should have the same behavior
+            assertThat(listElement.asJsonObject()).isNotNull();
+            assertThat(getElement.asJsonObject()).isNotNull();
+
+            // Both should return the same string representation
+            assertThat(listElement.toString()).isEqualTo(getElement.toString());
+        }
+    }
+
+    @Test
+    void asListWithNestedArrays() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        DefaultJsonParser parser = new DefaultJsonParser(objectMapper);
+
+        // Create an array containing nested arrays
+        DelegateJsonArray underTest = new DelegateJsonArray(objectMapper);
+        underTest.add(parser.createJsonValue("[1, 2, 3]"));
+        underTest.add(parser.createJsonValue("[\"a\", \"b\", \"c\"]"));
+
+        // Test that asList() returns proper DelegateJsonArray instances for nested arrays
+        List<JsonValue> list = underTest.asList();
+        assertThat(list).hasSize(2);
+
+        // Verify that elements from asList() behave consistently with get()
+        for (int i = 0; i < list.size(); i++) {
+            JsonValue listElement = list.get(i);
+            JsonValue getElement = underTest.get(i);
+
+            // Both should be DelegateJsonArray instances
+            assertThat(listElement.isJsonArray()).isTrue();
+            assertThat(getElement.isJsonArray()).isTrue();
+
+            // Both should have the same behavior
+            assertThat(listElement.asJsonArray()).isNotNull();
+            assertThat(getElement.asJsonArray()).isNotNull();
+
+            // Both should return the same string representation
+            assertThat(listElement.toString()).isEqualTo(getElement.toString());
+        }
     }
 
 }


### PR DESCRIPTION


<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

In src/main/java/io/lettuce/core/json/DelegateJsonArray.java around lines 61-63, asList() currently constructs elements using new DelegateJsonValue(jsonNode,objectMapper) which breaks consistency with get(int) that returns wrapped DelegateJsonObject/DelegateJsonArray for nested structures

Add unit tests for those scenarios

