### PR TITLE
Implement `MaxTopologyRefresh`

### DIFF
--- a/docs/advanced-usage/client-options.md
+++ b/docs/advanced-usage/client-options.md
@@ -335,6 +335,18 @@ addresses reported by Redis <code>CLUSTER NODES</code> output which
 typically contains IP addresses.</p></td>
 </tr>
 <tr>
+<td>Maximum topology refresh sources</td>
+<td><code>maxTopologyRefreshSources</code></td>
+<td><code>Integer.MAX_VALUE</code></td>
+</tr>
+<tr>
+<td colspan="3"><p>Since: 7.6</p>
+<p>Limit the number of nodes queried during topology refresh. This
+option can be combined with dynamic topology refresh sources to retain
+node discovery while reducing the number of nodes contacted during a
+refresh.</p></td>
+</tr>
+<tr>
 <td>Close stale connections</td>
 <td><code>closeStaleConnections</code></td>
 <td><code>true</code></td>

--- a/src/main/java/io/lettuce/core/cluster/ClusterTopologyRefreshOptions.java
+++ b/src/main/java/io/lettuce/core/cluster/ClusterTopologyRefreshOptions.java
@@ -54,6 +54,8 @@ public class ClusterTopologyRefreshOptions {
 
     public static final boolean DEFAULT_DYNAMIC_REFRESH_SOURCES = true;
 
+    public static final int DEFAULT_MAX_TOPOLOGY_REFRESH_SOURCES = Integer.MAX_VALUE;
+
     public static final boolean DEFAULT_PERIODIC_REFRESH_ENABLED = false;
 
     public static final long DEFAULT_REFRESH_PERIOD = 60;
@@ -73,6 +75,8 @@ public class ClusterTopologyRefreshOptions {
 
     private final boolean dynamicRefreshSources;
 
+    private final int maxTopologyRefreshSources;
+
     private final boolean periodicRefreshEnabled;
 
     private final Duration refreshPeriod;
@@ -85,6 +89,7 @@ public class ClusterTopologyRefreshOptions {
         this.adaptiveRefreshTimeout = builder.adaptiveRefreshTimeout;
         this.closeStaleConnections = builder.closeStaleConnections;
         this.dynamicRefreshSources = builder.dynamicRefreshSources;
+        this.maxTopologyRefreshSources = builder.maxTopologyRefreshSources;
         this.periodicRefreshEnabled = builder.periodicRefreshEnabled;
         this.refreshPeriod = builder.refreshPeriod;
         this.refreshTriggersReconnectAttempts = builder.refreshTriggersReconnectAttempts;
@@ -96,6 +101,7 @@ public class ClusterTopologyRefreshOptions {
         this.adaptiveRefreshTimeout = original.adaptiveRefreshTimeout;
         this.closeStaleConnections = original.closeStaleConnections;
         this.dynamicRefreshSources = original.dynamicRefreshSources;
+        this.maxTopologyRefreshSources = original.maxTopologyRefreshSources;
         this.periodicRefreshEnabled = original.periodicRefreshEnabled;
         this.refreshPeriod = original.refreshPeriod;
         this.refreshTriggersReconnectAttempts = original.refreshTriggersReconnectAttempts;
@@ -150,6 +156,8 @@ public class ClusterTopologyRefreshOptions {
         private boolean closeStaleConnections = DEFAULT_CLOSE_STALE_CONNECTIONS;
 
         private boolean dynamicRefreshSources = DEFAULT_DYNAMIC_REFRESH_SOURCES;
+
+        private int maxTopologyRefreshSources = DEFAULT_MAX_TOPOLOGY_REFRESH_SOURCES;
 
         private boolean periodicRefreshEnabled = DEFAULT_PERIODIC_REFRESH_ENABLED;
 
@@ -290,17 +298,35 @@ public class ClusterTopologyRefreshOptions {
 
         /**
          * Discover cluster nodes from topology and use the discovered nodes as source for the cluster topology. Using dynamic
-         * refresh will query all discovered nodes for the cluster topology and calculate the number of clients for each node.
-         * If set to {@code false}, only the initial seed nodes will be used as sources for topology discovery and the number of
-         * clients including response latency will be obtained only for the initial seed nodes. This can be useful when using
-         * Redis Cluster with many nodes. Defaults to {@code true}. See
-         * {@link ClusterTopologyRefreshOptions#DEFAULT_DYNAMIC_REFRESH_SOURCES}.
+         * refresh will query all discovered nodes for the cluster topology and calculate the number of clients for each node
+         * unless {@link #maxTopologyRefreshSources(int)} limits the refresh sources. If set to {@code false}, only the initial
+         * seed nodes will be used as sources for topology discovery and the number of clients including response latency will
+         * be obtained only for the initial seed nodes. This can be useful when using Redis Cluster with many nodes. Defaults to
+         * {@code true}. See {@link ClusterTopologyRefreshOptions#DEFAULT_DYNAMIC_REFRESH_SOURCES}.
          *
          * @param dynamicRefreshSources {@code true} to discover and query all cluster nodes for obtaining the cluster topology
          * @return {@code this}
          */
         public Builder dynamicRefreshSources(boolean dynamicRefreshSources) {
             this.dynamicRefreshSources = dynamicRefreshSources;
+            return this;
+        }
+
+        /**
+         * Limit the number of nodes queried during topology refresh. The limit applies to seed nodes and discovered nodes. A
+         * value of {@link Integer#MAX_VALUE} queries all available sources. Defaults to
+         * {@link ClusterTopologyRefreshOptions#DEFAULT_MAX_TOPOLOGY_REFRESH_SOURCES}.
+         *
+         * @param maxTopologyRefreshSources maximum number of nodes to query during topology refresh, must be greater than
+         *        {@literal 0}
+         * @return {@code this}
+         * @since 7.6
+         */
+        public Builder maxTopologyRefreshSources(int maxTopologyRefreshSources) {
+
+            LettuceAssert.isTrue(maxTopologyRefreshSources > 0, "Max topology refresh sources must be greater 0");
+
+            this.maxTopologyRefreshSources = maxTopologyRefreshSources;
             return this;
         }
 
@@ -447,16 +473,27 @@ public class ClusterTopologyRefreshOptions {
 
     /**
      * Discover cluster nodes from topology and use the discovered nodes as source for the cluster topology. Using dynamic
-     * refresh will query all discovered nodes for the cluster topology and calculate the number of clients for each node. If
-     * set to {@code false}, only the initial seed nodes will be used as sources for topology discovery and the number of
-     * clients including response latency will be obtained only for the initial seed nodes. This can be useful when using Redis
-     * Cluster with many nodes. Defaults to {@code true}. See
+     * refresh will query all discovered nodes for the cluster topology and calculate the number of clients for each node unless
+     * {@link #getMaxTopologyRefreshSources()} limits the refresh sources. If set to {@code false}, only the initial seed nodes
+     * will be used as sources for topology discovery and the number of clients including response latency will be obtained only
+     * for the initial seed nodes. This can be useful when using Redis Cluster with many nodes. Defaults to {@code true}. See
      * {@link ClusterTopologyRefreshOptions#DEFAULT_DYNAMIC_REFRESH_SOURCES}.
      *
      * @return {@code true} if dynamic refresh sources are enabled
      */
     public boolean useDynamicRefreshSources() {
         return dynamicRefreshSources;
+    }
+
+    /**
+     * Maximum number of nodes queried during topology refresh. Defaults to
+     * {@link ClusterTopologyRefreshOptions#DEFAULT_MAX_TOPOLOGY_REFRESH_SOURCES}.
+     *
+     * @return maximum number of nodes queried during topology refresh
+     * @since 7.6
+     */
+    public int getMaxTopologyRefreshSources() {
+        return maxTopologyRefreshSources;
     }
 
     /**

--- a/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
@@ -354,13 +354,13 @@ public class RedisClusterClient extends AbstractRedisClient {
 
         Iterable<RedisURI> seed;
         if (initialSeedNodes || partitions == null || partitions.isEmpty()) {
-            seed = this.initialUris;
+            seed = LettuceLists.newListDeduplicated(this.initialUris, getMaxTopologyRefreshSources());
         } else {
             List<RedisURI> uris = new ArrayList<>();
             for (RedisClusterNode partition : TopologyComparators.sortByUri(partitions)) {
                 uris.add(partition.getUri());
             }
-            seed = uris;
+            seed = LettuceLists.newListDeduplicated(uris, getMaxTopologyRefreshSources());
         }
         return seed;
     }
@@ -1038,7 +1038,7 @@ public class RedisClusterClient extends AbstractRedisClient {
         Iterable<RedisURI> topologyRefreshSource = getTopologyRefreshSource();
         CompletableFuture<Partitions> future = new CompletableFuture<>();
 
-        fetchPartitions(topologyRefreshSource).whenComplete((nodes, throwable) -> {
+        fetchPartitions(topologyRefreshSource, getMaxTopologyRefreshSources()).whenComplete((nodes, throwable) -> {
 
             if (throwable == null) {
                 future.complete(nodes);
@@ -1046,9 +1046,9 @@ public class RedisClusterClient extends AbstractRedisClient {
             }
 
             // Attempt recovery using initial seed nodes
-            if (useDynamicRefreshSources() && topologyRefreshSource != initialUris) {
+            if (useDynamicRefreshSources() && !usesInitialUris(topologyRefreshSource)) {
 
-                fetchPartitions(initialUris).whenComplete((nextNodes, nextThrowable) -> {
+                fetchPartitions(initialUris, Integer.MAX_VALUE).whenComplete((nextNodes, nextThrowable) -> {
 
                     if (nextThrowable != null) {
                         Throwable exception = Exceptions.unwrap(nextThrowable);
@@ -1084,10 +1084,12 @@ public class RedisClusterClient extends AbstractRedisClient {
         return future;
     }
 
-    private CompletionStage<Partitions> fetchPartitions(Iterable<RedisURI> topologyRefreshSource) {
+    private CompletionStage<Partitions> fetchPartitions(Iterable<RedisURI> topologyRefreshSource,
+            int maxTopologyRefreshSources) {
 
         CompletionStage<Map<RedisURI, Partitions>> topology = refresh.loadViews(topologyRefreshSource,
-                getClusterClientOptions().getSocketOptions().getConnectTimeout(), useDynamicRefreshSources());
+                getClusterClientOptions().getSocketOptions().getConnectTimeout(), useDynamicRefreshSources(),
+                maxTopologyRefreshSources);
 
         return topology.thenApply(partitions -> {
 
@@ -1265,6 +1267,27 @@ public class RedisClusterClient extends AbstractRedisClient {
         ClusterTopologyRefreshOptions topologyRefreshOptions = getClusterClientOptions().getTopologyRefreshOptions();
 
         return topologyRefreshOptions.useDynamicRefreshSources();
+    }
+
+    /**
+     * Returns the maximum number of nodes queried during topology refresh.
+     *
+     * @return maximum number of nodes queried during topology refresh.
+     * @see ClusterTopologyRefreshOptions#getMaxTopologyRefreshSources()
+     */
+    protected int getMaxTopologyRefreshSources() {
+
+        ClusterTopologyRefreshOptions topologyRefreshOptions = getClusterClientOptions().getTopologyRefreshOptions();
+
+        return topologyRefreshOptions.getMaxTopologyRefreshSources();
+    }
+
+    private boolean usesInitialUris(Iterable<RedisURI> topologyRefreshSource) {
+        return toUniqueRedisUris(initialUris).equals(toUniqueRedisUris(topologyRefreshSource));
+    }
+
+    private static List<RedisURI> toUniqueRedisUris(Iterable<RedisURI> candidates) {
+        return LettuceLists.newListDeduplicated(candidates, Integer.MAX_VALUE);
     }
 
     /**

--- a/src/main/java/io/lettuce/core/cluster/topology/ClusterTopologyRefresh.java
+++ b/src/main/java/io/lettuce/core/cluster/topology/ClusterTopologyRefresh.java
@@ -38,4 +38,20 @@ public interface ClusterTopologyRefresh {
      */
     CompletionStage<Map<RedisURI, Partitions>> loadViews(Iterable<RedisURI> seed, Duration connectTimeout, boolean discovery);
 
+    /**
+     * Load topology views from a collection of {@link RedisURI}s and return the view per {@link RedisURI}. Partitions contain
+     * an ordered list of {@link RedisClusterNode}s. The sort key is latency. Nodes with lower latency come first.
+     *
+     * @param seed collection of {@link RedisURI}s
+     * @param connectTimeout connect timeout
+     * @param discovery {@code true} to discover additional nodes
+     * @param maxTopologyRefreshSources maximum number of nodes to query during topology refresh
+     * @return mapping between {@link RedisURI} and {@link Partitions}
+     * @since 7.6
+     */
+    default CompletionStage<Map<RedisURI, Partitions>> loadViews(Iterable<RedisURI> seed, Duration connectTimeout,
+            boolean discovery, int maxTopologyRefreshSources) {
+        return loadViews(seed, connectTimeout, discovery);
+    }
+
 }

--- a/src/main/java/io/lettuce/core/cluster/topology/DefaultClusterTopologyRefresh.java
+++ b/src/main/java/io/lettuce/core/cluster/topology/DefaultClusterTopologyRefresh.java
@@ -54,6 +54,8 @@ import io.lettuce.core.codec.StringCodec;
 import io.lettuce.core.internal.ExceptionFactory;
 import io.lettuce.core.internal.Exceptions;
 import io.lettuce.core.internal.Futures;
+import io.lettuce.core.internal.LettuceLists;
+import io.lettuce.core.internal.LettuceSets;
 import io.lettuce.core.internal.LettuceStrings;
 import io.lettuce.core.resource.ClientResources;
 import io.netty.util.Timeout;
@@ -92,15 +94,23 @@ class DefaultClusterTopologyRefresh implements ClusterTopologyRefresh {
     @Override
     public CompletionStage<Map<RedisURI, Partitions>> loadViews(Iterable<RedisURI> seed, Duration connectTimeout,
             boolean discovery) {
+        return loadViews(seed, connectTimeout, discovery, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public CompletionStage<Map<RedisURI, Partitions>> loadViews(Iterable<RedisURI> seed, Duration connectTimeout,
+            boolean discovery, int maxTopologyRefreshSources) {
 
         if (!isEventLoopActive()) {
             return CompletableFuture.completedFuture(Collections.emptyMap());
         }
 
-        long commandTimeoutNs = getCommandTimeoutNs(seed);
+        List<RedisURI> refreshSources = LettuceLists.newListDeduplicated(seed, maxTopologyRefreshSources);
+
+        long commandTimeoutNs = getCommandTimeoutNs(refreshSources);
         ConnectionTracker tracker = new ConnectionTracker();
         long connectionTimeout = commandTimeoutNs + connectTimeout.toNanos();
-        openConnections(tracker, seed, connectionTimeout, TimeUnit.NANOSECONDS);
+        openConnections(tracker, refreshSources, connectionTimeout, TimeUnit.NANOSECONDS);
 
         CompletableFuture<NodeTopologyViews> composition = tracker.whenComplete(map -> {
             return new Connections(clientResources, map);
@@ -115,16 +125,25 @@ class DefaultClusterTopologyRefresh implements ClusterTopologyRefresh {
                         if (discovery && isEventLoopActive()) {
 
                             Set<RedisURI> allKnownUris = views.getClusterNodes();
-                            Set<RedisURI> discoveredNodes = difference(allKnownUris, toSet(seed));
+                            Set<RedisURI> discoveredNodes = difference(allKnownUris, toSet(refreshSources));
+                            int remainingSources = remainingSources(maxTopologyRefreshSources, refreshSources.size());
 
-                            if (discoveredNodes.isEmpty()) {
+                            if (discoveredNodes.isEmpty() || remainingSources == 0) {
                                 return CompletableFuture.completedFuture(views);
                             }
 
-                            openConnections(tracker, discoveredNodes, connectionTimeout, TimeUnit.NANOSECONDS);
+                            List<RedisURI> additionalSources = LettuceLists.newListDeduplicated(discoveredNodes,
+                                    remainingSources);
+
+                            if (additionalSources.isEmpty()) {
+                                return CompletableFuture.completedFuture(views);
+                            }
+
+                            openConnections(tracker, additionalSources, connectionTimeout, TimeUnit.NANOSECONDS);
 
                             return tracker.whenComplete(map -> {
-                                return new Connections(clientResources, map).retainAll(discoveredNodes);
+                                return new Connections(clientResources, map)
+                                        .retainAll(LettuceSets.newHashSet(additionalSources));
                             }).thenCompose(newConnections -> {
 
                                 Requests additionalTopology = newConnections
@@ -150,7 +169,7 @@ class DefaultClusterTopologyRefresh implements ClusterTopologyRefresh {
                     }).thenCompose((it) -> tracker.close().thenApply(ignore -> it)).thenCompose(it -> {
 
                         if (it.isEmpty()) {
-                            Exception exception = tryFail(requestedTopology, tracker, seed);
+                            Exception exception = tryFail(requestedTopology, tracker, refreshSources);
                             return Futures.failed(exception);
                         }
 
@@ -388,6 +407,10 @@ class DefaultClusterTopologyRefresh implements ClusterTopologyRefresh {
         }
 
         return result;
+    }
+
+    private static int remainingSources(int maxTopologyRefreshSources, int refreshSources) {
+        return Math.max(0, maxTopologyRefreshSources - refreshSources);
     }
 
     private static long getCommandTimeoutNs(Iterable<RedisURI> redisURIs) {

--- a/src/main/java/io/lettuce/core/internal/LettuceLists.java
+++ b/src/main/java/io/lettuce/core/internal/LettuceLists.java
@@ -72,6 +72,43 @@ public final class LettuceLists {
     }
 
     /**
+     * Creates a new {@link ArrayList} containing the first distinct elements from {@code elements} up to {@code maxElements}.
+     * Encounter order is preserved.
+     *
+     * @param elements the elements that the list should contain, must not be {@code null}.
+     * @param maxElements maximum number of distinct elements to include, must not be negative.
+     * @param <T> the element type
+     * @return a new {@link ArrayList} containing at most {@code maxElements} distinct elements from {@code elements}.
+     */
+    public static <T> List<T> newListDeduplicated(Iterable<? extends T> elements, int maxElements) {
+
+        LettuceAssert.notNull(elements, "Iterable must not be null");
+        LettuceAssert.isTrue(maxElements >= 0, "Max elements must not be negative");
+
+        List<T> objects = new ArrayList<>();
+
+        if (maxElements == 0) {
+            return objects;
+        }
+
+        HashSet<T> seen = new HashSet<>();
+
+        for (T element : elements) {
+            if (!seen.add(element)) {
+                continue;
+            }
+
+            objects.add(element);
+
+            if (objects.size() == maxElements) {
+                break;
+            }
+        }
+
+        return objects;
+    }
+
+    /**
      * Creates a new unmodifiable {@link ArrayList} containing all elements from {@code elements}.
      *
      * @param elements the elements that the list should contain, must not be {@code null}.

--- a/src/test/java/io/lettuce/core/cluster/ClusterTopologyRefreshOptionsUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/ClusterTopologyRefreshOptionsUnitTests.java
@@ -25,6 +25,7 @@ class ClusterTopologyRefreshOptionsUnitTests {
         ClusterTopologyRefreshOptions options = ClusterTopologyRefreshOptions.builder()//
                 .enablePeriodicRefresh(true).refreshPeriod(10, TimeUnit.MINUTES)//
                 .dynamicRefreshSources(false) //
+                .maxTopologyRefreshSources(3) //
                 .disableAllAdaptiveRefreshTriggers()//
                 .enableAdaptiveRefreshTrigger(RefreshTrigger.MOVED_REDIRECT)//
                 .adaptiveRefreshTriggersTimeout(15, TimeUnit.MILLISECONDS)//
@@ -36,6 +37,7 @@ class ClusterTopologyRefreshOptionsUnitTests {
         assertThat(options.isCloseStaleConnections()).isEqualTo(false);
         assertThat(options.isPeriodicRefreshEnabled()).isTrue();
         assertThat(options.useDynamicRefreshSources()).isFalse();
+        assertThat(options.getMaxTopologyRefreshSources()).isEqualTo(3);
         assertThat(options.getAdaptiveRefreshTimeout()).isEqualTo(Duration.ofMillis(15));
         assertThat(options.getAdaptiveRefreshTriggers()).containsOnly(RefreshTrigger.MOVED_REDIRECT);
         assertThat(options.getRefreshTriggersReconnectAttempts()).isEqualTo(2);
@@ -47,6 +49,7 @@ class ClusterTopologyRefreshOptionsUnitTests {
         ClusterTopologyRefreshOptions master = ClusterTopologyRefreshOptions.builder()//
                 .enablePeriodicRefresh(true).refreshPeriod(10, TimeUnit.MINUTES)//
                 .dynamicRefreshSources(false) //
+                .maxTopologyRefreshSources(3) //
                 .disableAllAdaptiveRefreshTriggers()//
                 .enableAdaptiveRefreshTrigger(RefreshTrigger.MOVED_REDIRECT)//
                 .adaptiveRefreshTriggersTimeout(15, TimeUnit.MILLISECONDS)//
@@ -60,6 +63,7 @@ class ClusterTopologyRefreshOptionsUnitTests {
         assertThat(options.isCloseStaleConnections()).isEqualTo(false);
         assertThat(options.isPeriodicRefreshEnabled()).isTrue();
         assertThat(options.useDynamicRefreshSources()).isFalse();
+        assertThat(options.getMaxTopologyRefreshSources()).isEqualTo(3);
         assertThat(options.getAdaptiveRefreshTimeout()).isEqualTo(Duration.ofMillis(15));
         assertThat(options.getAdaptiveRefreshTriggers()).containsOnly(RefreshTrigger.MOVED_REDIRECT);
         assertThat(options.getRefreshTriggersReconnectAttempts()).isEqualTo(2);
@@ -76,6 +80,8 @@ class ClusterTopologyRefreshOptionsUnitTests {
                 .isFalse();
         assertThat(options.useDynamicRefreshSources()).isEqualTo(ClusterTopologyRefreshOptions.DEFAULT_DYNAMIC_REFRESH_SOURCES)
                 .isTrue();
+        assertThat(options.getMaxTopologyRefreshSources())
+                .isEqualTo(ClusterTopologyRefreshOptions.DEFAULT_MAX_TOPOLOGY_REFRESH_SOURCES);
         assertThat(options.getAdaptiveRefreshTimeout())
                 .isEqualTo(ClusterTopologyRefreshOptions.DEFAULT_ADAPTIVE_REFRESH_TIMEOUT_DURATION);
         assertThat(options.getAdaptiveRefreshTriggers())
@@ -91,6 +97,8 @@ class ClusterTopologyRefreshOptionsUnitTests {
 
         assertThat(options.isPeriodicRefreshEnabled()).isTrue();
         assertThat(options.useDynamicRefreshSources()).isTrue();
+        assertThat(options.getMaxTopologyRefreshSources())
+                .isEqualTo(ClusterTopologyRefreshOptions.DEFAULT_MAX_TOPOLOGY_REFRESH_SOURCES);
         assertThat(options.getAdaptiveRefreshTriggers()).contains(RefreshTrigger.ASK_REDIRECT, RefreshTrigger.MOVED_REDIRECT,
                 RefreshTrigger.PERSISTENT_RECONNECTS);
     }
@@ -101,6 +109,14 @@ class ClusterTopologyRefreshOptionsUnitTests {
         ClusterTopologyRefreshOptions.Builder builder = ClusterTopologyRefreshOptions.builder();
 
         assertThatIllegalArgumentException().isThrownBy(builder::enableAdaptiveRefreshTrigger);
+    }
+
+    @Test
+    void invalidMaxTopologyRefreshSourcesShouldFail() {
+
+        ClusterTopologyRefreshOptions.Builder builder = ClusterTopologyRefreshOptions.builder();
+
+        assertThatIllegalArgumentException().isThrownBy(() -> builder.maxTopologyRefreshSources(0));
     }
 
 }

--- a/src/test/java/io/lettuce/core/cluster/topology/ClusterTopologyRefreshUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/topology/ClusterTopologyRefreshUnitTests.java
@@ -418,6 +418,40 @@ class ClusterTopologyRefreshUnitTests {
     }
 
     @Test
+    void shouldLimitDiscoveredNodesToConfiguredMaximum() {
+
+        List<RedisURI> seed = Collections.singletonList(RedisURI.create("127.0.0.1", 7380));
+
+        when(nodeConnectionFactory.connectToNodeAsync(any(RedisCodec.class),
+                eq(InetSocketAddress.createUnresolved("127.0.0.1", 7380))))
+                        .thenReturn(completedFuture((StatefulRedisConnection) connection1));
+
+        sut.loadViews(seed, Duration.ofSeconds(1), true, 1);
+
+        verify(nodeConnectionFactory).connectToNodeAsync(any(RedisCodec.class),
+                eq(InetSocketAddress.createUnresolved("127.0.0.1", 7380)));
+        verify(nodeConnectionFactory, never()).connectToNodeAsync(any(RedisCodec.class),
+                eq(InetSocketAddress.createUnresolved("127.0.0.1", 7381)));
+    }
+
+    @Test
+    void shouldLimitSeedNodesToConfiguredMaximum() {
+
+        List<RedisURI> seed = Arrays.asList(RedisURI.create("127.0.0.1", 7380), RedisURI.create("127.0.0.1", 7381));
+
+        when(nodeConnectionFactory.connectToNodeAsync(any(RedisCodec.class),
+                eq(InetSocketAddress.createUnresolved("127.0.0.1", 7380))))
+                        .thenReturn(completedFuture((StatefulRedisConnection) connection1));
+
+        sut.loadViews(seed, Duration.ofSeconds(1), true, 1);
+
+        verify(nodeConnectionFactory).connectToNodeAsync(any(RedisCodec.class),
+                eq(InetSocketAddress.createUnresolved("127.0.0.1", 7380)));
+        verify(nodeConnectionFactory, never()).connectToNodeAsync(any(RedisCodec.class),
+                eq(InetSocketAddress.createUnresolved("127.0.0.1", 7381)));
+    }
+
+    @Test
     void shouldNotFailOnDuplicateSeedNodes() {
 
         List<RedisURI> seed = Arrays.asList(RedisURI.create("127.0.0.1", 7380), RedisURI.create("127.0.0.1", 7381),

--- a/src/test/java/io/lettuce/core/cluster/topology/TopologyRefreshIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/topology/TopologyRefreshIntegrationTests.java
@@ -135,6 +135,25 @@ class TopologyRefreshIntegrationTests extends TestSupport {
     }
 
     @Test
+    void limitedDynamicSourcesPreserveDiscovery() {
+
+        ClusterTopologyRefreshOptions topologyRefreshOptions = ClusterTopologyRefreshOptions.builder()
+                .dynamicRefreshSources(true).maxTopologyRefreshSources(1).build();
+        clusterClient.setOptions(ClusterClientOptions.builder().topologyRefreshOptions(topologyRefreshOptions).build());
+        RedisAdvancedClusterAsyncCommands<String, String> clusterConnection = clusterClient.connect().async();
+
+        Partitions partitions = clusterClient.getPartitions();
+
+        RedisClusterNodeSnapshot node1 = (RedisClusterNodeSnapshot) partitions.getPartitionBySlot(0);
+        assertThat(node1.getConnectedClients()).isGreaterThanOrEqualTo(1);
+
+        RedisClusterNodeSnapshot node2 = (RedisClusterNodeSnapshot) partitions.getPartitionBySlot(15000);
+        assertThat(node2.getConnectedClients()).isNull();
+
+        clusterConnection.getStatefulConnection().close();
+    }
+
+    @Test
     void adaptiveTopologyUpdateOnDisconnectNodeIdConnection() {
 
         runReconnectTest((clusterConnection, node) -> {


### PR DESCRIPTION
Implemented maxTopologyRefreshSources to cap the number of topology refresh source nodes when dynamicRefreshSources is enabled. This limits the fan-out to discovered nodes while keeping dynamic discovery behavior.
#3565 
Thanks ! 😄 

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster topology refresh connection fan-out and recovery paths; misconfigured low limits could yield incomplete per-node stats or weaker refresh coverage, though defaults preserve prior unlimited behavior.
> 
> **Overview**
> Adds **`maxTopologyRefreshSources`** (since 7.6) on `ClusterTopologyRefreshOptions` so Redis Cluster clients can cap how many nodes they connect to during a topology refresh while keeping **dynamic refresh** enabled.
> 
> The limit is applied when building refresh sources in `RedisClusterClient` (deduplicated seeds/partition URIs) and in `DefaultClusterTopologyRefresh`, which only opens connections to the first N distinct seeds and uses any **remaining budget** for discovered nodes instead of querying every node. Failover still falls back to **initial seed URIs without the cap** (`Integer.MAX_VALUE`). A new `LettuceLists.newListDeduplicated` helper enforces distinct URIs in encounter order.
> 
> Docs describe the option; unit and integration tests cover builder validation, capped seed/discovery connections, and behavior where only queried nodes get `connected_clients` stats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08c5594185f0d1f347fa06ca103bcba3d9eb6df1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->