### PR TITLE
Improve resource management in client-side caching (listener cleanup + optional connection close) (#3526)

### DIFF
--- a/src/test/java/io/lettuce/core/support/caching/DefaultRedisCacheUnitTests.java
+++ b/src/test/java/io/lettuce/core/support/caching/DefaultRedisCacheUnitTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ */
+
+package io.lettuce.core.support.caching;
+
+import static io.lettuce.TestTags.UNIT_TEST;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.lettuce.core.StatefulRedisConnectionImpl;
+import io.lettuce.core.api.push.PushListener;
+import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.core.codec.StringCodec;
+
+/**
+ * Unit tests for {@link DefaultRedisCache}.
+ */
+@Tag(UNIT_TEST)
+class DefaultRedisCacheUnitTests {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void listenerShouldBeRemovedOnClose() {
+
+        StatefulRedisConnectionImpl<String, String> connection = mock(StatefulRedisConnectionImpl.class);
+        RedisCommands<String, String> commands = mock(RedisCommands.class);
+        when(connection.sync()).thenReturn(commands);
+
+        DefaultRedisCache<String, String> cache = new DefaultRedisCache<>(connection, StringCodec.UTF8);
+
+        cache.addInvalidationListener(key -> {
+        });
+
+        cache.close();
+
+        verify(connection).removeListener(any(PushListener.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void sharedConnectionShouldNotBeClosed() {
+
+        StatefulRedisConnectionImpl<String, String> connection = mock(StatefulRedisConnectionImpl.class);
+        RedisCommands<String, String> commands = mock(RedisCommands.class);
+        when(connection.sync()).thenReturn(commands);
+
+        DefaultRedisCache<String, String> cache = new DefaultRedisCache<>(connection, StringCodec.UTF8, false);
+
+        cache.close();
+
+        verify(connection, never()).close();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void defaultBehaviorShouldCloseConnection() {
+
+        StatefulRedisConnectionImpl<String, String> connection = mock(StatefulRedisConnectionImpl.class);
+        RedisCommands<String, String> commands = mock(RedisCommands.class);
+        when(connection.sync()).thenReturn(commands);
+
+        DefaultRedisCache<String, String> cache = new DefaultRedisCache<>(connection, StringCodec.UTF8);
+
+        cache.close();
+
+        verify(connection).close();
+    }
+
+}


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

> NOTE: This PR was split out from #3624 to keep concerns isolated and reviews focused.
> cc @a-TODO-rov

## Description
This PR addresses resource management issues in client-side caching (Fixes #3526).

### Problem
- `DefaultRedisCache` did not remove `PushListener` instances from the connection on `close()`, which can lead to memory leaks and duplicated invalidation behavior over time.
- Closing a `CacheFrontend` forcibly closed the underlying connection, which is problematic when the connection is shared across caches/components.

### Solution
- Track all registered listeners and **explicitly remove them** during `DefaultRedisCache#close()`.
- Introduce a `closeConnection` option (default: `true` for backward compatibility) to allow users to decide whether the underlying Redis connection should be closed when the cache closes.
- Add overloads for `ClientSideCaching#enable(...)` and `ClientSideCaching#create(...)` to accept `closeConnection`.

## Verification
- Added `DefaultRedisCacheUnitTests`:
  - verifies listener registration tracking and proper removal on `close()`
  - verifies connection close behavior depending on `closeConnection`

## Changes
- ClientSideCaching: added overloads for `enable/create` with `closeConnection` parameter.
- DefaultRedisCache: implemented listener tracking/removal + `closeConnection` logic.
- DefaultRedisCacheUnitTests: new unit tests for resource management.

Fixes #3526
Split from #3624