### PR TITLE
[automatic failover] Simple renaming of factory classes in MultiDb

### DIFF
--- a/src/main/java/io/lettuce/core/failover/AbstractRedisMultiDbConnectionBuilder.java
+++ b/src/main/java/io/lettuce/core/failover/AbstractRedisMultiDbConnectionBuilder.java
@@ -293,7 +293,7 @@ abstract class AbstractRedisMultiDbConnectionBuilder<MC extends BaseRedisMultiDb
                     HealthCheck healthCheck = null;
                     if (HealthCheckStrategySupplier.NO_HEALTH_CHECK != config.getHealthCheckStrategySupplier()) {
                         HealthCheckStrategy hcStrategy = config.getHealthCheckStrategySupplier().get(config.getRedisURI(),
-                                new DatabaseRawConnectionFactoryImpl(config.getClientOptions(), client));
+                                new RawConnectionFactoryImpl(config.getClientOptions(), client));
                         healthCheck = healthStatusManager.add(uri, hcStrategy);
                     }
 

--- a/src/main/java/io/lettuce/core/failover/DatabaseFactory.java
+++ b/src/main/java/io/lettuce/core/failover/DatabaseFactory.java
@@ -16,7 +16,7 @@ import io.lettuce.core.failover.health.HealthStatusManager;
  * @since 7.4
  */
 @FunctionalInterface
-interface DatabaseConnectionFactory<C extends StatefulRedisConnection<K, V>, K, V> {
+interface DatabaseFactory<C extends StatefulRedisConnection<K, V>, K, V> {
 
     /**
      * Create a new database connection for the given configuration.

--- a/src/main/java/io/lettuce/core/failover/RawConnectionFactory.java
+++ b/src/main/java/io/lettuce/core/failover/RawConnectionFactory.java
@@ -13,7 +13,7 @@ import io.lettuce.core.api.StatefulRedisConnection;
  */
 @Experimental
 @FunctionalInterface
-public interface DatabaseRawConnectionFactory {
+public interface RawConnectionFactory {
 
     /**
      * Creates a new bare connection to the specified database endpoint. The connection is created without CircuitBreaker
@@ -22,6 +22,6 @@ public interface DatabaseRawConnectionFactory {
      * @param endpoint the Redis URI of the database endpoint
      * @return a new stateful Redis connection to the specified endpoint
      */
-    StatefulRedisConnection<?, ?> connectToDatabase(RedisURI endpoint);
+    StatefulRedisConnection<?, ?> create(RedisURI endpoint);
 
 }

--- a/src/main/java/io/lettuce/core/failover/RawConnectionFactoryImpl.java
+++ b/src/main/java/io/lettuce/core/failover/RawConnectionFactoryImpl.java
@@ -5,7 +5,7 @@ import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
 
 /**
- * Implementation of {@link DatabaseRawConnectionFactory} for creating raw connections to databases.
+ * Implementation of {@link RawConnectionFactory} for creating raw connections to databases.
  * <p>
  * This factory is used by health check strategies to create dedicated connections for health checking, separate from the main
  * application connections.
@@ -13,7 +13,7 @@ import io.lettuce.core.api.StatefulRedisConnection;
  * There is room to improve this factory since it hides the underlying {@link ClientOptions}, which might need to mutate or to
  * be exposed depending on the use case.
  */
-class DatabaseRawConnectionFactoryImpl implements DatabaseRawConnectionFactory {
+class RawConnectionFactoryImpl implements RawConnectionFactory {
 
     private final ClientOptions clientOptions;
 
@@ -25,13 +25,13 @@ class DatabaseRawConnectionFactoryImpl implements DatabaseRawConnectionFactory {
      * @param clientOptions the client options to use for connections
      * @param client the multi-database client
      */
-    public DatabaseRawConnectionFactoryImpl(ClientOptions clientOptions, MultiDbClientImpl client) {
+    public RawConnectionFactoryImpl(ClientOptions clientOptions, MultiDbClientImpl client) {
         this.clientOptions = clientOptions;
         this.client = client;
     }
 
     @Override
-    public StatefulRedisConnection<?, ?> connectToDatabase(RedisURI endpoint) {
+    public StatefulRedisConnection<?, ?> create(RedisURI endpoint) {
         client.setOptions(clientOptions);
         try {
             return client.connect(endpoint);

--- a/src/main/java/io/lettuce/core/failover/StatefulRedisMultiDbConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/failover/StatefulRedisMultiDbConnectionImpl.java
@@ -77,7 +77,7 @@ class StatefulRedisMultiDbConnectionImpl<C extends StatefulRedisConnection<K, V>
 
     protected final Set<RedisConnectionStateListener> connectionStateListeners = ConcurrentHashMap.newKeySet();
 
-    protected final DatabaseConnectionFactory<C, K, V> connectionFactory;
+    protected final DatabaseFactory<C, K, V> connectionFactory;
 
     private final ReadWriteLock multiDbLock = new ReentrantReadWriteLock();
 
@@ -89,7 +89,7 @@ class StatefulRedisMultiDbConnectionImpl<C extends StatefulRedisConnection<K, V>
 
     public StatefulRedisMultiDbConnectionImpl(RedisDatabaseImpl<C> initialDatabase,
             Map<RedisURI, RedisDatabaseImpl<C>> connections, ClientResources resources, RedisCodec<K, V> codec,
-            DatabaseConnectionFactory<C, K, V> connectionFactory, HealthStatusManager healthStatusManager,
+            DatabaseFactory<C, K, V> connectionFactory, HealthStatusManager healthStatusManager,
             RedisDatabaseAsyncCompletion<C> completion) {
         if (connections == null || connections.isEmpty()) {
             throw new IllegalArgumentException("connections must not be empty");
@@ -716,7 +716,7 @@ class StatefulRedisMultiDbConnectionImpl<C extends StatefulRedisConnection<K, V>
 
         if (connectionFactory == null) {
             throw new UnsupportedOperationException(
-                    "Adding databases dynamically is not supported. Connection was created without a DatabaseConnectionFactory.");
+                    "Adding databases dynamically is not supported. Connection was created without a DatabaseFactory.");
         }
 
         RedisURI redisURI = databaseConfig.getRedisURI();

--- a/src/main/java/io/lettuce/core/failover/StatefulRedisMultiDbPubSubConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/failover/StatefulRedisMultiDbPubSubConnectionImpl.java
@@ -51,7 +51,7 @@ class StatefulRedisMultiDbPubSubConnectionImpl<K, V>
      */
     public StatefulRedisMultiDbPubSubConnectionImpl(RedisDatabaseImpl<StatefulRedisPubSubConnection<K, V>> initialDatabase,
             Map<RedisURI, RedisDatabaseImpl<StatefulRedisPubSubConnection<K, V>>> connections, ClientResources resources,
-            RedisCodec<K, V> codec, DatabaseConnectionFactory<StatefulRedisPubSubConnection<K, V>, K, V> connectionFactory,
+            RedisCodec<K, V> codec, DatabaseFactory<StatefulRedisPubSubConnection<K, V>, K, V> connectionFactory,
             HealthStatusManager healthStatusManager,
             RedisDatabaseAsyncCompletion<StatefulRedisPubSubConnection<K, V>> completion) {
         super(initialDatabase, connections, resources, codec, connectionFactory, healthStatusManager, completion);

--- a/src/main/java/io/lettuce/core/failover/health/HealthCheckStrategySupplier.java
+++ b/src/main/java/io/lettuce/core/failover/health/HealthCheckStrategySupplier.java
@@ -2,7 +2,7 @@ package io.lettuce.core.failover.health;
 
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.annotations.Experimental;
-import io.lettuce.core.failover.DatabaseRawConnectionFactory;
+import io.lettuce.core.failover.RawConnectionFactory;
 
 /**
  * Supplier for health check strategies.
@@ -27,6 +27,6 @@ public interface HealthCheckStrategySupplier {
      * @param connectionFactory the connection factory
      * @return the health check strategy
      */
-    HealthCheckStrategy get(RedisURI redisURI, DatabaseRawConnectionFactory connectionFactory);
+    HealthCheckStrategy get(RedisURI redisURI, RawConnectionFactory connectionFactory);
 
 }

--- a/src/main/java/io/lettuce/core/failover/health/PingStrategy.java
+++ b/src/main/java/io/lettuce/core/failover/health/PingStrategy.java
@@ -3,7 +3,7 @@ package io.lettuce.core.failover.health;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.annotations.Experimental;
 import io.lettuce.core.api.StatefulRedisConnection;
-import io.lettuce.core.failover.DatabaseRawConnectionFactory;
+import io.lettuce.core.failover.RawConnectionFactory;
 
 /**
  * Health check strategy that uses PING command to check endpoint health.
@@ -14,15 +14,15 @@ import io.lettuce.core.failover.DatabaseRawConnectionFactory;
 @Experimental
 public class PingStrategy implements HealthCheckStrategy {
 
-    private final DatabaseRawConnectionFactory connectionFactory;
+    private final RawConnectionFactory connectionFactory;
 
     private final HealthCheckStrategy.Config config;
 
-    public PingStrategy(DatabaseRawConnectionFactory connectionFactory) {
+    public PingStrategy(RawConnectionFactory connectionFactory) {
         this(connectionFactory, HealthCheckStrategy.Config.create());
     }
 
-    public PingStrategy(DatabaseRawConnectionFactory connectionFactory, HealthCheckStrategy.Config config) {
+    public PingStrategy(RawConnectionFactory connectionFactory, HealthCheckStrategy.Config config) {
         this.connectionFactory = connectionFactory;
         this.config = config;
     }
@@ -54,7 +54,7 @@ public class PingStrategy implements HealthCheckStrategy {
 
     @Override
     public HealthStatus doHealthCheck(RedisURI endpoint) {
-        try (StatefulRedisConnection<?, ?> connection = connectionFactory.connectToDatabase(endpoint)) {
+        try (StatefulRedisConnection<?, ?> connection = connectionFactory.create(endpoint)) {
 
             if (connection == null) {
                 return HealthStatus.UNHEALTHY;

--- a/src/test/java/io/lettuce/core/failover/StatefulRedisMultiDbConnectionImplUnitTests.java
+++ b/src/test/java/io/lettuce/core/failover/StatefulRedisMultiDbConnectionImplUnitTests.java
@@ -102,7 +102,7 @@ class StatefulRedisMultiDbConnectionImplUnitTests {
     private HealthStatusManager healthStatusManager;
 
     @Mock
-    private DatabaseConnectionFactory<StatefulRedisConnection<String, String>, String, String> connectionFactory;
+    private DatabaseFactory<StatefulRedisConnection<String, String>, String, String> connectionFactory;
 
     private RedisCodec<String, String> codec;
 

--- a/src/test/java/io/lettuce/core/failover/health/PingStrategyIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/failover/health/PingStrategyIntegrationTests.java
@@ -7,7 +7,7 @@ import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.failover.DatabaseConfig;
-import io.lettuce.core.failover.DatabaseRawConnectionFactory;
+import io.lettuce.core.failover.RawConnectionFactory;
 import io.lettuce.core.failover.MultiDbClient;
 import io.lettuce.core.failover.MultiDbTestSupport;
 import io.lettuce.core.failover.api.StatefulRedisMultiDbConnection;
@@ -49,7 +49,7 @@ public class PingStrategyIntegrationTests extends MultiDbTestSupport {
 
     private static RedisURI proxyUri2;
 
-    private static TestDatabaseRawConnectionFactoryImpl rawConnectionFactory;
+    private static TestRawConnectionFactoryImpl rawConnectionFactory;
 
     @Inject
     PingStrategyIntegrationTests(MultiDbClient client) {
@@ -108,12 +108,12 @@ public class PingStrategyIntegrationTests extends MultiDbTestSupport {
     }
 
     @BeforeAll
-    static void setupDatabaseConnectionProvider() {
-        rawConnectionFactory = new TestDatabaseRawConnectionFactoryImpl();
+    static void setupConnectionFactory() {
+        rawConnectionFactory = new TestRawConnectionFactoryImpl();
     }
 
     @AfterAll
-    static void cleanupDatabaseConnectionProvider() {
+    static void cleanupConnectionFactory() {
         rawConnectionFactory.close();
     }
 
@@ -309,16 +309,16 @@ public class PingStrategyIntegrationTests extends MultiDbTestSupport {
         }
     }
 
-    private static class TestDatabaseRawConnectionFactoryImpl implements DatabaseRawConnectionFactory {
+    private static class TestRawConnectionFactoryImpl implements RawConnectionFactory {
 
         private final RedisClient client;
 
-        public TestDatabaseRawConnectionFactoryImpl() {
+        public TestRawConnectionFactoryImpl() {
             this.client = RedisClient.create(TestClientResources.get());
         }
 
         @Override
-        public StatefulRedisConnection<?, ?> connectToDatabase(RedisURI endpoint) {
+        public StatefulRedisConnection<?, ?> create(RedisURI endpoint) {
             return client.connect(endpoint);
         }
 


### PR DESCRIPTION
Attempt to improve factory type names in `io.lettuce.core.failover` package;

DatabaseRawConnectionFactory.**connectToDatabase** -> DatabaseRawConnectionFactory.**create**

**DatabaseRawConnectionFactory** -> **RawConnectionFactory**

**DatabaseRawConnectionFactoryImpl** -> **RawConnectionFactoryImpl**

**DatabaseConnectionFactory** -> **DatabaseFactory**











