### PR TITLE
SharedLock ThreadLocal threadWriters memory leak may cause CPU usage to reach 100% #3489

### DIFF
--- a/src/main/java/io/lettuce/core/protocol/DefaultEndpoint.java
+++ b/src/main/java/io/lettuce/core/protocol/DefaultEndpoint.java
@@ -607,6 +607,9 @@ public class DefaultEndpoint implements RedisChannelWriter, Endpoint, PushHandle
 
             cancelBufferedCommands("Close");
 
+            // Clean up ThreadLocal state to prevent memory leaks in thread pools
+            sharedLock.cleanup();
+
             Channel channel = getOpenChannel();
 
             if (channel != null) {

--- a/src/main/java/io/lettuce/core/protocol/SharedLock.java
+++ b/src/main/java/io/lettuce/core/protocol/SharedLock.java
@@ -152,4 +152,15 @@ class SharedLock {
         }
     }
 
+    /**
+     * Clean up thread-local state for the current thread. This should be called when the endpoint is being closed to prevent
+     * memory leaks in long-lived thread pools (e.g., Netty event loops).
+     * <p>
+     * This method removes the ThreadLocal entry for the current thread, preventing the SharedLock instance from being retained
+     * in the thread's ThreadLocalMap after the endpoint is closed.
+     */
+    void cleanup() {
+        threadWriters.remove();
+    }
+
 }

--- a/src/test/java/io/lettuce/core/protocol/SharedLockUnitTests.java
+++ b/src/test/java/io/lettuce/core/protocol/SharedLockUnitTests.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -56,6 +57,78 @@ public class SharedLockUnitTests {
 
         await = cntOtherThread.await(1, TimeUnit.SECONDS);
         Assertions.assertTrue(await);
+    }
+
+    @Test
+    public void cleanupShouldRemoveThreadLocalEntry() throws Exception {
+        final SharedLock sharedLock = new SharedLock();
+
+        // Access the threadWriters field via reflection
+        Field threadWritersField = SharedLock.class.getDeclaredField("threadWriters");
+        threadWritersField.setAccessible(true);
+        ThreadLocal<Integer> threadWriters = (ThreadLocal<Integer>) threadWritersField.get(sharedLock);
+
+        // Use the SharedLock to create a ThreadLocal entry
+        sharedLock.incrementWriters();
+        Assertions.assertEquals(1, threadWriters.get());
+
+        sharedLock.incrementWriters();
+        Assertions.assertEquals(2, threadWriters.get());
+
+        sharedLock.decrementWriters();
+        Assertions.assertEquals(1, threadWriters.get());
+
+        sharedLock.decrementWriters();
+        // After decrement to zero, ThreadLocal entry should still exist (not removed automatically)
+        Assertions.assertEquals(0, threadWriters.get());
+
+        // Now call cleanup() to remove the ThreadLocal entry
+        sharedLock.cleanup();
+
+        // After cleanup, get() should return the initial value (0) again
+        // This indicates the ThreadLocal entry was removed and re-initialized
+        Integer valueAfterCleanup = threadWriters.get();
+        Assertions.assertEquals(0, valueAfterCleanup);
+    }
+
+    @Test
+    public void cleanupWithMultipleThreads() throws InterruptedException {
+        final SharedLock sharedLock = new SharedLock();
+        final int threadCount = 100;
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch completionLatch = new CountDownLatch(threadCount);
+
+        // Create multiple threads that will use the SharedLock
+        for (int i = 0; i < threadCount; i++) {
+            new Thread(() -> {
+                try {
+                    startLatch.await();
+                    // Each thread increments and decrements multiple times
+                    for (int j = 0; j < 10; j++) {
+                        sharedLock.incrementWriters();
+                        sharedLock.decrementWriters();
+                    }
+                    // Simulate endpoint close by calling cleanup
+                    sharedLock.cleanup();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    completionLatch.countDown();
+                }
+            }).start();
+        }
+
+        // Start all threads at once
+        startLatch.countDown();
+
+        // Wait for all threads to complete
+        boolean completed = completionLatch.await(10, TimeUnit.SECONDS);
+        Assertions.assertTrue(completed, "All threads should complete within timeout");
+
+        // After all threads complete and cleanup, the SharedLock should be in a clean state
+        // We can verify this by doing an exclusive operation
+        String result = sharedLock.doExclusive(() -> "success");
+        Assertions.assertEquals("success", result);
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
In certain cases (see #3489) the cleanup in `ThreadLocalMap.expungeStaleEntry()` might spike CPU usage because of excessive number of `ThreadLocalMap` entries.

We attempt to alleviate this problem by cleaning the ThreadLocal variable for threads that close the respective connection.

Closes #3489 


Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
