### PR TITLE
Fix SharedLock ThreadLocal threadWriters memory leak may cause CPU usage to reach 100%

### DIFF
--- a/src/main/java/io/lettuce/core/protocol/SharedLock.java
+++ b/src/main/java/io/lettuce/core/protocol/SharedLock.java
@@ -66,7 +66,16 @@ class SharedLock {
         }
 
         WRITERS.decrementAndGet(this);
-        threadWriters.set(threadWriters.get() - 1);
+
+        Integer currentThreadWriterValue = threadWriters.get();
+        int newThreadWriterValue = currentThreadWriterValue - 1;
+
+        if (newThreadWriterValue <= 0) {
+            threadWriters.remove();
+            return;
+        }
+
+        threadWriters.set(newThreadWriterValue);
     }
 
     /**

--- a/src/test/java/io/lettuce/core/protocol/SharedLockUnitTests.java
+++ b/src/test/java/io/lettuce/core/protocol/SharedLockUnitTests.java
@@ -1,5 +1,6 @@
 package io.lettuce.core.protocol;
 
+import java.lang.reflect.Field;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -56,6 +57,42 @@ public class SharedLockUnitTests {
 
         await = cntOtherThread.await(1, TimeUnit.SECONDS);
         Assertions.assertTrue(await);
+    }
+
+    @Test
+    public void removes_threadLocal_entry_when_writer_depth_reaches_zero() throws Exception {
+
+        SharedLock sharedLock = new SharedLock();
+
+        CountingThreadLocal countingThreadLocal = new CountingThreadLocal();
+        Field field = SharedLock.class.getDeclaredField("threadWriters");
+        field.setAccessible(true);
+        field.set(sharedLock, countingThreadLocal);
+
+        Assertions.assertEquals(0, countingThreadLocal.initialValueCalls);
+
+        sharedLock.incrementWriters();
+        Assertions.assertEquals(1, countingThreadLocal.initialValueCalls,
+                "initialValue() should be called once on the first ThreadLocal#get()");
+
+        sharedLock.decrementWriters();
+
+        sharedLock.incrementWriters();
+        Assertions.assertEquals(2, countingThreadLocal.initialValueCalls,
+                "initialValue() should be called again after remove()");
+    }
+
+    // Test Helper Class
+    static class CountingThreadLocal extends ThreadLocal<Integer> {
+
+        int initialValueCalls = 0;
+
+        @Override
+        protected Integer initialValue() {
+            initialValueCalls++;
+            return 0;
+        }
+
     }
 
 }


### PR DESCRIPTION
This PR SharedLock.decrementWriters() to call threadWriters.remove() when the per-thread writer depth reaches zero, preventing unused ThreadLocal entries from lingering.
This helps avoid the ThreadLocalMap.expungeStaleEntry() CPU spikes reported in #3489

Thanks ! 

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
