### PR TITLE
[automatic failover] Refactor Circuit Breaker Command Tracking

### DIFF
--- a/src/main/java/io/lettuce/core/failover/MultiDbOutboundHandler.java
+++ b/src/main/java/io/lettuce/core/failover/MultiDbOutboundHandler.java
@@ -1,15 +1,11 @@
 package io.lettuce.core.failover;
 
-import java.util.List;
+import java.util.Collection;
 
-import io.lettuce.core.RedisCommandTimeoutException;
-import io.lettuce.core.protocol.CompleteableCommand;
-import io.lettuce.core.protocol.RedisCommand;
+import io.lettuce.core.failover.DatabaseCommandTracker.CircuitBreakerAwareCommand;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
 
 /**
  * Channel handler for tracking command results and recording them to the circuit breaker.
@@ -39,15 +35,18 @@ class MultiDbOutboundHandler extends ChannelOutboundHandlerAdapter {
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         if (circuitBreaker != null) {
 
-            if (msg instanceof RedisCommand<?, ?, ?>) {
-                promise.addListener(recorder(circuitBreaker.getGeneration(), (RedisCommand<?, ?, ?>) msg));
+            if (msg instanceof CircuitBreakerAwareCommand<?, ?, ?>) {
+                promise.addListener(((CircuitBreakerAwareCommand<?, ?, ?>) msg));
             }
 
-            if (msg instanceof List) {
-                List<?> list = (List<?>) msg;
-                for (Object o : list) {
-                    if (o instanceof RedisCommand<?, ?, ?>) {
-                        promise.addListener(recorder(circuitBreaker.getGeneration(), (RedisCommand<?, ?, ?>) o));
+            if (msg instanceof Collection) {
+                Collection<?> collection = (Collection<?>) msg;
+                for (Object cmd : collection) {
+                    if (cmd instanceof CircuitBreakerAwareCommand<?, ?, ?>) {
+                        // we want to use the generation that is active at the time of write.
+                        // Using a lamda which acces directly to circuitBreaker.getGeneration() here would delay capturing the
+                        // generation and use a potentially wrong generation, a later one.
+                        promise.addListener(((CircuitBreakerAwareCommand<?, ?, ?>) cmd));
                     }
                 }
             }
@@ -55,33 +54,6 @@ class MultiDbOutboundHandler extends ChannelOutboundHandlerAdapter {
         // Pass the write operation down the pipeline
         super.write(ctx, msg, promise);
 
-    }
-
-    private GenericFutureListener<? extends Future<? super Void>> recorder(CircuitBreakerGeneration generation,
-            RedisCommand<?, ?, ?> command) {
-        return future -> {
-            // Record failure if write failed
-            if (!future.isSuccess()) {
-                generation.recordResult(future.cause());
-            } else {
-                // Track command completion if write succeeded
-                recordOnCommandComplete(generation, command);
-            }
-        };
-    }
-
-    private void recordOnCommandComplete(CircuitBreakerGeneration generation, RedisCommand<?, ?, ?> command) {
-        // Attach completion callback to track success/failure
-        if (command instanceof CompleteableCommand) {
-            CompleteableCommand<?> completeable = (CompleteableCommand<?>) command;
-            completeable.onComplete((o, e) -> {
-                // Record failures except for RedisCommandTimeoutException
-                // Timeouts are recorded by DatabaseCommandTracker
-                if (!(e instanceof RedisCommandTimeoutException)) {
-                    generation.recordResult(e);
-                }
-            });
-        }
     }
 
 }


### PR DESCRIPTION
Closes #3567 

## Summary
Refactored circuit breaker command tracking to use a wrapper-based approach instead of callback-based tracking, improving consistency and reducing code duplication.

## Changes

### Core Improvements
- **Introduced `CircuitBreakerAwareCommand`**: New `CommandWrapper` subclass that tracks circuit breaker results through lifecycle hooks
- **Simplified tracking logic**: Replaced callback-based tracking with wrapper-based approach using `doBeforeComplete()` and `doBeforeError()` hooks
- **Unified error handling**: All command results (success/failure) are now recorded consistently through the wrapper

### Modified Components
- **`DatabaseCommandTracker`**: 
  - Wraps commands in `CircuitBreakerAwareCommand` before writing
  - Removed `attachRecorder()` method and callback-based tracking
  - Records exceptions for each command in batch operations
  
- **`MultiDbOutboundHandler`**: 
  - Simplified to only attach listeners for `CircuitBreakerAwareCommand` instances
  - Removed `recorder()` and `recordOnCommandComplete()` methods
  - Changed from `List` to `Collection` for better type flexibility

- **`CommandWrapper`**: 
  - Added `doBeforeComplete()` and `doBeforeError()` lifecycle hooks
  - Hooks are called before delegating to wrapped command and notifying consumers

## Benefits
- Cleaner separation of concerns
- Reduced code complexity and duplication
- More maintainable circuit breaker tracking mechanism
- Consistent error recording across all command execution paths


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it refactors circuit-breaker result recording across both command completion and Netty write paths; subtle ordering/generation-capture changes could affect failover behavior under load.
> 
> **Overview**
> Circuit-breaker command tracking is refactored to a wrapper-based approach: `DatabaseCommandTracker` now wraps commands in `CircuitBreakerAwareCommand` (reusing existing wrappers via `CommandWrapper.unwrap`) so results are recorded via `doBeforeComplete()`/`doBeforeError()` rather than `onComplete` callbacks.
> 
> `MultiDbOutboundHandler` is simplified to only attach Netty `ChannelPromise` listeners when the outbound message is a `CircuitBreakerAwareCommand` (or a `Collection` of them), ensuring the circuit-breaker generation is captured at write time.
> 
> `CommandWrapper` gains new lifecycle hooks (`doBeforeComplete`, `doBeforeError`) invoked before delegating completion/error and before notifying consumers, enabling consistent pre-notification side effects such as circuit-breaker recording; batch write exception handling now records the failure per command.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 409319f15cab646c725d264259d7017e229ca555. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->