### PR TITLE
SearchArgs.returnField with alias produces malformed redis command #3528 (7.1.x)

### DIFF
--- a/src/main/java/io/lettuce/core/search/arguments/SearchArgs.java
+++ b/src/main/java/io/lettuce/core/search/arguments/SearchArgs.java
@@ -558,10 +558,19 @@ public class SearchArgs<K, V> {
 
         if (!returnFields.isEmpty()) {
             args.add(CommandKeyword.RETURN);
-            args.add(returnFields.size());
+            // Count total number of field specifications (field + optional AS + alias)
+            int count = returnFields.size();
+
+            // Add 2 for each "AS" keyword and alias value
+            count += (int) (returnFields.values().stream().filter(Optional::isPresent).count() * 2);
+
+            args.add(count);
             returnFields.forEach((field, as) -> {
                 args.addKey(field);
-                as.ifPresent(args::addKey);
+                if (as.isPresent()) {
+                    args.add(CommandKeyword.AS);
+                    args.addKey(as.get());
+                }
             });
         }
 

--- a/src/test/java/io/lettuce/core/RediSearchCommandBuilderUnitTests.java
+++ b/src/test/java/io/lettuce/core/RediSearchCommandBuilderUnitTests.java
@@ -11,6 +11,7 @@ import static io.lettuce.core.search.arguments.AggregateArgs.*;
 
 import io.lettuce.core.codec.StringCodec;
 import io.lettuce.core.protocol.Command;
+import io.lettuce.core.protocol.CommandArgs;
 import io.lettuce.core.search.AggregationReply;
 import io.lettuce.core.search.SearchReply;
 import io.lettuce.core.search.arguments.AggregateArgs;
@@ -755,6 +756,18 @@ class RediSearchCommandBuilderUnitTests {
 
         assertThat(command.getType()).isEqualTo(FT_CURSOR);
         assertThat(buf.toString(StandardCharsets.UTF_8)).isEqualTo(result);
+    }
+
+    @Test
+    void returnFieldsWithAlias() {
+        SearchArgs<String, String> options = SearchArgs.<String, String> builder().returnField("as_is")
+                .returnField("$.field", "alias").build();
+
+        CommandArgs<String, String> args = new CommandArgs<>(new StringCodec());
+        options.build(args);
+
+        // buggy implementation returns "RETURN 2 key<as_is> key<$.field> key<alias> DIALECT "
+        assertThat("RETURN 4 key<as_is> key<$.field> AS key<alias> DIALECT 2").isEqualTo(args.toCommandString());
     }
 
 }


### PR DESCRIPTION
Porting fix fo https://github.com/redis/lettuce/issues/3528 to the 7.1.x branch

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
