### PR TITLE
fix bug: issue #3595 and add unit test 

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/PooledClusterConnectionProvider.java
+++ b/src/main/java/io/lettuce/core/cluster/PooledClusterConnectionProvider.java
@@ -615,10 +615,14 @@ class PooledClusterConnectionProvider<K, V>
             return false;
         }
 
-        if (connectionKey.host != null && partitions.getPartition(connectionKey.host, connectionKey.port) != null) {
-            return false;
-        }
+        RedisClusterNode node = partitions.getPartition(connectionKey.host, connectionKey.port);
 
+        if (connectionKey.host != null && node != null) {
+            if (connectionKey.connectionIntent == ConnectionIntent.READ && node.getRole().isUpstream()) {
+                return true;
+            }
+            return connectionKey.connectionIntent == ConnectionIntent.WRITE && node.getRole().isReplica();
+        }
         return true;
     }
 

--- a/src/main/java/io/lettuce/core/cluster/PooledClusterConnectionProvider.java
+++ b/src/main/java/io/lettuce/core/cluster/PooledClusterConnectionProvider.java
@@ -614,15 +614,17 @@ class PooledClusterConnectionProvider<K, V>
         if (connectionKey.nodeId != null && partitions.getPartitionByNodeId(connectionKey.nodeId) != null) {
             return false;
         }
+        if (connectionKey.host != null) {
+            RedisClusterNode node = partitions.getPartition(connectionKey.host, connectionKey.port);
 
-        RedisClusterNode node = partitions.getPartition(connectionKey.host, connectionKey.port);
-
-        if (connectionKey.host != null && node != null) {
-            if (connectionKey.connectionIntent == ConnectionIntent.READ && node.getRole().isUpstream()) {
-                return true;
+            if (node != null) {
+                if (connectionKey.connectionIntent == ConnectionIntent.READ && node.getRole().isUpstream()) {
+                    return true;
+                }
+                return connectionKey.connectionIntent == ConnectionIntent.WRITE && node.getRole().isReplica();
             }
-            return connectionKey.connectionIntent == ConnectionIntent.WRITE && node.getRole().isReplica();
         }
+
         return true;
     }
 


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stale-connection logic on every partition reconfigure; wrong intent/role pairing could close valid connections or leave bad ones open during failovers.
> 
> **Overview**
> Fixes cluster connection pooling so **stale connections are dropped when a node's role changes** after topology refresh, not only when the host disappears from the view.
> 
> `PooledClusterConnectionProvider.isStale` now treats host/port keys as stale when **READ** intent no longer matches an upstream (master) node, or **WRITE** intent no longer matches a replica—e.g. closing replica **READ** pools after a replica is promoted to master. A unit test simulates `ReadFrom.REPLICA` + `setPartitions` after promotion and asserts the pooled connection is closed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92433a86c2765bfac11969b11bba742062eaeec5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->