### PR TITLE
[automatic failover] Remove unused redisURI parameter from PingStrategy constructors

### DIFF
--- a/src/main/java/io/lettuce/core/failover/health/PingStrategy.java
+++ b/src/main/java/io/lettuce/core/failover/health/PingStrategy.java
@@ -10,11 +10,11 @@ public class PingStrategy implements HealthCheckStrategy {
 
     private final HealthCheckStrategy.Config config;
 
-    public PingStrategy(RedisURI redisURI, DatabaseRawConnectionFactory connectionFactory) {
-        this(redisURI, connectionFactory, HealthCheckStrategy.Config.create());
+    public PingStrategy(DatabaseRawConnectionFactory connectionFactory) {
+        this(connectionFactory, HealthCheckStrategy.Config.create());
     }
 
-    public PingStrategy(RedisURI redisURI, DatabaseRawConnectionFactory connectionFactory, HealthCheckStrategy.Config config) {
+    public PingStrategy(DatabaseRawConnectionFactory connectionFactory, HealthCheckStrategy.Config config) {
         this.connectionFactory = connectionFactory;
         this.config = config;
     }
@@ -63,6 +63,6 @@ public class PingStrategy implements HealthCheckStrategy {
         // No resources to close
     }
 
-    public static final HealthCheckStrategySupplier DEFAULT = PingStrategy::new;
+    public static final HealthCheckStrategySupplier DEFAULT = (uri, connectionFactory) -> new PingStrategy(connectionFactory);
 
 }

--- a/src/test/java/io/lettuce/core/failover/health/PingStrategyTest.java
+++ b/src/test/java/io/lettuce/core/failover/health/PingStrategyTest.java
@@ -49,7 +49,7 @@ class PingStrategyTest {
         @DisplayName("Should create PingStrategy with default config")
         void shouldCreateWithDefaultConfig() {
             // When
-            PingStrategy strategy = new PingStrategy(testUri, connectionFactory);
+            PingStrategy strategy = new PingStrategy(connectionFactory);
 
             // Then
             assertThat(strategy).isNotNull();
@@ -69,7 +69,7 @@ class PingStrategyTest {
                     .numProbes(3).delayInBetweenProbes(100).policy(ProbingPolicy.BuiltIn.MAJORITY_SUCCESS).build();
 
             // When
-            PingStrategy strategy = new PingStrategy(testUri, connectionFactory, customConfig);
+            PingStrategy strategy = new PingStrategy(connectionFactory, customConfig);
 
             // Then
             assertThat(strategy.getInterval()).isEqualTo(500);
@@ -94,7 +94,7 @@ class PingStrategyTest {
             when(connection.sync()).thenReturn((RedisCommands) syncCommands);
             when(syncCommands.ping()).thenReturn("PONG");
 
-            PingStrategy strategy = new PingStrategy(testUri, connectionFactory);
+            PingStrategy strategy = new PingStrategy(connectionFactory);
 
             // When
             HealthStatus status = strategy.doHealthCheck(testUri);
@@ -116,7 +116,7 @@ class PingStrategyTest {
             when(connection.sync()).thenReturn((RedisCommands) syncCommands);
             when(syncCommands.ping()).thenReturn("UNEXPECTED");
 
-            PingStrategy strategy = new PingStrategy(testUri, connectionFactory);
+            PingStrategy strategy = new PingStrategy(connectionFactory);
 
             // When
             HealthStatus status = strategy.doHealthCheck(testUri);
@@ -132,7 +132,7 @@ class PingStrategyTest {
             // Given
             when(connectionFactory.connectToDatabase(testUri)).thenReturn(null);
 
-            PingStrategy strategy = new PingStrategy(testUri, connectionFactory);
+            PingStrategy strategy = new PingStrategy(connectionFactory);
 
             // When
             HealthStatus status = strategy.doHealthCheck(testUri);
@@ -149,7 +149,7 @@ class PingStrategyTest {
             // Given
             when(connectionFactory.connectToDatabase(testUri)).thenThrow(new RuntimeException("Connection failed"));
 
-            PingStrategy strategy = new PingStrategy(testUri, connectionFactory);
+            PingStrategy strategy = new PingStrategy(connectionFactory);
 
             // When
             HealthStatus status = strategy.doHealthCheck(testUri);
@@ -167,7 +167,7 @@ class PingStrategyTest {
             when(connection.sync()).thenReturn((RedisCommands) syncCommands);
             when(syncCommands.ping()).thenThrow(new RuntimeException("PING failed"));
 
-            PingStrategy strategy = new PingStrategy(testUri, connectionFactory);
+            PingStrategy strategy = new PingStrategy(connectionFactory);
 
             // When
             HealthStatus status = strategy.doHealthCheck(testUri);
@@ -186,7 +186,7 @@ class PingStrategyTest {
             when(connection.sync()).thenReturn((RedisCommands) syncCommands);
             when(syncCommands.ping()).thenThrow(new RuntimeException("PING failed"));
 
-            PingStrategy strategy = new PingStrategy(testUri, connectionFactory);
+            PingStrategy strategy = new PingStrategy(connectionFactory);
 
             // When
             strategy.doHealthCheck(testUri);
@@ -204,7 +204,7 @@ class PingStrategyTest {
             when(connection.sync()).thenReturn((RedisCommands) syncCommands);
             when(syncCommands.ping()).thenReturn("PONG");
 
-            PingStrategy strategy = new PingStrategy(testUri, connectionFactory);
+            PingStrategy strategy = new PingStrategy(connectionFactory);
 
             // When
             HealthStatus status1 = strategy.doHealthCheck(testUri);


### PR DESCRIPTION
The `redisURI` parameter in `PingStrategy` constructors was never used in the
implementation. 

Changes:
- Removed RedisURI parameter from both PingStrategy constructors
- Updated DEFAULT supplier to use a lambda instead of a method reference

Relates to : #3564 