### PR TITLE
Fix command queue corruption on encoding failures (#3443)

### DIFF
--- a/src/main/java/io/lettuce/core/RedisPublisher.java
+++ b/src/main/java/io/lettuce/core/RedisPublisher.java
@@ -59,6 +59,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
  * are emitted as they are decoded. Otherwise, results are processed at command completion.
  *
  * @author Mark Paluch
+ * @author Tihomir Mateev
  * @since 5.0
  */
 class RedisPublisher<K, V, T> implements Publisher<T> {
@@ -293,7 +294,7 @@ class RedisPublisher<K, V, T> implements Publisher<T> {
                     try {
                         DEMAND.decrementAndGet(this);
                         this.subscriber.onNext(t);
-                    } catch (Exception e) {
+                    } catch (Throwable e) {
                         onError(e);
                     }
                     return;
@@ -544,7 +545,7 @@ class RedisPublisher<K, V, T> implements Publisher<T> {
 
                         try {
                             subscription.checkCommandDispatch();
-                        } catch (Exception ex) {
+                        } catch (Throwable ex) {
                             subscription.onError(ex);
                         }
                         subscription.checkOnDataAvailable();
@@ -575,7 +576,7 @@ class RedisPublisher<K, V, T> implements Publisher<T> {
                             return;
                         }
                     } while (subscription.hasDemand());
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     subscription.onError(e);
                 }
             }

--- a/src/main/java/io/lettuce/core/protocol/CommandEncoder.java
+++ b/src/main/java/io/lettuce/core/protocol/CommandEncoder.java
@@ -76,10 +76,12 @@ public class CommandEncoder extends MessageToByteEncoder<Object> {
         try {
             out.markWriterIndex();
             command.encode(out);
-        } catch (RuntimeException e) {
-            out.resetWriterIndex();
-            command.completeExceptionally(new EncoderException(
-                    "Cannot encode command. Please close the connection as the connection state may be out of sync.", e));
+        } catch (Throwable e) {
+            ctx.close();
+            logger.error("{} Cannot encode command. Closing the connection as the connection state may be out of sync.",
+                    logPrefix(ctx.channel()), e);
+            throw new EncoderException(
+                    "Cannot encode command. Closing the connection as the connection state may be out of sync.", e);
         }
 
         if (debugEnabled) {

--- a/src/main/java/io/lettuce/core/protocol/CommandHandler.java
+++ b/src/main/java/io/lettuce/core/protocol/CommandHandler.java
@@ -76,6 +76,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
  * @author Daniel Albuquerque
  * @author Gavin Cook
  * @author Anuraag Agrawal
+ * @author Tihomir Mateev
  */
 public class CommandHandler extends ChannelDuplexHandler implements HasQueuedCommands {
 
@@ -646,8 +647,7 @@ public class CommandHandler extends ChannelDuplexHandler implements HasQueuedCom
                         return;
                     }
 
-                } catch (Exception e) {
-
+                } catch (Throwable e) {
                     ctx.close();
                     throw e;
                 }
@@ -672,8 +672,7 @@ public class CommandHandler extends ChannelDuplexHandler implements HasQueuedCom
                         decodeBufferPolicy.afterPartialDecode(buffer);
                         return;
                     }
-                } catch (Exception e) {
-
+                } catch (Throwable e) {
                     ctx.close();
                     throw e;
                 }
@@ -691,8 +690,9 @@ public class CommandHandler extends ChannelDuplexHandler implements HasQueuedCom
                                 logger.debug("{} Completing command {}", logPrefix(), command);
                             }
                             complete(command);
-                        } catch (Exception e) {
+                        } catch (Throwable e) {
                             logger.warn("{} Unexpected exception during request: {}", logPrefix, e.toString(), e);
+                            command.completeExceptionally(e);
                         }
                     }
                 }

--- a/src/test/java/io/lettuce/core/protocol/CodecFailureIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/protocol/CodecFailureIntegrationTests.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2011-Present, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ */
+package io.lettuce.core.protocol;
+
+import static io.lettuce.TestTags.INTEGRATION_TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import javax.inject.Inject;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.TestSupport;
+import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.event.connection.ReconnectAttemptEvent;
+import io.netty.handler.codec.EncoderException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.test.LettuceExtension;
+
+/**
+ * Integration tests for command encoding error scenarios with GET/SET commands against a Redis test instance.
+ *
+ * @author Lettuce Contributors
+ */
+@ExtendWith(LettuceExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Tag(INTEGRATION_TEST)
+class CodecFailureIntegrationTests extends TestSupport {
+
+    private final RedisClient client;
+
+    private final StatefulRedisConnection<String, String> connection;
+
+    @Inject
+    CodecFailureIntegrationTests(RedisClient client, StatefulRedisConnection<String, String> connection) {
+        this.client = client;
+        this.connection = connection;
+    }
+
+    @BeforeEach
+    void setUp() {
+        this.connection.async().flushall();
+    }
+
+    @Test
+    void testCommandsWithCustomCodecRuntimeException() {
+
+        final Integer[] reconnects = { 0 };
+        client.getResources().eventBus().get().subscribe(event -> {
+            if (event instanceof ReconnectAttemptEvent) {
+                reconnects[0]++;
+            }
+        });
+
+        try (StatefulRedisConnection<String, String> customConnection = client.connect(failingCodec)) {
+            RedisCommands<String, String> customRedis = customConnection.sync();
+
+            // First, test that normal values work fine
+            String normalKey = "normal-key";
+            String normalValue = "normal-value";
+
+            String result = customRedis.set(normalKey, normalValue);
+            assertThat(result).isEqualTo("OK");
+
+            String retrieved = customRedis.get(normalKey);
+            assertThat(retrieved).isEqualTo(normalValue);
+
+            // Now test that the specific failure value throws an exception
+            String failingKey = "failing-key";
+            String failingValue = "encoding_failure";
+
+            assertThatThrownBy(() -> customRedis.set(failingKey, failingValue)).isInstanceOf(EncoderException.class)
+                    .hasMessageContaining(
+                            "Cannot encode command. Closing the connection as the connection state may be out of sync.");
+
+            // test that commands are executed after reconnecting
+            retrieved = customRedis.get(normalKey);
+            assertThat(retrieved).isEqualTo(normalValue);
+
+            // verify that we have reconnected after the exception
+            assertThat(reconnects[0]).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void testCommandsWithCustomCodecOutOfMemoryError() {
+
+        try (StatefulRedisConnection<String, String> customConnection = client.connect(failingCodecOOM)) {
+            RedisCommands<String, String> customRedis = customConnection.sync();
+
+            // First, test that normal values work fine
+            String normalKey = "normal-key";
+            String normalValue = "normal-value";
+
+            String result = customRedis.set(normalKey, normalValue);
+            assertThat(result).isEqualTo("OK");
+
+            String retrieved = customRedis.get(normalKey);
+            assertThat(retrieved).isEqualTo(normalValue);
+
+            // Now test that the specific failure value throws an exception
+            String failingKey = "failing-key";
+            String failingValue = "encoding_failure";
+
+            assertThatThrownBy(() -> customRedis.set(failingKey, failingValue)).isInstanceOf(EncoderException.class)
+                    .hasMessageContaining(
+                            "Cannot encode command. Closing the connection as the connection state may be out of sync.");
+
+            // test that we can get correct response after encoding failure
+            retrieved = customRedis.get(normalKey);
+            assertThat(retrieved).isEqualTo(normalValue);
+        }
+    }
+
+    @Test
+    void testDecodeFailureForReply() {
+        // First, set a value using the normal connection
+        String testKey = "decode-failure-key";
+        String testValue = "decode_failure_trigger";
+
+        connection.sync().set(testKey, testValue);
+
+        // Create a codec that fails during value decoding for specific values
+        RedisCodec<String, String> decodingFailureCodec = new RedisCodec<String, String>() {
+
+            @Override
+            public String decodeKey(ByteBuffer bytes) {
+                return StandardCharsets.UTF_8.decode(bytes).toString();
+            }
+
+            @Override
+            public String decodeValue(ByteBuffer bytes) {
+                String value = StandardCharsets.UTF_8.decode(bytes).toString();
+                // Throw exception when decoding specific value
+                if ("decode_failure_trigger".equals(value)) {
+                    throw new RuntimeException("Simulated decoding failure during value decoding");
+                }
+                return value;
+            }
+
+            @Override
+            public ByteBuffer encodeKey(String key) {
+                return StandardCharsets.UTF_8.encode(key);
+            }
+
+            @Override
+            public ByteBuffer encodeValue(String value) {
+                return StandardCharsets.UTF_8.encode(value);
+            }
+
+        };
+
+        try (StatefulRedisConnection<String, String> customConnection = client.connect(decodingFailureCodec)) {
+            RedisCommands<String, String> customRedis = customConnection.sync();
+
+            // Test that normal values work fine
+            String normalKey = "normal-decode-key";
+            String normalValue = "normal-value";
+
+            customRedis.set(normalKey, normalValue);
+            String retrieved = customRedis.get(normalKey);
+            assertThat(retrieved).isEqualTo(normalValue);
+
+            // Now test that decoding the problematic value throws an exception
+            // The command was executed on Redis (the value is there), but decoding fails
+            assertThatThrownBy(() -> customRedis.get(testKey))
+                    .hasMessageContaining("Simulated decoding failure during value decoding");
+
+            // Verify that the connection remains usable after decode failure
+            retrieved = customRedis.get(normalKey);
+            assertThat(retrieved).isEqualTo(normalValue);
+
+            // Verify the value is actually stored in Redis using the normal connection
+            String valueFromNormalConnection = connection.sync().get(testKey);
+            assertThat(valueFromNormalConnection).isEqualTo(testValue);
+        }
+    }
+
+    @Test
+    void testDecodeFailureForReplyOOM() {
+        // First, set a value using the normal connection
+        String testKey = "decode-failure-key";
+        String testValue = "decode_failure_trigger";
+
+        connection.sync().set(testKey, testValue);
+
+        // Create a codec that fails during value decoding for specific values
+        RedisCodec<String, String> decodingFailureCodec = new RedisCodec<String, String>() {
+
+            @Override
+            public String decodeKey(ByteBuffer bytes) {
+                return StandardCharsets.UTF_8.decode(bytes).toString();
+            }
+
+            @Override
+            public String decodeValue(ByteBuffer bytes) {
+                String value = StandardCharsets.UTF_8.decode(bytes).toString();
+                // Throw exception when decoding specific value
+                if ("decode_failure_trigger".equals(value)) {
+                    throw new OutOfMemoryError("Simulated decoding failure during value decoding");
+                }
+                return value;
+            }
+
+            @Override
+            public ByteBuffer encodeKey(String key) {
+                return StandardCharsets.UTF_8.encode(key);
+            }
+
+            @Override
+            public ByteBuffer encodeValue(String value) {
+                return StandardCharsets.UTF_8.encode(value);
+            }
+
+        };
+
+        try (StatefulRedisConnection<String, String> customConnection = client.connect(decodingFailureCodec)) {
+            RedisCommands<String, String> customRedis = customConnection.sync();
+
+            // Test that normal values work fine
+            String normalKey = "normal-decode-key";
+            String normalValue = "normal-value";
+
+            customRedis.set(normalKey, normalValue);
+            String retrieved = customRedis.get(normalKey);
+            assertThat(retrieved).isEqualTo(normalValue);
+
+            // Now test that decoding the problematic value throws an exception
+            // The command was executed on Redis (the value is there), but decoding fails
+            assertThatThrownBy(() -> customRedis.get(testKey))
+                    .hasMessageContaining("Simulated decoding failure during value decoding");
+
+            // Verify that the connection remains usable after decode failure
+            retrieved = customRedis.get(normalKey);
+            assertThat(retrieved).isEqualTo(normalValue);
+
+            // Verify the value is actually stored in Redis using the normal connection
+            String valueFromNormalConnection = connection.sync().get(testKey);
+            assertThat(valueFromNormalConnection).isEqualTo(testValue);
+        }
+    }
+
+    // Create a codec that fails during value encoding with "encoding_failure" keyword
+    RedisCodec<String, String> failingCodec = new RedisCodec<String, String>() {
+
+        @Override
+        public String decodeKey(ByteBuffer bytes) {
+            return StandardCharsets.UTF_8.decode(bytes).toString();
+        }
+
+        @Override
+        public String decodeValue(ByteBuffer bytes) {
+            return StandardCharsets.UTF_8.decode(bytes).toString();
+        }
+
+        @Override
+        public ByteBuffer encodeKey(String key) {
+            return StandardCharsets.UTF_8.encode(key);
+        }
+
+        @Override
+        public ByteBuffer encodeValue(String value) {
+            // Only throw exception for specific value to test selective encoding failure
+            if ("encoding_failure".equals(value)) {
+                throw new RuntimeException("Simulated encoding failure during value encoding");
+            }
+            return StandardCharsets.UTF_8.encode(value);
+        }
+
+    };
+
+    // Create a codec that fails during value encoding with "encoding_failure" keyword
+    RedisCodec<String, String> failingCodecOOM = new RedisCodec<String, String>() {
+
+        @Override
+        public String decodeKey(ByteBuffer bytes) {
+            return StandardCharsets.UTF_8.decode(bytes).toString();
+        }
+
+        @Override
+        public String decodeValue(ByteBuffer bytes) {
+            return StandardCharsets.UTF_8.decode(bytes).toString();
+        }
+
+        @Override
+        public ByteBuffer encodeKey(String key) {
+            return StandardCharsets.UTF_8.encode(key);
+        }
+
+        @Override
+        public ByteBuffer encodeValue(String value) {
+            // Only throw exception for specific value to test selective encoding failure
+            if ("encoding_failure".equals(value)) {
+                throw new OutOfMemoryError("JVM running out of memory during decoding");
+            }
+            return StandardCharsets.UTF_8.encode(value);
+        }
+
+    };
+
+}

--- a/src/test/java/io/lettuce/core/protocol/ReactiveStreamErrorIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/protocol/ReactiveStreamErrorIntegrationTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2011-2025, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ */
+package io.lettuce.core.protocol;
+
+import static io.lettuce.TestTags.INTEGRATION_TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.TestSupport;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
+import io.lettuce.test.LettuceExtension;
+
+/**
+ * Integration tests simulating reactive stream errors similar to the Spring Data example. This test reproduces the issue where
+ * OutOfMemoryError thrown during reactive operations can cause out-of-order responses and result mismatches.
+ *
+ * @author Tihomir Mateev
+ * @see <a href="https://github.com/nordnet/lettuce-out-of-order">Lettuce OutOfOrder repo</a>
+ */
+@ExtendWith(LettuceExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Tag(INTEGRATION_TEST)
+class ReactiveStreamErrorIntegrationTests extends TestSupport {
+
+    private final StatefulRedisConnection<String, String> connection;
+
+    private static final SecureRandom random = new SecureRandom();
+
+    private static final String KEY_TO_WORK_ON = "lettuce:session-1234-4567-7890";
+
+    @Inject
+    ReactiveStreamErrorIntegrationTests(RedisClient client, StatefulRedisConnection<String, String> connection) {
+        this.connection = connection;
+    }
+
+    @BeforeEach
+    void setUp() {
+        this.connection.sync().flushall();
+    }
+
+    @Test
+    void errorSimulation() throws InterruptedException {
+        ExecutorService executorService = Executors.newCachedThreadPool();
+        AtomicInteger messageOutOfOrder = new AtomicInteger(0);
+
+        RedisReactiveCommands<String, String> reactive = connection.reactive();
+
+        Runnable readTask = () -> IntStream.range(0, 100).forEach(i -> {
+            reactive.get(KEY_TO_WORK_ON).doOnNext(result -> {
+                if (result.equals("OK")) {
+                    messageOutOfOrder.getAndIncrement();
+                }
+            }).block(Duration.ofMillis(100));
+        });
+
+        Runnable writeTask = () -> IntStream.range(0, 100).forEach(i -> {
+            String id = "value:" + i;
+            reactive.set(KEY_TO_WORK_ON, id).doOnNext(result -> {
+
+                if (random.nextBoolean()) {
+                    throw new OutOfMemoryError("Simulated error");
+                }
+            }).block(Duration.ofMillis(100));
+        });
+
+        IntStream.range(0, 1000).forEach(i -> executorService.submit(readTask));
+        IntStream.range(0, 1000).forEach(i -> executorService.submit(writeTask));
+
+        executorService.shutdown();
+        assertThat(executorService.awaitTermination(1, TimeUnit.MINUTES)).isTrue();
+
+        Assertions.assertEquals(0, messageOutOfOrder.get());
+    }
+
+}

--- a/src/test/java/io/lettuce/core/reliability/AtLeastOnceIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/reliability/AtLeastOnceIntegrationTests.java
@@ -174,7 +174,7 @@ class AtLeastOnceIntegrationTests {
 
         assertThat(verificationConnection.get(key)).isEqualTo("2");
 
-        assertThat(ConnectionTestUtil.getStack(connection.getStatefulConnection())).isNotEmpty();
+        assertThat(connection.get(key)).isEqualTo("2");
 
         connection.getStatefulConnection().close();
     }

--- a/src/test/java/io/lettuce/core/reliability/AtMostOnceIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/reliability/AtMostOnceIntegrationTests.java
@@ -172,15 +172,7 @@ class AtMostOnceIntegrationTests {
         assertThat(command.isCancelled()).isFalse();
         assertThat(getException(command)).isInstanceOf(EncoderException.class);
 
-        Wait.untilTrue(() -> !ConnectionTestUtil.getStack(connection).isEmpty()).waitOrTimeout();
-
-        assertThat(ConnectionTestUtil.getStack(connection)).isNotEmpty();
-        ConnectionTestUtil.getStack(connection).clear();
-
         assertThat(sync.get(key)).isEqualTo("2");
-
-        assertThat(ConnectionTestUtil.getStack(connection)).isEmpty();
-        assertThat(ConnectionTestUtil.getCommandBuffer(connection)).isEmpty();
 
         connection.close();
     }


### PR DESCRIPTION
* Correctly handling the encoding error for Lettuce [POC]

Summary:
Add encoding error tracking to prevent command queue corruption

  - Add markEncodingError() and hasEncodingError() methods to RedisCommand interface
  - Implement encoding error flag in Command class with volatile boolean
  - Mark commands with encoding errors in CommandEncoder on encode failures
  - Add lazy cleanup of encoding failures in CommandHandler response processing
  - Update all RedisCommand implementations to support encoding error tracking
  - Add comprehensive unit tests and integration tests for encoding error handling

Fixes issue where encoding failures could corrupt the outstanding command queue by leaving failed commands in the stack without proper cleanup, causing responses to be matched to wrong commands.

Test Plan: UTs, Integration testing

Reviewers: yayang, ureview

Reviewed By: yayang

Tags: #has_java

JIRA Issues: REDIS-14050

Differential Revision: https://code.uberinternal.com/D19068147

* Fix error command handling code logic and add integration test for encoding failure

Summary: Fix error command handling code logic and add integration test for encoding failure

Test Plan: unittest, integration test

Reviewers: #ldap_storage_sre_cache, ureview, jingzhao

Reviewed By: #ldap_storage_sre_cache, jingzhao

Tags: #has_java

JIRA Issues: REDIS-14192

Differential Revision: https://code.uberinternal.com/D19271701

* latest changes

* Addressing the reactive streams issue

* Addressing the encoding issues Addressing some general cases

* Formatting issues

* Test failures addressed

* Polishing

---------



(cherry picked from commit f65b8d18789aad6aee58346d991e744df00103c6)

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
