### PR TITLE
Deprecate commands

### DIFF
--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -390,11 +390,13 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
         return dispatch(commandBuilder.brpop(timeout, keys));
     }
 
+    @Deprecated
     @Override
     public RedisFuture<V> brpoplpush(long timeout, K source, K destination) {
         return dispatch(commandBuilder.brpoplpush(timeout, source, destination));
     }
 
+    @Deprecated
     @Override
     public RedisFuture<V> brpoplpush(double timeout, K source, K destination) {
         return dispatch(commandBuilder.brpoplpush(timeout, source, destination));

--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -2788,6 +2788,7 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
         return dispatch(commandBuilder.setex(key, seconds, value));
     }
 
+    @Deprecated
     @Override
     public RedisFuture<Boolean> setnx(K key, V value) {
         return dispatch(commandBuilder.setnx(key, value));

--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -1292,17 +1292,20 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
         return dispatch(commandBuilder.georadius(GEORADIUS_RO, key, longitude, latitude, distance, unit.name(), geoArgs));
     }
 
+    @Deprecated
     @Override
     public RedisFuture<Set<V>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit) {
         return georadiusbymember_ro(key, member, distance, unit);
     }
 
+    @Deprecated
     @Override
     public RedisFuture<List<GeoWithin<V>>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit,
             GeoArgs geoArgs) {
         return georadiusbymember_ro(key, member, distance, unit, geoArgs);
     }
 
+    @Deprecated
     @Override
     public RedisFuture<Long> georadiusbymember(K key, V member, double distance, Unit unit,
             GeoRadiusStoreArgs<K> geoRadiusStoreArgs) {

--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -1430,6 +1430,7 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
     }
 
     @Override
+    @Deprecated
     public RedisFuture<String> hmset(K key, Map<K, V> map) {
         return dispatch(commandBuilder.hmset(key, map));
     }

--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -1364,6 +1364,7 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
         return dispatch(commandBuilder.getrange(key, start, end));
     }
 
+    @Deprecated
     @Override
     public RedisFuture<V> getset(K key, V value) {
         return dispatch(commandBuilder.getset(key, value));

--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -2634,6 +2634,7 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
         return dispatch(commandBuilder.rpop(key, count));
     }
 
+    @Deprecated
     @Override
     public RedisFuture<V> rpoplpush(K source, K destination) {
         return dispatch(commandBuilder.rpoplpush(source, destination));

--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -2517,6 +2517,7 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
         return dispatch(commandBuilder.ping());
     }
 
+    @Deprecated
     @Override
     public RedisFuture<String> psetex(K key, long milliseconds, V value) {
         return dispatch(commandBuilder.psetex(key, milliseconds, value));

--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -2781,6 +2781,7 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
         return dispatch(commandBuilder.setbit(key, offset, value));
     }
 
+    @Deprecated
     @Override
     public RedisFuture<String> setex(K key, long seconds, V value) {
         return dispatch(commandBuilder.setex(key, seconds, value));

--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -1263,17 +1263,20 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
         return dispatch(commandBuilder.geopos(key, members));
     }
 
+    @Deprecated
     @Override
     public RedisFuture<Set<V>> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit) {
         return georadius_ro(key, longitude, latitude, distance, unit);
     }
 
+    @Deprecated
     @Override
     public RedisFuture<List<GeoWithin<V>>> georadius(K key, double longitude, double latitude, double distance,
             GeoArgs.Unit unit, GeoArgs geoArgs) {
         return georadius_ro(key, longitude, latitude, distance, unit, geoArgs);
     }
 
+    @Deprecated
     @Override
     public RedisFuture<Long> georadius(K key, double longitude, double latitude, double distance, Unit unit,
             GeoRadiusStoreArgs<K> geoRadiusStoreArgs) {

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -1335,6 +1335,7 @@ public abstract class AbstractRedisReactiveCommands<K, V>
                 () -> commandBuilder.georadius(GEORADIUS_RO, key, longitude, latitude, distance, unit.name(), geoArgs));
     }
 
+    @Deprecated
     @Override
     public Flux<V> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit) {
         return georadiusbymember_ro(key, member, distance, unit);

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -2581,6 +2581,7 @@ public abstract class AbstractRedisReactiveCommands<K, V>
         return createMono(commandBuilder::ping);
     }
 
+    @Deprecated
     @Override
     public Mono<String> psetex(K key, long milliseconds, V value) {
         return createMono(() -> commandBuilder.psetex(key, milliseconds, value));

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -2845,6 +2845,7 @@ public abstract class AbstractRedisReactiveCommands<K, V>
         return createMono(() -> commandBuilder.setbit(key, offset, value));
     }
 
+    @Deprecated
     @Override
     public Mono<String> setex(K key, long seconds, V value) {
         return createMono(() -> commandBuilder.setex(key, seconds, value));

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -2698,6 +2698,7 @@ public abstract class AbstractRedisReactiveCommands<K, V>
         return createDissolvingFlux(() -> commandBuilder.rpop(key, count));
     }
 
+    @Deprecated
     @Override
     public Mono<V> rpoplpush(K source, K destination) {
         return createMono(() -> commandBuilder.rpoplpush(source, destination));

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -1341,11 +1341,13 @@ public abstract class AbstractRedisReactiveCommands<K, V>
         return georadiusbymember_ro(key, member, distance, unit);
     }
 
+    @Deprecated
     @Override
     public Flux<GeoWithin<V>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit, GeoArgs geoArgs) {
         return georadiusbymember_ro(key, member, distance, unit, geoArgs);
     }
 
+    @Deprecated
     @Override
     public Mono<Long> georadiusbymember(K key, V member, double distance, Unit unit, GeoRadiusStoreArgs<K> geoRadiusStoreArgs) {
         return createMono(() -> commandBuilder.georadiusbymember(key, member, distance, unit.name(), geoRadiusStoreArgs));

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -1492,6 +1492,7 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
+    @Deprecated
     public Mono<String> hmset(K key, Map<K, V> map) {
         return createMono(() -> commandBuilder.hmset(key, map));
     }

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -1304,17 +1304,20 @@ public abstract class AbstractRedisReactiveCommands<K, V>
         return createDissolvingFlux(() -> commandBuilder.geoposValues(key, members));
     }
 
+    @Deprecated
     @Override
     public Flux<V> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit) {
         return georadius_ro(key, longitude, latitude, distance, unit);
     }
 
+    @Deprecated
     @Override
     public Flux<GeoWithin<V>> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit,
             GeoArgs geoArgs) {
         return georadius_ro(key, longitude, latitude, distance, unit, geoArgs);
     }
 
+    @Deprecated
     @Override
     public Mono<Long> georadius(K key, double longitude, double latitude, double distance, Unit unit,
             GeoRadiusStoreArgs<K> geoRadiusStoreArgs) {

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -409,11 +409,13 @@ public abstract class AbstractRedisReactiveCommands<K, V>
         return createMono(() -> commandBuilder.brpop(timeout, keys));
     }
 
+    @Deprecated
     @Override
     public Mono<V> brpoplpush(long timeout, K source, K destination) {
         return createMono(() -> commandBuilder.brpoplpush(timeout, source, destination));
     }
 
+    @Deprecated
     @Override
     public Mono<V> brpoplpush(double timeout, K source, K destination) {
         return createMono(() -> commandBuilder.brpoplpush(timeout, source, destination));

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -2852,6 +2852,7 @@ public abstract class AbstractRedisReactiveCommands<K, V>
         return createMono(() -> commandBuilder.setex(key, seconds, value));
     }
 
+    @Deprecated
     @Override
     public Mono<Boolean> setnx(K key, V value) {
         return createMono(() -> commandBuilder.setnx(key, value));

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -1406,6 +1406,7 @@ public abstract class AbstractRedisReactiveCommands<K, V>
         return createMono(() -> commandBuilder.getrange(key, start, end));
     }
 
+    @Deprecated
     @Override
     public Mono<V> getset(K key, V value) {
         return createMono(() -> commandBuilder.getset(key, value));

--- a/src/main/java/io/lettuce/core/api/async/RedisGeoAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisGeoAsyncCommands.java
@@ -199,7 +199,10 @@ public interface RedisGeoAsyncCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return set of members.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     RedisFuture<Set<V>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit);
 
     /**
@@ -212,7 +215,10 @@ public interface RedisGeoAsyncCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     RedisFuture<List<GeoWithin<V>>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit, GeoArgs geoArgs);
 
     /**
@@ -226,7 +232,10 @@ public interface RedisGeoAsyncCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     RedisFuture<Long> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit,
             GeoRadiusStoreArgs<K> geoRadiusStoreArgs);
 

--- a/src/main/java/io/lettuce/core/api/async/RedisGeoAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisGeoAsyncCommands.java
@@ -148,7 +148,10 @@ public interface RedisGeoAsyncCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return bulk reply.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     RedisFuture<Set<V>> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit);
 
     /**
@@ -161,7 +164,10 @@ public interface RedisGeoAsyncCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     RedisFuture<List<GeoWithin<V>>> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit,
             GeoArgs geoArgs);
 
@@ -177,7 +183,10 @@ public interface RedisGeoAsyncCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     RedisFuture<Long> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit,
             GeoRadiusStoreArgs<K> geoRadiusStoreArgs);
 

--- a/src/main/java/io/lettuce/core/api/async/RedisGeoAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisGeoAsyncCommands.java
@@ -148,8 +148,8 @@ public interface RedisGeoAsyncCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return bulk reply.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     RedisFuture<Set<V>> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit);
@@ -164,8 +164,8 @@ public interface RedisGeoAsyncCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     RedisFuture<List<GeoWithin<V>>> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit,
@@ -183,8 +183,8 @@ public interface RedisGeoAsyncCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     RedisFuture<Long> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit,
@@ -199,8 +199,8 @@ public interface RedisGeoAsyncCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return set of members.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     RedisFuture<Set<V>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit);
@@ -215,8 +215,8 @@ public interface RedisGeoAsyncCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     RedisFuture<List<GeoWithin<V>>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit, GeoArgs geoArgs);
@@ -232,8 +232,8 @@ public interface RedisGeoAsyncCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     RedisFuture<Long> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit,

--- a/src/main/java/io/lettuce/core/api/async/RedisGeoAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisGeoAsyncCommands.java
@@ -183,8 +183,9 @@ public interface RedisGeoAsyncCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
-     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
-     *             command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.7, use
+     *             {@link #geosearchstore(Object, Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs, boolean)} instead.
+     *             This command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     RedisFuture<Long> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit,
@@ -232,8 +233,9 @@ public interface RedisGeoAsyncCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
-     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
-     *             command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.7, use
+     *             {@link #geosearchstore(Object, Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs, boolean)} instead.
+     *             This command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     RedisFuture<Long> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit,

--- a/src/main/java/io/lettuce/core/api/async/RedisGeoAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisGeoAsyncCommands.java
@@ -148,7 +148,7 @@ public interface RedisGeoAsyncCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return bulk reply.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
      *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
@@ -164,7 +164,7 @@ public interface RedisGeoAsyncCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
      *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
@@ -183,7 +183,7 @@ public interface RedisGeoAsyncCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
      *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
@@ -199,7 +199,7 @@ public interface RedisGeoAsyncCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return set of members.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
      *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
@@ -215,7 +215,7 @@ public interface RedisGeoAsyncCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
      *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
@@ -232,7 +232,7 @@ public interface RedisGeoAsyncCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
      *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated

--- a/src/main/java/io/lettuce/core/api/async/RedisHashAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisHashAsyncCommands.java
@@ -170,8 +170,8 @@ public interface RedisHashAsyncCommands<K, V> {
      * @param key the key.
      * @param map the hash to apply.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead.
-     * This command is deprecated by Redis since version 4.0.0.
+     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead. This command is deprecated by Redis
+     *             since version 4.0.0.
      */
     @Deprecated
     RedisFuture<String> hmset(K key, Map<K, V> map);

--- a/src/main/java/io/lettuce/core/api/async/RedisHashAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisHashAsyncCommands.java
@@ -170,7 +170,10 @@ public interface RedisHashAsyncCommands<K, V> {
      * @param key the key.
      * @param map the hash to apply.
      * @return String simple-string-reply.
+     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead.
+     * This command is deprecated by Redis since version 4.0.0.
      */
+    @Deprecated
     RedisFuture<String> hmset(K key, Map<K, V> map);
 
     /**

--- a/src/main/java/io/lettuce/core/api/async/RedisHashAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisHashAsyncCommands.java
@@ -170,7 +170,7 @@ public interface RedisHashAsyncCommands<K, V> {
      * @param key the key.
      * @param map the hash to apply.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead. This command is deprecated by Redis
+     * @deprecated since 7.7, use {@link #hset(java.lang.Object, java.util.Map)} instead. This command is deprecated by Redis
      *             since version 4.0.0.
      */
     @Deprecated

--- a/src/main/java/io/lettuce/core/api/async/RedisListAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisListAsyncCommands.java
@@ -155,7 +155,10 @@ public interface RedisListAsyncCommands<K, V> {
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
+     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, long)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     RedisFuture<V> brpoplpush(long timeout, K source, K destination);
 
     /**
@@ -167,7 +170,10 @@ public interface RedisListAsyncCommands<K, V> {
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
      * @since 6.1.3
+     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, double)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     RedisFuture<V> brpoplpush(double timeout, K source, K destination);
 
     /**

--- a/src/main/java/io/lettuce/core/api/async/RedisListAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisListAsyncCommands.java
@@ -155,8 +155,8 @@ public interface RedisListAsyncCommands<K, V> {
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
-     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, long)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, long)} instead. This command is deprecated by
+     *             Redis since version 6.2.0.
      */
     @Deprecated
     RedisFuture<V> brpoplpush(long timeout, K source, K destination);
@@ -170,8 +170,8 @@ public interface RedisListAsyncCommands<K, V> {
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
      * @since 6.1.3
-     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, double)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, double)} instead. This command is deprecated by
+     *             Redis since version 6.2.0.
      */
     @Deprecated
     RedisFuture<V> brpoplpush(double timeout, K source, K destination);
@@ -399,8 +399,8 @@ public interface RedisListAsyncCommands<K, V> {
      * @param source the source key.
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped and pushed.
-     * @deprecated since 7.4.0, use {@link #lmove(Object, Object, LMoveArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #lmove(Object, Object, LMoveArgs)} instead. This command is deprecated by Redis since
+     *             version 6.2.0.
      */
     @Deprecated
     RedisFuture<V> rpoplpush(K source, K destination);

--- a/src/main/java/io/lettuce/core/api/async/RedisListAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisListAsyncCommands.java
@@ -393,7 +393,10 @@ public interface RedisListAsyncCommands<K, V> {
      * @param source the source key.
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped and pushed.
+     * @deprecated since 7.4.0, use {@link #lmove(Object, Object, LMoveArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     RedisFuture<V> rpoplpush(K source, K destination);
 
     /**

--- a/src/main/java/io/lettuce/core/api/async/RedisListAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisListAsyncCommands.java
@@ -155,8 +155,8 @@ public interface RedisListAsyncCommands<K, V> {
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
-     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, long)} instead. This command is deprecated by
-     *             Redis since version 6.2.0.
+     * @deprecated since 7.7, use {@link #blmove(Object, Object, LMoveArgs, long)} instead. This command is deprecated by Redis
+     *             since version 6.2.0.
      */
     @Deprecated
     RedisFuture<V> brpoplpush(long timeout, K source, K destination);
@@ -170,7 +170,7 @@ public interface RedisListAsyncCommands<K, V> {
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
      * @since 6.1.3
-     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, double)} instead. This command is deprecated by
+     * @deprecated since 7.7, use {@link #blmove(Object, Object, LMoveArgs, double)} instead. This command is deprecated by
      *             Redis since version 6.2.0.
      */
     @Deprecated
@@ -399,7 +399,7 @@ public interface RedisListAsyncCommands<K, V> {
      * @param source the source key.
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped and pushed.
-     * @deprecated since 7.4.0, use {@link #lmove(Object, Object, LMoveArgs)} instead. This command is deprecated by Redis since
+     * @deprecated since 7.7, use {@link #lmove(Object, Object, LMoveArgs)} instead. This command is deprecated by Redis since
      *             version 6.2.0.
      */
     @Deprecated

--- a/src/main/java/io/lettuce/core/api/async/RedisStringAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisStringAsyncCommands.java
@@ -434,7 +434,10 @@ public interface RedisStringAsyncCommands<K, V> {
      * @param seconds the seconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
+     * This command is deprecated by Redis since version 2.6.12.
      */
+    @Deprecated
     RedisFuture<String> setex(K key, long seconds, V value);
 
     /**

--- a/src/main/java/io/lettuce/core/api/async/RedisStringAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisStringAsyncCommands.java
@@ -302,8 +302,8 @@ public interface RedisStringAsyncCommands<K, V> {
      * @param key the key.
      * @param value the value.
      * @return V bulk-string-reply the old value stored at {@code key}, or {@code null} when {@code key} did not exist.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
+     *             version 6.2.0.
      */
     @Deprecated
     RedisFuture<V> getset(K key, V value);
@@ -437,8 +437,8 @@ public interface RedisStringAsyncCommands<K, V> {
      * @param seconds the seconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
-     * This command is deprecated by Redis since version 2.6.12.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
+     *             version 2.6.12.
      */
     @Deprecated
     RedisFuture<String> setex(K key, long seconds, V value);
@@ -450,8 +450,8 @@ public interface RedisStringAsyncCommands<K, V> {
      * @param milliseconds the milliseconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
-     * This command is deprecated by Redis since version 2.6.12.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
+     *             version 2.6.12.
      */
     @Deprecated
     RedisFuture<String> psetex(K key, long milliseconds, V value);
@@ -464,8 +464,8 @@ public interface RedisStringAsyncCommands<K, V> {
      * @return Boolean integer-reply specifically:
      *
      *         {@code 1} if the key was set {@code 0} if the key was not set.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
-     * This command is deprecated by Redis since version 2.6.12.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
+     *             version 2.6.12.
      */
     @Deprecated
     RedisFuture<Boolean> setnx(K key, V value);

--- a/src/main/java/io/lettuce/core/api/async/RedisStringAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisStringAsyncCommands.java
@@ -302,7 +302,10 @@ public interface RedisStringAsyncCommands<K, V> {
      * @param key the key.
      * @param value the value.
      * @return V bulk-string-reply the old value stored at {@code key}, or {@code null} when {@code key} did not exist.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     RedisFuture<V> getset(K key, V value);
 
     /**

--- a/src/main/java/io/lettuce/core/api/async/RedisStringAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisStringAsyncCommands.java
@@ -447,7 +447,10 @@ public interface RedisStringAsyncCommands<K, V> {
      * @param milliseconds the milliseconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
+     * This command is deprecated by Redis since version 2.6.12.
      */
+    @Deprecated
     RedisFuture<String> psetex(K key, long milliseconds, V value);
 
     /**

--- a/src/main/java/io/lettuce/core/api/async/RedisStringAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisStringAsyncCommands.java
@@ -461,7 +461,10 @@ public interface RedisStringAsyncCommands<K, V> {
      * @return Boolean integer-reply specifically:
      *
      *         {@code 1} if the key was set {@code 0} if the key was not set.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
+     * This command is deprecated by Redis since version 2.6.12.
      */
+    @Deprecated
     RedisFuture<Boolean> setnx(K key, V value);
 
     /**

--- a/src/main/java/io/lettuce/core/api/async/RedisStringAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisStringAsyncCommands.java
@@ -302,7 +302,7 @@ public interface RedisStringAsyncCommands<K, V> {
      * @param key the key.
      * @param value the value.
      * @return V bulk-string-reply the old value stored at {@code key}, or {@code null} when {@code key} did not exist.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
+     * @deprecated since 7.7, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
      *             version 6.2.0.
      */
     @Deprecated
@@ -437,8 +437,7 @@ public interface RedisStringAsyncCommands<K, V> {
      * @param seconds the seconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
-     *             version 2.6.12.
+     * @deprecated since 7.7, use {@link #set(Object, Object, SetArgs)} instead.
      */
     @Deprecated
     RedisFuture<String> setex(K key, long seconds, V value);
@@ -450,8 +449,7 @@ public interface RedisStringAsyncCommands<K, V> {
      * @param milliseconds the milliseconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
-     *             version 2.6.12.
+     * @deprecated since 7.7, use {@link #set(Object, Object, SetArgs)} instead.
      */
     @Deprecated
     RedisFuture<String> psetex(K key, long milliseconds, V value);
@@ -464,8 +462,7 @@ public interface RedisStringAsyncCommands<K, V> {
      * @return Boolean integer-reply specifically:
      *
      *         {@code 1} if the key was set {@code 0} if the key was not set.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
-     *             version 2.6.12.
+     * @deprecated since 7.7, use {@link #set(Object, Object, SetArgs)} instead.
      */
     @Deprecated
     RedisFuture<Boolean> setnx(K key, V value);

--- a/src/main/java/io/lettuce/core/api/reactive/RedisGeoReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisGeoReactiveCommands.java
@@ -146,7 +146,10 @@ public interface RedisGeoReactiveCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return bulk reply.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Flux<V> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit);
 
     /**
@@ -159,7 +162,10 @@ public interface RedisGeoReactiveCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Flux<GeoWithin<V>> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit, GeoArgs geoArgs);
 
     /**
@@ -174,7 +180,10 @@ public interface RedisGeoReactiveCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Mono<Long> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit,
             GeoRadiusStoreArgs<K> geoRadiusStoreArgs);
 

--- a/src/main/java/io/lettuce/core/api/reactive/RedisGeoReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisGeoReactiveCommands.java
@@ -196,7 +196,10 @@ public interface RedisGeoReactiveCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return set of members.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Flux<V> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit);
 
     /**
@@ -209,7 +212,10 @@ public interface RedisGeoReactiveCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Flux<GeoWithin<V>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit, GeoArgs geoArgs);
 
     /**
@@ -223,7 +229,10 @@ public interface RedisGeoReactiveCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Mono<Long> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit, GeoRadiusStoreArgs<K> geoRadiusStoreArgs);
 
     /**

--- a/src/main/java/io/lettuce/core/api/reactive/RedisGeoReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisGeoReactiveCommands.java
@@ -146,8 +146,8 @@ public interface RedisGeoReactiveCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return bulk reply.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     Flux<V> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit);
@@ -162,8 +162,8 @@ public interface RedisGeoReactiveCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     Flux<GeoWithin<V>> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit, GeoArgs geoArgs);
@@ -180,8 +180,8 @@ public interface RedisGeoReactiveCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     Mono<Long> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit,
@@ -196,8 +196,8 @@ public interface RedisGeoReactiveCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return set of members.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     Flux<V> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit);
@@ -212,8 +212,8 @@ public interface RedisGeoReactiveCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     Flux<GeoWithin<V>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit, GeoArgs geoArgs);
@@ -229,8 +229,8 @@ public interface RedisGeoReactiveCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     Mono<Long> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit, GeoRadiusStoreArgs<K> geoRadiusStoreArgs);

--- a/src/main/java/io/lettuce/core/api/reactive/RedisGeoReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisGeoReactiveCommands.java
@@ -180,8 +180,9 @@ public interface RedisGeoReactiveCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
-     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
-     *             command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.7, use
+     *             {@link #geosearchstore(Object, Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs, boolean)} instead.
+     *             This command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     Mono<Long> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit,
@@ -229,8 +230,9 @@ public interface RedisGeoReactiveCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
-     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
-     *             command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.7, use
+     *             {@link #geosearchstore(Object, Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs, boolean)} instead.
+     *             This command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     Mono<Long> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit, GeoRadiusStoreArgs<K> geoRadiusStoreArgs);

--- a/src/main/java/io/lettuce/core/api/reactive/RedisGeoReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisGeoReactiveCommands.java
@@ -146,7 +146,7 @@ public interface RedisGeoReactiveCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return bulk reply.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
      *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
@@ -162,7 +162,7 @@ public interface RedisGeoReactiveCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
      *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
@@ -180,7 +180,7 @@ public interface RedisGeoReactiveCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
      *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
@@ -196,7 +196,7 @@ public interface RedisGeoReactiveCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return set of members.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
      *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
@@ -212,7 +212,7 @@ public interface RedisGeoReactiveCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
      *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
@@ -229,7 +229,7 @@ public interface RedisGeoReactiveCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
      *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated

--- a/src/main/java/io/lettuce/core/api/reactive/RedisHashReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisHashReactiveCommands.java
@@ -179,8 +179,8 @@ public interface RedisHashReactiveCommands<K, V> {
      * @param key the key.
      * @param map the hash to apply.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead.
-     * This command is deprecated by Redis since version 4.0.0.
+     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead. This command is deprecated by Redis
+     *             since version 4.0.0.
      */
     @Deprecated
     Mono<String> hmset(K key, Map<K, V> map);

--- a/src/main/java/io/lettuce/core/api/reactive/RedisHashReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisHashReactiveCommands.java
@@ -179,7 +179,10 @@ public interface RedisHashReactiveCommands<K, V> {
      * @param key the key.
      * @param map the hash to apply.
      * @return String simple-string-reply.
+     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead.
+     * This command is deprecated by Redis since version 4.0.0.
      */
+    @Deprecated
     Mono<String> hmset(K key, Map<K, V> map);
 
     /**

--- a/src/main/java/io/lettuce/core/api/reactive/RedisHashReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisHashReactiveCommands.java
@@ -179,7 +179,7 @@ public interface RedisHashReactiveCommands<K, V> {
      * @param key the key.
      * @param map the hash to apply.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead. This command is deprecated by Redis
+     * @deprecated since 7.7, use {@link #hset(java.lang.Object, java.util.Map)} instead. This command is deprecated by Redis
      *             since version 4.0.0.
      */
     @Deprecated

--- a/src/main/java/io/lettuce/core/api/reactive/RedisListReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisListReactiveCommands.java
@@ -156,7 +156,10 @@ public interface RedisListReactiveCommands<K, V> {
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
+     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, double)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Mono<V> brpoplpush(long timeout, K source, K destination);
 
     /**
@@ -168,7 +171,10 @@ public interface RedisListReactiveCommands<K, V> {
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
      * @since 6.1.3
+     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, long)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Mono<V> brpoplpush(double timeout, K source, K destination);
 
     /**

--- a/src/main/java/io/lettuce/core/api/reactive/RedisListReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisListReactiveCommands.java
@@ -156,8 +156,8 @@ public interface RedisListReactiveCommands<K, V> {
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
-     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, double)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, double)} instead. This command is deprecated by
+     *             Redis since version 6.2.0.
      */
     @Deprecated
     Mono<V> brpoplpush(long timeout, K source, K destination);
@@ -171,8 +171,8 @@ public interface RedisListReactiveCommands<K, V> {
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
      * @since 6.1.3
-     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, long)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, long)} instead. This command is deprecated by
+     *             Redis since version 6.2.0.
      */
     @Deprecated
     Mono<V> brpoplpush(double timeout, K source, K destination);
@@ -401,8 +401,8 @@ public interface RedisListReactiveCommands<K, V> {
      * @param source the source key.
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped and pushed.
-     * @deprecated since 7.4.0, use {@link #lmove(Object, Object, LMoveArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #lmove(Object, Object, LMoveArgs)} instead. This command is deprecated by Redis since
+     *             version 6.2.0.
      */
     @Deprecated
     Mono<V> rpoplpush(K source, K destination);

--- a/src/main/java/io/lettuce/core/api/reactive/RedisListReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisListReactiveCommands.java
@@ -395,7 +395,10 @@ public interface RedisListReactiveCommands<K, V> {
      * @param source the source key.
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped and pushed.
+     * @deprecated since 7.4.0, use {@link #lmove(Object, Object, LMoveArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Mono<V> rpoplpush(K source, K destination);
 
     /**

--- a/src/main/java/io/lettuce/core/api/reactive/RedisListReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisListReactiveCommands.java
@@ -156,7 +156,7 @@ public interface RedisListReactiveCommands<K, V> {
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
-     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, double)} instead. This command is deprecated by
+     * @deprecated since 7.7, use {@link #blmove(Object, Object, LMoveArgs, double)} instead. This command is deprecated by
      *             Redis since version 6.2.0.
      */
     @Deprecated
@@ -171,8 +171,8 @@ public interface RedisListReactiveCommands<K, V> {
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
      * @since 6.1.3
-     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, long)} instead. This command is deprecated by
-     *             Redis since version 6.2.0.
+     * @deprecated since 7.7, use {@link #blmove(Object, Object, LMoveArgs, long)} instead. This command is deprecated by Redis
+     *             since version 6.2.0.
      */
     @Deprecated
     Mono<V> brpoplpush(double timeout, K source, K destination);
@@ -401,7 +401,7 @@ public interface RedisListReactiveCommands<K, V> {
      * @param source the source key.
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped and pushed.
-     * @deprecated since 7.4.0, use {@link #lmove(Object, Object, LMoveArgs)} instead. This command is deprecated by Redis since
+     * @deprecated since 7.7, use {@link #lmove(Object, Object, LMoveArgs)} instead. This command is deprecated by Redis since
      *             version 6.2.0.
      */
     @Deprecated

--- a/src/main/java/io/lettuce/core/api/reactive/RedisListReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisListReactiveCommands.java
@@ -156,8 +156,8 @@ public interface RedisListReactiveCommands<K, V> {
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
-     * @deprecated since 7.7, use {@link #blmove(Object, Object, LMoveArgs, double)} instead. This command is deprecated by
-     *             Redis since version 6.2.0.
+     * @deprecated since 7.7, use {@link #blmove(Object, Object, LMoveArgs, long)} instead. This command is deprecated by Redis
+     *             since version 6.2.0.
      */
     @Deprecated
     Mono<V> brpoplpush(long timeout, K source, K destination);
@@ -171,8 +171,8 @@ public interface RedisListReactiveCommands<K, V> {
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
      * @since 6.1.3
-     * @deprecated since 7.7, use {@link #blmove(Object, Object, LMoveArgs, long)} instead. This command is deprecated by Redis
-     *             since version 6.2.0.
+     * @deprecated since 7.7, use {@link #blmove(Object, Object, LMoveArgs, double)} instead. This command is deprecated by
+     *             Redis since version 6.2.0.
      */
     @Deprecated
     Mono<V> brpoplpush(double timeout, K source, K destination);

--- a/src/main/java/io/lettuce/core/api/reactive/RedisStringReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisStringReactiveCommands.java
@@ -438,7 +438,10 @@ public interface RedisStringReactiveCommands<K, V> {
      * @param seconds the seconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
+     * This command is deprecated by Redis since version 2.6.12.
      */
+    @Deprecated
     Mono<String> setex(K key, long seconds, V value);
 
     /**

--- a/src/main/java/io/lettuce/core/api/reactive/RedisStringReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisStringReactiveCommands.java
@@ -303,8 +303,8 @@ public interface RedisStringReactiveCommands<K, V> {
      * @param key the key.
      * @param value the value.
      * @return V bulk-string-reply the old value stored at {@code key}, or {@code null} when {@code key} did not exist.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
+     *             version 6.2.0.
      */
     @Deprecated
     Mono<V> getset(K key, V value);
@@ -441,8 +441,8 @@ public interface RedisStringReactiveCommands<K, V> {
      * @param seconds the seconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
-     * This command is deprecated by Redis since version 2.6.12.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
+     *             version 2.6.12.
      */
     @Deprecated
     Mono<String> setex(K key, long seconds, V value);
@@ -454,8 +454,8 @@ public interface RedisStringReactiveCommands<K, V> {
      * @param milliseconds the milliseconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
-     * This command is deprecated by Redis since version 2.6.12.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
+     *             version 2.6.12.
      */
     @Deprecated
     Mono<String> psetex(K key, long milliseconds, V value);
@@ -468,8 +468,8 @@ public interface RedisStringReactiveCommands<K, V> {
      * @return Boolean integer-reply specifically:
      *
      *         {@code 1} if the key was set {@code 0} if the key was not set.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
-     * This command is deprecated by Redis since version 2.6.12.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
+     *             version 2.6.12.
      */
     @Deprecated
     Mono<Boolean> setnx(K key, V value);

--- a/src/main/java/io/lettuce/core/api/reactive/RedisStringReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisStringReactiveCommands.java
@@ -465,7 +465,10 @@ public interface RedisStringReactiveCommands<K, V> {
      * @return Boolean integer-reply specifically:
      *
      *         {@code 1} if the key was set {@code 0} if the key was not set.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
+     * This command is deprecated by Redis since version 2.6.12.
      */
+    @Deprecated
     Mono<Boolean> setnx(K key, V value);
 
     /**

--- a/src/main/java/io/lettuce/core/api/reactive/RedisStringReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisStringReactiveCommands.java
@@ -303,7 +303,10 @@ public interface RedisStringReactiveCommands<K, V> {
      * @param key the key.
      * @param value the value.
      * @return V bulk-string-reply the old value stored at {@code key}, or {@code null} when {@code key} did not exist.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Mono<V> getset(K key, V value);
 
     /**

--- a/src/main/java/io/lettuce/core/api/reactive/RedisStringReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisStringReactiveCommands.java
@@ -451,7 +451,10 @@ public interface RedisStringReactiveCommands<K, V> {
      * @param milliseconds the milliseconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
+     * This command is deprecated by Redis since version 2.6.12.
      */
+    @Deprecated
     Mono<String> psetex(K key, long milliseconds, V value);
 
     /**

--- a/src/main/java/io/lettuce/core/api/reactive/RedisStringReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisStringReactiveCommands.java
@@ -303,7 +303,7 @@ public interface RedisStringReactiveCommands<K, V> {
      * @param key the key.
      * @param value the value.
      * @return V bulk-string-reply the old value stored at {@code key}, or {@code null} when {@code key} did not exist.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
+     * @deprecated since 7.7, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
      *             version 6.2.0.
      */
     @Deprecated
@@ -441,8 +441,7 @@ public interface RedisStringReactiveCommands<K, V> {
      * @param seconds the seconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
-     *             version 2.6.12.
+     * @deprecated since 7.7, use {@link #set(Object, Object, SetArgs)} instead.
      */
     @Deprecated
     Mono<String> setex(K key, long seconds, V value);
@@ -454,8 +453,7 @@ public interface RedisStringReactiveCommands<K, V> {
      * @param milliseconds the milliseconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
-     *             version 2.6.12.
+     * @deprecated since 7.7, use {@link #set(Object, Object, SetArgs)} instead.
      */
     @Deprecated
     Mono<String> psetex(K key, long milliseconds, V value);
@@ -468,8 +466,7 @@ public interface RedisStringReactiveCommands<K, V> {
      * @return Boolean integer-reply specifically:
      *
      *         {@code 1} if the key was set {@code 0} if the key was not set.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
-     *             version 2.6.12.
+     * @deprecated since 7.7, use {@link #set(Object, Object, SetArgs)} instead.
      */
     @Deprecated
     Mono<Boolean> setnx(K key, V value);

--- a/src/main/java/io/lettuce/core/api/sync/RedisGeoCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisGeoCommands.java
@@ -147,8 +147,8 @@ public interface RedisGeoCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return bulk reply.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     Set<V> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit);
@@ -163,8 +163,8 @@ public interface RedisGeoCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     List<GeoWithin<V>> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit, GeoArgs geoArgs);
@@ -181,8 +181,8 @@ public interface RedisGeoCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     Long georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit,
@@ -197,8 +197,8 @@ public interface RedisGeoCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return set of members.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     Set<V> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit);
@@ -213,8 +213,8 @@ public interface RedisGeoCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     List<GeoWithin<V>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit, GeoArgs geoArgs);
@@ -230,8 +230,8 @@ public interface RedisGeoCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     Long georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit, GeoRadiusStoreArgs<K> geoRadiusStoreArgs);

--- a/src/main/java/io/lettuce/core/api/sync/RedisGeoCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisGeoCommands.java
@@ -197,7 +197,10 @@ public interface RedisGeoCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return set of members.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Set<V> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit);
 
     /**
@@ -210,7 +213,10 @@ public interface RedisGeoCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     List<GeoWithin<V>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit, GeoArgs geoArgs);
 
     /**
@@ -224,7 +230,10 @@ public interface RedisGeoCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Long georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit, GeoRadiusStoreArgs<K> geoRadiusStoreArgs);
 
     /**

--- a/src/main/java/io/lettuce/core/api/sync/RedisGeoCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisGeoCommands.java
@@ -147,7 +147,10 @@ public interface RedisGeoCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return bulk reply.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Set<V> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit);
 
     /**
@@ -160,7 +163,10 @@ public interface RedisGeoCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     List<GeoWithin<V>> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit, GeoArgs geoArgs);
 
     /**
@@ -175,7 +181,10 @@ public interface RedisGeoCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
+     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Long georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit,
             GeoRadiusStoreArgs<K> geoRadiusStoreArgs);
 

--- a/src/main/java/io/lettuce/core/api/sync/RedisGeoCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisGeoCommands.java
@@ -181,8 +181,9 @@ public interface RedisGeoCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
-     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
-     *             command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.7, use
+     *             {@link #geosearchstore(Object, Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs, boolean)} instead.
+     *             This command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     Long georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit,
@@ -230,8 +231,9 @@ public interface RedisGeoCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
-     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
-     *             command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.7, use
+     *             {@link #geosearchstore(Object, Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs, boolean)} instead.
+     *             This command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     Long georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit, GeoRadiusStoreArgs<K> geoRadiusStoreArgs);

--- a/src/main/java/io/lettuce/core/api/sync/RedisGeoCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisGeoCommands.java
@@ -147,7 +147,7 @@ public interface RedisGeoCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return bulk reply.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
      *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
@@ -163,7 +163,7 @@ public interface RedisGeoCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
      *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
@@ -181,7 +181,7 @@ public interface RedisGeoCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
      *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
@@ -197,7 +197,7 @@ public interface RedisGeoCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return set of members.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
      *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
@@ -213,7 +213,7 @@ public interface RedisGeoCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
      *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
@@ -230,7 +230,7 @@ public interface RedisGeoCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
-     * @deprecated since 7.4.0, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
      *             command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated

--- a/src/main/java/io/lettuce/core/api/sync/RedisHashCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisHashCommands.java
@@ -169,8 +169,8 @@ public interface RedisHashCommands<K, V> {
      * @param key the key.
      * @param map the hash to apply.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead.
-     * This command is deprecated by Redis since version 4.0.0.
+     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead. This command is deprecated by Redis
+     *             since version 4.0.0.
      */
     @Deprecated
     String hmset(K key, Map<K, V> map);

--- a/src/main/java/io/lettuce/core/api/sync/RedisHashCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisHashCommands.java
@@ -169,7 +169,10 @@ public interface RedisHashCommands<K, V> {
      * @param key the key.
      * @param map the hash to apply.
      * @return String simple-string-reply.
+     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead.
+     * This command is deprecated by Redis since version 4.0.0.
      */
+    @Deprecated
     String hmset(K key, Map<K, V> map);
 
     /**

--- a/src/main/java/io/lettuce/core/api/sync/RedisHashCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisHashCommands.java
@@ -169,7 +169,7 @@ public interface RedisHashCommands<K, V> {
      * @param key the key.
      * @param map the hash to apply.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead. This command is deprecated by Redis
+     * @deprecated since 7.7, use {@link #hset(java.lang.Object, java.util.Map)} instead. This command is deprecated by Redis
      *             since version 4.0.0.
      */
     @Deprecated

--- a/src/main/java/io/lettuce/core/api/sync/RedisListCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisListCommands.java
@@ -154,7 +154,10 @@ public interface RedisListCommands<K, V> {
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
+     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, long)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     V brpoplpush(long timeout, K source, K destination);
 
     /**
@@ -166,7 +169,10 @@ public interface RedisListCommands<K, V> {
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
      * @since 6.1.3
+     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, double)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     V brpoplpush(double timeout, K source, K destination);
 
     /**

--- a/src/main/java/io/lettuce/core/api/sync/RedisListCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisListCommands.java
@@ -154,8 +154,8 @@ public interface RedisListCommands<K, V> {
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
-     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, long)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, long)} instead. This command is deprecated by
+     *             Redis since version 6.2.0.
      */
     @Deprecated
     V brpoplpush(long timeout, K source, K destination);
@@ -169,8 +169,8 @@ public interface RedisListCommands<K, V> {
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
      * @since 6.1.3
-     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, double)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, double)} instead. This command is deprecated by
+     *             Redis since version 6.2.0.
      */
     @Deprecated
     V brpoplpush(double timeout, K source, K destination);
@@ -398,8 +398,8 @@ public interface RedisListCommands<K, V> {
      * @param source the source key.
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped and pushed.
-     * @deprecated since 7.4.0, use {@link #lmove(Object, Object, LMoveArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #lmove(Object, Object, LMoveArgs)} instead. This command is deprecated by Redis since
+     *             version 6.2.0.
      */
     @Deprecated
     V rpoplpush(K source, K destination);

--- a/src/main/java/io/lettuce/core/api/sync/RedisListCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisListCommands.java
@@ -392,7 +392,10 @@ public interface RedisListCommands<K, V> {
      * @param source the source key.
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped and pushed.
+     * @deprecated since 7.4.0, use {@link #lmove(Object, Object, LMoveArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     V rpoplpush(K source, K destination);
 
     /**

--- a/src/main/java/io/lettuce/core/api/sync/RedisListCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisListCommands.java
@@ -154,8 +154,8 @@ public interface RedisListCommands<K, V> {
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
-     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, long)} instead. This command is deprecated by
-     *             Redis since version 6.2.0.
+     * @deprecated since 7.7, use {@link #blmove(Object, Object, LMoveArgs, long)} instead. This command is deprecated by Redis
+     *             since version 6.2.0.
      */
     @Deprecated
     V brpoplpush(long timeout, K source, K destination);
@@ -169,7 +169,7 @@ public interface RedisListCommands<K, V> {
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
      * @since 6.1.3
-     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, double)} instead. This command is deprecated by
+     * @deprecated since 7.7, use {@link #blmove(Object, Object, LMoveArgs, double)} instead. This command is deprecated by
      *             Redis since version 6.2.0.
      */
     @Deprecated
@@ -398,7 +398,7 @@ public interface RedisListCommands<K, V> {
      * @param source the source key.
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped and pushed.
-     * @deprecated since 7.4.0, use {@link #lmove(Object, Object, LMoveArgs)} instead. This command is deprecated by Redis since
+     * @deprecated since 7.7, use {@link #lmove(Object, Object, LMoveArgs)} instead. This command is deprecated by Redis since
      *             version 6.2.0.
      */
     @Deprecated

--- a/src/main/java/io/lettuce/core/api/sync/RedisStringCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisStringCommands.java
@@ -433,7 +433,10 @@ public interface RedisStringCommands<K, V> {
      * @param seconds the seconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
+     * @deprecated since 7.4.0, use {@link #set(K, V, SetArgs)} instead.
+     * This command is deprecated by Redis since version 2.6.12.
      */
+    @Deprecated
     String setex(K key, long seconds, V value);
 
     /**

--- a/src/main/java/io/lettuce/core/api/sync/RedisStringCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisStringCommands.java
@@ -301,7 +301,10 @@ public interface RedisStringCommands<K, V> {
      * @param key the key.
      * @param value the value.
      * @return V bulk-string-reply the old value stored at {@code key}, or {@code null} when {@code key} did not exist.
+     * @deprecated since 7.4.0, use {@link #set(K, V, SetArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     V getset(K key, V value);
 
     /**

--- a/src/main/java/io/lettuce/core/api/sync/RedisStringCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisStringCommands.java
@@ -301,8 +301,8 @@ public interface RedisStringCommands<K, V> {
      * @param key the key.
      * @param value the value.
      * @return V bulk-string-reply the old value stored at {@code key}, or {@code null} when {@code key} did not exist.
-     * @deprecated since 7.4.0, use {@link #set(K, V, SetArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #set(K, V, SetArgs)} instead. This command is deprecated by Redis since version
+     *             6.2.0.
      */
     @Deprecated
     V getset(K key, V value);
@@ -436,8 +436,8 @@ public interface RedisStringCommands<K, V> {
      * @param seconds the seconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #set(K, V, SetArgs)} instead.
-     * This command is deprecated by Redis since version 2.6.12.
+     * @deprecated since 7.4.0, use {@link #set(K, V, SetArgs)} instead. This command is deprecated by Redis since version
+     *             2.6.12.
      */
     @Deprecated
     String setex(K key, long seconds, V value);
@@ -449,8 +449,8 @@ public interface RedisStringCommands<K, V> {
      * @param milliseconds the milliseconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #set(K, V, SetArgs)} instead.
-     * This command is deprecated by Redis since version 2.6.12.
+     * @deprecated since 7.4.0, use {@link #set(K, V, SetArgs)} instead. This command is deprecated by Redis since version
+     *             2.6.12.
      */
     @Deprecated
     String psetex(K key, long milliseconds, V value);
@@ -463,8 +463,8 @@ public interface RedisStringCommands<K, V> {
      * @return Boolean integer-reply specifically:
      *
      *         {@code 1} if the key was set {@code 0} if the key was not set.
-     * @deprecated since 7.4.0, use {@link #set(K, V, SetArgs)} instead.
-     * This command is deprecated by Redis since version 2.6.12.
+     * @deprecated since 7.4.0, use {@link #set(K, V, SetArgs)} instead. This command is deprecated by Redis since version
+     *             2.6.12.
      */
     @Deprecated
     Boolean setnx(K key, V value);

--- a/src/main/java/io/lettuce/core/api/sync/RedisStringCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisStringCommands.java
@@ -460,7 +460,10 @@ public interface RedisStringCommands<K, V> {
      * @return Boolean integer-reply specifically:
      *
      *         {@code 1} if the key was set {@code 0} if the key was not set.
+     * @deprecated since 7.4.0, use {@link #set(K, V, SetArgs)} instead.
+     * This command is deprecated by Redis since version 2.6.12.
      */
+    @Deprecated
     Boolean setnx(K key, V value);
 
     /**

--- a/src/main/java/io/lettuce/core/api/sync/RedisStringCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisStringCommands.java
@@ -446,7 +446,10 @@ public interface RedisStringCommands<K, V> {
      * @param milliseconds the milliseconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
+     * @deprecated since 7.4.0, use {@link #set(K, V, SetArgs)} instead.
+     * This command is deprecated by Redis since version 2.6.12.
      */
+    @Deprecated
     String psetex(K key, long milliseconds, V value);
 
     /**

--- a/src/main/java/io/lettuce/core/api/sync/RedisStringCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisStringCommands.java
@@ -301,8 +301,7 @@ public interface RedisStringCommands<K, V> {
      * @param key the key.
      * @param value the value.
      * @return V bulk-string-reply the old value stored at {@code key}, or {@code null} when {@code key} did not exist.
-     * @deprecated since 7.4.0, use {@link #set(K, V, SetArgs)} instead. This command is deprecated by Redis since version
-     *             6.2.0.
+     * @deprecated since 7.7, use {@link #set(K, V, SetArgs)} instead. This command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     V getset(K key, V value);
@@ -436,8 +435,7 @@ public interface RedisStringCommands<K, V> {
      * @param seconds the seconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #set(K, V, SetArgs)} instead. This command is deprecated by Redis since version
-     *             2.6.12.
+     * @deprecated since 7.7, use {@link #set(K, V, SetArgs)} instead.
      */
     @Deprecated
     String setex(K key, long seconds, V value);
@@ -449,8 +447,7 @@ public interface RedisStringCommands<K, V> {
      * @param milliseconds the milliseconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #set(K, V, SetArgs)} instead. This command is deprecated by Redis since version
-     *             2.6.12.
+     * @deprecated since 7.7, use {@link #set(K, V, SetArgs)} instead.
      */
     @Deprecated
     String psetex(K key, long milliseconds, V value);
@@ -463,8 +460,7 @@ public interface RedisStringCommands<K, V> {
      * @return Boolean integer-reply specifically:
      *
      *         {@code 1} if the key was set {@code 0} if the key was not set.
-     * @deprecated since 7.4.0, use {@link #set(K, V, SetArgs)} instead. This command is deprecated by Redis since version
-     *             2.6.12.
+     * @deprecated since 7.7, use {@link #set(K, V, SetArgs)} instead.
      */
     @Deprecated
     Boolean setnx(K key, V value);

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionGeoAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionGeoAsyncCommands.java
@@ -147,7 +147,10 @@ public interface NodeSelectionGeoAsyncCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return bulk reply.
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     AsyncExecutions<Set<V>> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit);
 
     /**
@@ -160,7 +163,10 @@ public interface NodeSelectionGeoAsyncCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     AsyncExecutions<List<GeoWithin<V>>> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit,
             GeoArgs geoArgs);
 
@@ -176,7 +182,11 @@ public interface NodeSelectionGeoAsyncCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
+     * @deprecated since 7.7, use
+     *             {@link #geosearchstore(Object, Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs, boolean)} instead.
+     *             This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     AsyncExecutions<Long> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit,
             GeoRadiusStoreArgs<K> geoRadiusStoreArgs);
 
@@ -189,7 +199,10 @@ public interface NodeSelectionGeoAsyncCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return set of members.
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     AsyncExecutions<Set<V>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit);
 
     /**
@@ -202,7 +215,10 @@ public interface NodeSelectionGeoAsyncCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     AsyncExecutions<List<GeoWithin<V>>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit, GeoArgs geoArgs);
 
     /**
@@ -216,7 +232,11 @@ public interface NodeSelectionGeoAsyncCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
+     * @deprecated since 7.7, use
+     *             {@link #geosearchstore(Object, Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs, boolean)} instead.
+     *             This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     AsyncExecutions<Long> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit,
             GeoRadiusStoreArgs<K> geoRadiusStoreArgs);
 

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionHashAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionHashAsyncCommands.java
@@ -169,7 +169,10 @@ public interface NodeSelectionHashAsyncCommands<K, V> {
      * @param key the key.
      * @param map the hash to apply.
      * @return String simple-string-reply.
+     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead.
+     * This command is deprecated by Redis since version 4.0.0.
      */
+    @Deprecated
     AsyncExecutions<String> hmset(K key, Map<K, V> map);
 
     /**

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionHashAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionHashAsyncCommands.java
@@ -169,8 +169,8 @@ public interface NodeSelectionHashAsyncCommands<K, V> {
      * @param key the key.
      * @param map the hash to apply.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead.
-     * This command is deprecated by Redis since version 4.0.0.
+     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead. This command is deprecated by Redis
+     *             since version 4.0.0.
      */
     @Deprecated
     AsyncExecutions<String> hmset(K key, Map<K, V> map);

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionHashAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionHashAsyncCommands.java
@@ -169,7 +169,7 @@ public interface NodeSelectionHashAsyncCommands<K, V> {
      * @param key the key.
      * @param map the hash to apply.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead. This command is deprecated by Redis
+     * @deprecated since 7.7, use {@link #hset(java.lang.Object, java.util.Map)} instead. This command is deprecated by Redis
      *             since version 4.0.0.
      */
     @Deprecated

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionListAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionListAsyncCommands.java
@@ -154,7 +154,10 @@ public interface NodeSelectionListAsyncCommands<K, V> {
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
+     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, long)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     AsyncExecutions<V> brpoplpush(long timeout, K source, K destination);
 
     /**
@@ -166,7 +169,10 @@ public interface NodeSelectionListAsyncCommands<K, V> {
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
      * @since 6.1.3
+     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, double)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     AsyncExecutions<V> brpoplpush(double timeout, K source, K destination);
 
     /**

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionListAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionListAsyncCommands.java
@@ -154,8 +154,8 @@ public interface NodeSelectionListAsyncCommands<K, V> {
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
-     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, long)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, long)} instead. This command is deprecated by
+     *             Redis since version 6.2.0.
      */
     @Deprecated
     AsyncExecutions<V> brpoplpush(long timeout, K source, K destination);
@@ -169,8 +169,8 @@ public interface NodeSelectionListAsyncCommands<K, V> {
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
      * @since 6.1.3
-     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, double)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, double)} instead. This command is deprecated by
+     *             Redis since version 6.2.0.
      */
     @Deprecated
     AsyncExecutions<V> brpoplpush(double timeout, K source, K destination);
@@ -398,8 +398,8 @@ public interface NodeSelectionListAsyncCommands<K, V> {
      * @param source the source key.
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped and pushed.
-     * @deprecated since 7.4.0, use {@link #lmove(Object, Object, LMoveArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #lmove(Object, Object, LMoveArgs)} instead. This command is deprecated by Redis since
+     *             version 6.2.0.
      */
     @Deprecated
     AsyncExecutions<V> rpoplpush(K source, K destination);

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionListAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionListAsyncCommands.java
@@ -392,7 +392,10 @@ public interface NodeSelectionListAsyncCommands<K, V> {
      * @param source the source key.
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped and pushed.
+     * @deprecated since 7.4.0, use {@link #lmove(Object, Object, LMoveArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     AsyncExecutions<V> rpoplpush(K source, K destination);
 
     /**

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionListAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionListAsyncCommands.java
@@ -154,8 +154,8 @@ public interface NodeSelectionListAsyncCommands<K, V> {
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
-     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, long)} instead. This command is deprecated by
-     *             Redis since version 6.2.0.
+     * @deprecated since 7.7, use {@link #blmove(Object, Object, LMoveArgs, long)} instead. This command is deprecated by Redis
+     *             since version 6.2.0.
      */
     @Deprecated
     AsyncExecutions<V> brpoplpush(long timeout, K source, K destination);
@@ -169,7 +169,7 @@ public interface NodeSelectionListAsyncCommands<K, V> {
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
      * @since 6.1.3
-     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, double)} instead. This command is deprecated by
+     * @deprecated since 7.7, use {@link #blmove(Object, Object, LMoveArgs, double)} instead. This command is deprecated by
      *             Redis since version 6.2.0.
      */
     @Deprecated
@@ -398,7 +398,7 @@ public interface NodeSelectionListAsyncCommands<K, V> {
      * @param source the source key.
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped and pushed.
-     * @deprecated since 7.4.0, use {@link #lmove(Object, Object, LMoveArgs)} instead. This command is deprecated by Redis since
+     * @deprecated since 7.7, use {@link #lmove(Object, Object, LMoveArgs)} instead. This command is deprecated by Redis since
      *             version 6.2.0.
      */
     @Deprecated

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionStringAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionStringAsyncCommands.java
@@ -300,7 +300,10 @@ public interface NodeSelectionStringAsyncCommands<K, V> {
      * @param key the key.
      * @param value the value.
      * @return V bulk-string-reply the old value stored at {@code key}, or {@code null} when {@code key} did not exist.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     AsyncExecutions<V> getset(K key, V value);
 
     /**

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionStringAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionStringAsyncCommands.java
@@ -445,7 +445,10 @@ public interface NodeSelectionStringAsyncCommands<K, V> {
      * @param milliseconds the milliseconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
+     * This command is deprecated by Redis since version 2.6.12.
      */
+    @Deprecated
     AsyncExecutions<String> psetex(K key, long milliseconds, V value);
 
     /**

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionStringAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionStringAsyncCommands.java
@@ -432,7 +432,10 @@ public interface NodeSelectionStringAsyncCommands<K, V> {
      * @param seconds the seconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
+     * This command is deprecated by Redis since version 2.6.12.
      */
+    @Deprecated
     AsyncExecutions<String> setex(K key, long seconds, V value);
 
     /**

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionStringAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionStringAsyncCommands.java
@@ -300,8 +300,8 @@ public interface NodeSelectionStringAsyncCommands<K, V> {
      * @param key the key.
      * @param value the value.
      * @return V bulk-string-reply the old value stored at {@code key}, or {@code null} when {@code key} did not exist.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
+     *             version 6.2.0.
      */
     @Deprecated
     AsyncExecutions<V> getset(K key, V value);
@@ -435,8 +435,8 @@ public interface NodeSelectionStringAsyncCommands<K, V> {
      * @param seconds the seconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
-     * This command is deprecated by Redis since version 2.6.12.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
+     *             version 2.6.12.
      */
     @Deprecated
     AsyncExecutions<String> setex(K key, long seconds, V value);
@@ -448,8 +448,8 @@ public interface NodeSelectionStringAsyncCommands<K, V> {
      * @param milliseconds the milliseconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
-     * This command is deprecated by Redis since version 2.6.12.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
+     *             version 2.6.12.
      */
     @Deprecated
     AsyncExecutions<String> psetex(K key, long milliseconds, V value);
@@ -462,8 +462,8 @@ public interface NodeSelectionStringAsyncCommands<K, V> {
      * @return Boolean integer-reply specifically:
      *
      *         {@code 1} if the key was set {@code 0} if the key was not set.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
-     * This command is deprecated by Redis since version 2.6.12.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
+     *             version 2.6.12.
      */
     @Deprecated
     AsyncExecutions<Boolean> setnx(K key, V value);

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionStringAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionStringAsyncCommands.java
@@ -459,7 +459,10 @@ public interface NodeSelectionStringAsyncCommands<K, V> {
      * @return Boolean integer-reply specifically:
      *
      *         {@code 1} if the key was set {@code 0} if the key was not set.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
+     * This command is deprecated by Redis since version 2.6.12.
      */
+    @Deprecated
     AsyncExecutions<Boolean> setnx(K key, V value);
 
     /**

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionStringAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionStringAsyncCommands.java
@@ -300,7 +300,7 @@ public interface NodeSelectionStringAsyncCommands<K, V> {
      * @param key the key.
      * @param value the value.
      * @return V bulk-string-reply the old value stored at {@code key}, or {@code null} when {@code key} did not exist.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
+     * @deprecated since 7.7, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
      *             version 6.2.0.
      */
     @Deprecated
@@ -435,8 +435,7 @@ public interface NodeSelectionStringAsyncCommands<K, V> {
      * @param seconds the seconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
-     *             version 2.6.12.
+     * @deprecated since 7.7, use {@link #set(Object, Object, SetArgs)} instead.
      */
     @Deprecated
     AsyncExecutions<String> setex(K key, long seconds, V value);
@@ -448,8 +447,7 @@ public interface NodeSelectionStringAsyncCommands<K, V> {
      * @param milliseconds the milliseconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
-     *             version 2.6.12.
+     * @deprecated since 7.7, use {@link #set(Object, Object, SetArgs)} instead.
      */
     @Deprecated
     AsyncExecutions<String> psetex(K key, long milliseconds, V value);
@@ -462,8 +460,7 @@ public interface NodeSelectionStringAsyncCommands<K, V> {
      * @return Boolean integer-reply specifically:
      *
      *         {@code 1} if the key was set {@code 0} if the key was not set.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
-     *             version 2.6.12.
+     * @deprecated since 7.7, use {@link #set(Object, Object, SetArgs)} instead.
      */
     @Deprecated
     AsyncExecutions<Boolean> setnx(K key, V value);

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionGeoCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionGeoCommands.java
@@ -147,7 +147,10 @@ public interface NodeSelectionGeoCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return bulk reply.
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Executions<Set<V>> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit);
 
     /**
@@ -160,7 +163,10 @@ public interface NodeSelectionGeoCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Executions<List<GeoWithin<V>>> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit,
             GeoArgs geoArgs);
 
@@ -176,7 +182,11 @@ public interface NodeSelectionGeoCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
+     * @deprecated since 7.7, use
+     *             {@link #geosearchstore(Object, Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs, boolean)} instead.
+     *             This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Executions<Long> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit,
             GeoRadiusStoreArgs<K> geoRadiusStoreArgs);
 
@@ -189,7 +199,10 @@ public interface NodeSelectionGeoCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return set of members.
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Executions<Set<V>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit);
 
     /**
@@ -202,7 +215,10 @@ public interface NodeSelectionGeoCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Executions<List<GeoWithin<V>>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit, GeoArgs geoArgs);
 
     /**
@@ -216,7 +232,11 @@ public interface NodeSelectionGeoCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
+     * @deprecated since 7.7, use
+     *             {@link #geosearchstore(Object, Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs, boolean)} instead.
+     *             This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Executions<Long> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit,
             GeoRadiusStoreArgs<K> geoRadiusStoreArgs);
 

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionHashCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionHashCommands.java
@@ -169,8 +169,8 @@ public interface NodeSelectionHashCommands<K, V> {
      * @param key the key.
      * @param map the hash to apply.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead.
-     * This command is deprecated by Redis since version 4.0.0.
+     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead. This command is deprecated by Redis
+     *             since version 4.0.0.
      */
     @Deprecated
     Executions<String> hmset(K key, Map<K, V> map);

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionHashCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionHashCommands.java
@@ -169,7 +169,10 @@ public interface NodeSelectionHashCommands<K, V> {
      * @param key the key.
      * @param map the hash to apply.
      * @return String simple-string-reply.
+     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead.
+     * This command is deprecated by Redis since version 4.0.0.
      */
+    @Deprecated
     Executions<String> hmset(K key, Map<K, V> map);
 
     /**

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionHashCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionHashCommands.java
@@ -169,7 +169,7 @@ public interface NodeSelectionHashCommands<K, V> {
      * @param key the key.
      * @param map the hash to apply.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead. This command is deprecated by Redis
+     * @deprecated since 7.7, use {@link #hset(java.lang.Object, java.util.Map)} instead. This command is deprecated by Redis
      *             since version 4.0.0.
      */
     @Deprecated

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionListCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionListCommands.java
@@ -154,8 +154,8 @@ public interface NodeSelectionListCommands<K, V> {
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
-     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, long)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, long)} instead. This command is deprecated by
+     *             Redis since version 6.2.0.
      */
     @Deprecated
     Executions<V> brpoplpush(long timeout, K source, K destination);
@@ -169,8 +169,8 @@ public interface NodeSelectionListCommands<K, V> {
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
      * @since 6.1.3
-     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, double)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, double)} instead. This command is deprecated by
+     *             Redis since version 6.2.0.
      */
     @Deprecated
     Executions<V> brpoplpush(double timeout, K source, K destination);
@@ -398,8 +398,8 @@ public interface NodeSelectionListCommands<K, V> {
      * @param source the source key.
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped and pushed.
-     * @deprecated since 7.4.0, use {@link #lmove(Object, Object, LMoveArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #lmove(Object, Object, LMoveArgs)} instead. This command is deprecated by Redis since
+     *             version 6.2.0.
      */
     @Deprecated
     Executions<V> rpoplpush(K source, K destination);

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionListCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionListCommands.java
@@ -392,7 +392,10 @@ public interface NodeSelectionListCommands<K, V> {
      * @param source the source key.
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped and pushed.
+     * @deprecated since 7.4.0, use {@link #lmove(Object, Object, LMoveArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Executions<V> rpoplpush(K source, K destination);
 
     /**

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionListCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionListCommands.java
@@ -154,7 +154,10 @@ public interface NodeSelectionListCommands<K, V> {
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
+     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, long)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Executions<V> brpoplpush(long timeout, K source, K destination);
 
     /**
@@ -166,7 +169,10 @@ public interface NodeSelectionListCommands<K, V> {
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
      * @since 6.1.3
+     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, double)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Executions<V> brpoplpush(double timeout, K source, K destination);
 
     /**

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionListCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionListCommands.java
@@ -154,8 +154,8 @@ public interface NodeSelectionListCommands<K, V> {
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
-     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, long)} instead. This command is deprecated by
-     *             Redis since version 6.2.0.
+     * @deprecated since 7.7, use {@link #blmove(Object, Object, LMoveArgs, long)} instead. This command is deprecated by Redis
+     *             since version 6.2.0.
      */
     @Deprecated
     Executions<V> brpoplpush(long timeout, K source, K destination);
@@ -169,7 +169,7 @@ public interface NodeSelectionListCommands<K, V> {
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
      * @since 6.1.3
-     * @deprecated since 7.4.0, use {@link #blmove(Object, Object, LMoveArgs, double)} instead. This command is deprecated by
+     * @deprecated since 7.7, use {@link #blmove(Object, Object, LMoveArgs, double)} instead. This command is deprecated by
      *             Redis since version 6.2.0.
      */
     @Deprecated
@@ -398,7 +398,7 @@ public interface NodeSelectionListCommands<K, V> {
      * @param source the source key.
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped and pushed.
-     * @deprecated since 7.4.0, use {@link #lmove(Object, Object, LMoveArgs)} instead. This command is deprecated by Redis since
+     * @deprecated since 7.7, use {@link #lmove(Object, Object, LMoveArgs)} instead. This command is deprecated by Redis since
      *             version 6.2.0.
      */
     @Deprecated

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionStringCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionStringCommands.java
@@ -300,7 +300,10 @@ public interface NodeSelectionStringCommands<K, V> {
      * @param key the key.
      * @param value the value.
      * @return V bulk-string-reply the old value stored at {@code key}, or {@code null} when {@code key} did not exist.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
+     * This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Executions<V> getset(K key, V value);
 
     /**

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionStringCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionStringCommands.java
@@ -445,7 +445,10 @@ public interface NodeSelectionStringCommands<K, V> {
      * @param milliseconds the milliseconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
+     * This command is deprecated by Redis since version 2.6.12.
      */
+    @Deprecated
     Executions<String> psetex(K key, long milliseconds, V value);
 
     /**

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionStringCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionStringCommands.java
@@ -300,8 +300,8 @@ public interface NodeSelectionStringCommands<K, V> {
      * @param key the key.
      * @param value the value.
      * @return V bulk-string-reply the old value stored at {@code key}, or {@code null} when {@code key} did not exist.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
-     * This command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
+     *             version 6.2.0.
      */
     @Deprecated
     Executions<V> getset(K key, V value);
@@ -435,8 +435,8 @@ public interface NodeSelectionStringCommands<K, V> {
      * @param seconds the seconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
-     * This command is deprecated by Redis since version 2.6.12.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
+     *             version 2.6.12.
      */
     @Deprecated
     Executions<String> setex(K key, long seconds, V value);
@@ -448,8 +448,8 @@ public interface NodeSelectionStringCommands<K, V> {
      * @param milliseconds the milliseconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
-     * This command is deprecated by Redis since version 2.6.12.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
+     *             version 2.6.12.
      */
     @Deprecated
     Executions<String> psetex(K key, long milliseconds, V value);
@@ -462,8 +462,8 @@ public interface NodeSelectionStringCommands<K, V> {
      * @return Boolean integer-reply specifically:
      *
      *         {@code 1} if the key was set {@code 0} if the key was not set.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
-     * This command is deprecated by Redis since version 2.6.12.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
+     *             version 2.6.12.
      */
     @Deprecated
     Executions<Boolean> setnx(K key, V value);

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionStringCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionStringCommands.java
@@ -459,7 +459,10 @@ public interface NodeSelectionStringCommands<K, V> {
      * @return Boolean integer-reply specifically:
      *
      *         {@code 1} if the key was set {@code 0} if the key was not set.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
+     * This command is deprecated by Redis since version 2.6.12.
      */
+    @Deprecated
     Executions<Boolean> setnx(K key, V value);
 
     /**

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionStringCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionStringCommands.java
@@ -432,7 +432,10 @@ public interface NodeSelectionStringCommands<K, V> {
      * @param seconds the seconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
+     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead.
+     * This command is deprecated by Redis since version 2.6.12.
      */
+    @Deprecated
     Executions<String> setex(K key, long seconds, V value);
 
     /**

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionStringCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionStringCommands.java
@@ -300,7 +300,7 @@ public interface NodeSelectionStringCommands<K, V> {
      * @param key the key.
      * @param value the value.
      * @return V bulk-string-reply the old value stored at {@code key}, or {@code null} when {@code key} did not exist.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
+     * @deprecated since 7.7, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
      *             version 6.2.0.
      */
     @Deprecated
@@ -435,8 +435,7 @@ public interface NodeSelectionStringCommands<K, V> {
      * @param seconds the seconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
-     *             version 2.6.12.
+     * @deprecated since 7.7, use {@link #set(Object, Object, SetArgs)} instead.
      */
     @Deprecated
     Executions<String> setex(K key, long seconds, V value);
@@ -448,8 +447,7 @@ public interface NodeSelectionStringCommands<K, V> {
      * @param milliseconds the milliseconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
-     *             version 2.6.12.
+     * @deprecated since 7.7, use {@link #set(Object, Object, SetArgs)} instead.
      */
     @Deprecated
     Executions<String> psetex(K key, long milliseconds, V value);
@@ -462,8 +460,7 @@ public interface NodeSelectionStringCommands<K, V> {
      * @return Boolean integer-reply specifically:
      *
      *         {@code 1} if the key was set {@code 0} if the key was not set.
-     * @deprecated since 7.4.0, use {@link #set(Object, Object, SetArgs)} instead. This command is deprecated by Redis since
-     *             version 2.6.12.
+     * @deprecated since 7.7, use {@link #set(Object, Object, SetArgs)} instead.
      */
     @Deprecated
     Executions<Boolean> setnx(K key, V value);

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisGeoCoroutinesCommands.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisGeoCoroutinesCommands.kt
@@ -55,13 +55,7 @@ interface RedisGeoCoroutinesCommands<K : Any, V : Any> {
      * @return Long integer-reply the number of elements that were added to the set.
      * @since 6.1
      */
-    suspend fun geoadd(
-        key: K,
-        longitude: Double,
-        latitude: Double,
-        member: V,
-        args: GeoAddArgs
-    ): Long?
+    suspend fun geoadd(key: K, longitude: Double, latitude: Double, member: V, args: GeoAddArgs): Long?
 
     /**
      * Multi geo add.
@@ -138,87 +132,8 @@ interface RedisGeoCoroutinesCommands<K : Any, V : Any> {
     suspend fun geopos(key: K, vararg members: V): List<GeoCoordinates>
 
     /**
-     * Retrieve members selected by distance with the center of `longitude` and `latitude`.
-     *
-     * @param key the key of the geo set.
-     * @param longitude the longitude coordinate according to WGS84.
-     * @param latitude the latitude coordinate according to WGS84.
-     * @param distance radius distance.
-     * @param unit distance unit.
-     * @return bulk reply.
-     */
-    fun georadius(key: K, longitude: Double, latitude: Double, distance: Double, unit: GeoArgs.Unit): Flow<V>
-
-    /**
-     * Retrieve members selected by distance with the center of `longitude` and `latitude`.
-     *
-     * @param key the key of the geo set.
-     * @param longitude the longitude coordinate according to WGS84.
-     * @param latitude the latitude coordinate according to WGS84.
-     * @param distance radius distance.
-     * @param unit distance unit.
-     * @param geoArgs args to control the result.
-     * @return nested multi-bulk reply. The [GeoWithin] contains only fields which were requested by [GeoArgs].
-     */
-    fun georadius(key: K, longitude: Double, latitude: Double, distance: Double, unit: GeoArgs.Unit, geoArgs: GeoArgs): Flow<GeoWithin<V>>
-
-    /**
-     * Perform a [georadius(Any, Double, Double, Double, GeoArgs.Unit, GeoArgs)] query and store the results in a
-     * sorted set.
-     *
-     * @param key the key of the geo set.
-     * @param longitude the longitude coordinate according to WGS84.
-     * @param latitude the latitude coordinate according to WGS84.
-     * @param distance radius distance.
-     * @param unit distance unit.
-     * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
-     *        their locations a sorted set.
-     * @return Long integer-reply the number of elements in the result.
-     */
-    suspend fun georadius(key: K, longitude: Double, latitude: Double, distance: Double, unit: GeoArgs.Unit, geoRadiusStoreArgs: GeoRadiusStoreArgs<K>): Long?
-
-    /**
-     * Retrieve members selected by distance with the center of `member`. The member itself is always contained in the
-     * results.
-     *
-     * @param key the key of the geo set.
-     * @param member reference member.
-     * @param distance radius distance.
-     * @param unit distance unit.
-     * @return set of members.
-     */
-    fun georadiusbymember(key: K, member: V, distance: Double, unit: GeoArgs.Unit): Flow<V>
-
-    /**
-     * Retrieve members selected by distance with the center of `member`. The member itself is always contained in the
-     * results.
-     *
-     * @param key the key of the geo set.
-     * @param member reference member.
-     * @param distance radius distance.
-     * @param unit distance unit.
-     * @param geoArgs args to control the result.
-     * @return nested multi-bulk reply. The [GeoWithin] contains only fields which were requested by [GeoArgs].
-     */
-    fun georadiusbymember(key: K, member: V, distance: Double, unit: GeoArgs.Unit, geoArgs: GeoArgs): Flow<GeoWithin<V>>
-
-    /**
-     * Perform a [georadiusbymember(Any, Any, Double, GeoArgs.Unit, GeoArgs)] query and store the results in a
-     * sorted set.
-     *
-     * @param key the key of the geo set.
-     * @param member reference member.
-     * @param distance radius distance.
-     * @param unit distance unit.
-     * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
-     *        their locations a sorted set.
-     * @return Long integer-reply the number of elements in the result.
-     */
-    suspend fun georadiusbymember(key: K, member: V, distance: Double, unit: GeoArgs.Unit, geoRadiusStoreArgs: GeoRadiusStoreArgs<K>): Long?
-
-    /**
-     * Retrieve members selected by distance with the center of `reference` the search `predicate`.
-     * Use [GeoSearch] to create reference and predicate objects.
+     * Retrieve members selected by distance with the center of `reference` the search `predicate`. Use
+     * [GeoSearch] to create reference and predicate objects.
      *
      * @param key the key of the geo set.
      * @param reference the reference member or longitude/latitude coordinates.
@@ -229,8 +144,8 @@ interface RedisGeoCoroutinesCommands<K : Any, V : Any> {
     fun geosearch(key: K, reference: GeoSearch.GeoRef<K>, predicate: GeoSearch.GeoPredicate): Flow<V>
 
     /**
-     * Retrieve members selected by distance with the center of `reference` the search `predicate`.
-     * Use [GeoSearch] to create reference and predicate objects.
+     * Retrieve members selected by distance with the center of `reference` the search `predicate`. Use
+     * [GeoSearch] to create reference and predicate objects.
      *
      * @param key the key of the geo set.
      * @param reference the reference member or longitude/latitude coordinates.
@@ -250,7 +165,8 @@ interface RedisGeoCoroutinesCommands<K : Any, V : Any> {
      * @param reference the reference member or longitude/latitude coordinates.
      * @param predicate the bounding box or radius to search in.
      * @param geoArgs args to control the result.
-     * @param storeDist stores the items in a sorted set populated with their distance from the center of the circle or box, as a floating-point number, in the same unit specified for that shape.
+     * @param storeDist stores the items in a sorted set populated with their distance from the center of the circle or box, as
+     *        a floating-point number, in the same unit specified for that shape.
      * @return Long integer-reply the number of elements in the result.
      * @since 6.1
      */

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisGeoCoroutinesCommandsImpl.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisGeoCoroutinesCommandsImpl.kt
@@ -80,36 +80,9 @@ internal class RedisGeoCoroutinesCommandsImpl<K : Any, V : Any>(internal val ops
     override fun geohash(key: K, vararg members: V): Flow<Value<String>> =
         ops.geohash(key, *members).asFlow()
 
-    override fun georadius(
-        key: K,
-        longitude: Double,
-        latitude: Double,
-        distance: Double,
-        unit: GeoArgs.Unit
-    ): Flow<V> = ops.georadius(key, longitude, latitude, distance, unit).asFlow()
-
-    override fun georadius(
-        key: K,
-        longitude: Double,
-        latitude: Double,
-        distance: Double,
-        unit: GeoArgs.Unit,
-        geoArgs: GeoArgs
-    ): Flow<GeoWithin<V>> =
-        ops.georadius(key, longitude, latitude, distance, unit, geoArgs).asFlow()
-
-    override suspend fun georadius(key: K, longitude: Double, latitude: Double, distance: Double, unit: GeoArgs.Unit, geoRadiusStoreArgs: GeoRadiusStoreArgs<K>): Long? = ops.georadius(key, longitude, latitude, distance, unit, geoRadiusStoreArgs).awaitFirstOrNull()
-
-    override fun georadiusbymember(key: K, member: V, distance: Double, unit: GeoArgs.Unit): Flow<V> = ops.georadiusbymember(key, member, distance, unit).asFlow()
-
-    override fun georadiusbymember(key: K, member: V, distance: Double, unit: GeoArgs.Unit, geoArgs: GeoArgs): Flow<GeoWithin<V>> = ops.georadiusbymember(key, member, distance, unit, geoArgs).asFlow()
-
-    override suspend fun georadiusbymember(key: K, member: V, distance: Double, unit: GeoArgs.Unit, geoRadiusStoreArgs: GeoRadiusStoreArgs<K>): Long? = ops.georadiusbymember(key, member, distance, unit, geoRadiusStoreArgs).awaitFirstOrNull()
-
     override fun geosearch(key: K, reference: GeoSearch.GeoRef<K>, predicate: GeoSearch.GeoPredicate): Flow<V> = ops.geosearch(key, reference, predicate).asFlow()
 
     override fun geosearch(key: K, reference: GeoSearch.GeoRef<K>, predicate: GeoSearch.GeoPredicate, geoArgs: GeoArgs): Flow<GeoWithin<V>>  = ops.geosearch(key, reference, predicate, geoArgs).asFlow()
 
     override suspend fun geosearchstore(destination: K, key: K, reference: GeoSearch.GeoRef<K>, predicate: GeoSearch.GeoPredicate, geoArgs: GeoArgs, storeDist: Boolean): Long? = ops.geosearchstore(destination, key, reference, predicate, geoArgs, storeDist).awaitFirstOrNull()
 }
-

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisHashCoroutinesCommands.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisHashCoroutinesCommands.kt
@@ -139,6 +139,10 @@ interface RedisHashCoroutinesCommands<K : Any, V : Any> {
      * @param map the hash to apply.
      * @return String simple-string-reply.
      */
+    @Deprecated(
+        message = "@deprecated since 7.4.0. Use hset(key, map) instead. HMSET is deprecated by Redis since version 4.0.0.",
+        replaceWith = ReplaceWith("hset(key, map)")
+    )
     suspend fun hmset(key: K, map: Map<K, V>): String?
 
     /**

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisHashCoroutinesCommands.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisHashCoroutinesCommands.kt
@@ -133,19 +133,6 @@ interface RedisHashCoroutinesCommands<K : Any, V : Any> {
     fun hmget(key: K, vararg fields: K): Flow<KeyValue<K, V>>
 
     /**
-     * Set multiple hash fields to multiple values.
-     *
-     * @param key the key.
-     * @param map the hash to apply.
-     * @return String simple-string-reply.
-     */
-    @Deprecated(
-        message = "@deprecated since 7.4.0. Use hset(key, map) instead. HMSET is deprecated by Redis since version 4.0.0.",
-        replaceWith = ReplaceWith("hset(key, map)")
-    )
-    suspend fun hmset(key: K, map: Map<K, V>): String?
-
-    /**
      * Return a random field from the hash stored at `key`.
      *
      * @param key the key.

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisHashCoroutinesCommandsImpl.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisHashCoroutinesCommandsImpl.kt
@@ -80,9 +80,6 @@ internal class RedisHashCoroutinesCommandsImpl<K : Any, V : Any>(internal val op
     override suspend fun hrandfieldWithvalues(key: K, count: Long): List<KeyValue<K, V>> =
         ops.hrandfieldWithvalues(key, count).asFlow().toList()
 
-    override suspend fun hmset(key: K, map: Map<K, V>): String? =
-        ops.hmset(key, map).awaitFirstOrNull()
-
     override suspend fun hscan(key: K): MapScanCursor<K, V>? =
         ops.hscan(key).awaitFirstOrNull()
 

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisJsonCoroutinesCommands.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisJsonCoroutinesCommands.kt
@@ -8,11 +8,12 @@
 package io.lettuce.core.api.coroutines
 
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
-import io.lettuce.core.json.JsonPath
+import kotlinx.coroutines.flow.Flow
 import io.lettuce.core.json.JsonType
 import io.lettuce.core.json.JsonValue
 import io.lettuce.core.json.arguments.JsonGetArgs
 import io.lettuce.core.json.arguments.JsonMsetArgs
+import io.lettuce.core.json.JsonPath
 import io.lettuce.core.json.arguments.JsonRangeArgs
 import io.lettuce.core.json.arguments.JsonSetArgs
 
@@ -225,9 +226,11 @@ interface RedisJsonCoroutinesCommands<K : Any, V : Any> {
     suspend fun jsonArrpop(key: K): List<JsonValue>
 
     /**
-     * Remove and return the JSON value at index -1 (last element) in the array at the {@link JsonPath#ROOT_PATH} as raw JSON strings.
+     * Remove and return the JSON value at index -1 (last element) in the array at the {@link JsonPath#ROOT_PATH} as raw JSON
+     * strings.
      * <p>
-     * Behaves like [jsonArrpop(Any)] but returns {@code List<String>} with raw JSON instead of [JsonValue] wrappers.
+     * Behaves like [jsonArrpop(Any)] but returns {@code List<String>} with raw JSON instead of [JsonValue]
+     * wrappers.
      *
      * @param key the key holding the JSON document.
      * @return List<String> the removed element, or null if the specified path is not an array.

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisJsonCoroutinesCommands.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisJsonCoroutinesCommands.kt
@@ -8,12 +8,11 @@
 package io.lettuce.core.api.coroutines
 
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
-import kotlinx.coroutines.flow.Flow
+import io.lettuce.core.json.JsonPath
 import io.lettuce.core.json.JsonType
 import io.lettuce.core.json.JsonValue
 import io.lettuce.core.json.arguments.JsonGetArgs
 import io.lettuce.core.json.arguments.JsonMsetArgs
-import io.lettuce.core.json.JsonPath
 import io.lettuce.core.json.arguments.JsonRangeArgs
 import io.lettuce.core.json.arguments.JsonSetArgs
 
@@ -226,11 +225,9 @@ interface RedisJsonCoroutinesCommands<K : Any, V : Any> {
     suspend fun jsonArrpop(key: K): List<JsonValue>
 
     /**
-     * Remove and return the JSON value at index -1 (last element) in the array at the {@link JsonPath#ROOT_PATH} as raw JSON
-     * strings.
+     * Remove and return the JSON value at index -1 (last element) in the array at the {@link JsonPath#ROOT_PATH} as raw JSON strings.
      * <p>
-     * Behaves like [jsonArrpop(Any)] but returns {@code List<String>} with raw JSON instead of [JsonValue]
-     * wrappers.
+     * Behaves like [jsonArrpop(Any)] but returns {@code List<String>} with raw JSON instead of [JsonValue] wrappers.
      *
      * @param key the key holding the JSON document.
      * @return List<String> the removed element, or null if the specified path is not an array.

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisKeyCoroutinesCommands.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisKeyCoroutinesCommands.kt
@@ -255,16 +255,6 @@ interface RedisKeyCoroutinesCommands<K : Any, V : Any> {
     fun keys(pattern: String): Flow<K>
 
     /**
-     * Find all keys matching the given pattern (legacy overload).
-     *
-     * @param pattern the pattern type: patternkey (pattern).
-     * @return List&lt;K&gt; array-reply list of keys matching {@code pattern}.
-     * @deprecated Use {@link #keys(String)} instead. This legacy overload will be removed in a later version.
-     */
-    @Deprecated("Use keys(String) instead. This legacy overload will be removed in a later version.")
-    fun keysLegacy(pattern: K): Flow<K>
-
-    /**
      * Atomically transfer a key from a Redis instance to another one.
      *
      * @param host the host.

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisKeyCoroutinesCommandsImpl.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisKeyCoroutinesCommandsImpl.kt
@@ -116,8 +116,6 @@ internal class RedisKeyCoroutinesCommandsImpl<K : Any, V : Any>(internal val ops
 
     override fun keys(pattern: String): Flow<K> = ops.keys(pattern).asFlow()
 
-    override fun keysLegacy(pattern: K): Flow<K> = ops.keysLegacy(pattern).asFlow()
-
     override suspend fun migrate(
         host: String,
         port: Int,

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisListCoroutinesCommands.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisListCoroutinesCommands.kt
@@ -151,29 +151,6 @@ interface RedisListCoroutinesCommands<K : Any, V : Any> {
     suspend fun brpop(timeout: Double, vararg keys: K): KeyValue<K, V>?
 
     /**
-     * Pop a value from a list, push it to another list and return it; or block until one is available.
-     *
-     * @param timeout the timeout in seconds.
-     * @param source the source key.
-     * @param destination the destination type: key.
-     * @return V bulk-string-reply the element being popped from `source` and pushed to `destination`. If
-     *         `timeout` is reached, a.
-     */
-    suspend fun brpoplpush(timeout: Long, source: K, destination: K): V?
-
-    /**
-     * Pop a value from a list, push it to another list and return it; or block until one is available.
-     *
-     * @param timeout the timeout in seconds.
-     * @param source the source key.
-     * @param destination the destination type: key.
-     * @return V bulk-string-reply the element being popped from `source` and pushed to `destination`. If
-     *         `timeout` is reached, a.
-     * @since 6.1.3
-     */
-    suspend fun brpoplpush(timeout: Double, source: K, destination: K): V?
-
-    /**
      * Get an element from a list by its index.
      *
      * @param key the key.
@@ -376,15 +353,6 @@ interface RedisListCoroutinesCommands<K : Any, V : Any> {
      * @since 6.1
      */
     suspend fun rpop(key: K, count: Long): List<V>
-
-    /**
-     * Remove the last element in a list, append it to another list and return it.
-     *
-     * @param source the source key.
-     * @param destination the destination type: key.
-     * @return V bulk-string-reply the element being popped and pushed.
-     */
-    suspend fun rpoplpush(source: K, destination: K): V?
 
     /**
      * Append one or multiple values to a list.

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisListCoroutinesCommandsImpl.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisListCoroutinesCommandsImpl.kt
@@ -81,12 +81,6 @@ internal class RedisListCoroutinesCommandsImpl<K : Any, V : Any>(internal val op
     override suspend fun brpop(timeout: Double, vararg keys: K): KeyValue<K, V>? =
         ops.brpop(timeout, *keys).awaitFirstOrNull()
 
-    override suspend fun brpoplpush(timeout: Long, source: K, destination: K): V? =
-        ops.brpoplpush(timeout, source, destination).awaitFirstOrNull()
-
-    override suspend fun brpoplpush(timeout: Double, source: K, destination: K): V? =
-        ops.brpoplpush(timeout, source, destination).awaitFirstOrNull()
-
     override suspend fun lindex(key: K, index: Long): V? =
         ops.lindex(key, index).awaitFirstOrNull()
 
@@ -140,9 +134,6 @@ internal class RedisListCoroutinesCommandsImpl<K : Any, V : Any>(internal val op
 
     override suspend fun rpop(key: K, count: Long): List<V> =
         ops.rpop(key, count).asFlow().toList()
-
-    override suspend fun rpoplpush(source: K, destination: K): V? =
-        ops.rpoplpush(source, destination).awaitFirstOrNull()
 
     override suspend fun rpush(key: K, vararg values: V): Long? =
         ops.rpush(key, *values).awaitFirstOrNull()

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisStringCoroutinesCommands.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisStringCoroutinesCommands.kt
@@ -240,15 +240,6 @@ interface RedisStringCoroutinesCommands<K : Any, V : Any> {
     suspend fun getrange(key: K, start: Long, end: Long): V?
 
     /**
-     * Set the string value of a key and return its old value.
-     *
-     * @param key the key.
-     * @param value the value.
-     * @return V bulk-string-reply the old value stored at `key`, or `null` when `key` did not exist.
-     */
-    suspend fun getset(key: K, value: V): V?
-
-    /**
      * Increment the integer value of a key by one.
      *
      * @param key the key.
@@ -360,37 +351,6 @@ interface RedisStringCoroutinesCommands<K : Any, V : Any> {
      * @return Long integer-reply the original bit value stored at <em>offset</em>.
      */
     suspend fun setbit(key: K, offset: Long, value: Int): Long?
-
-    /**
-     * Set the value and expiration of a key.
-     *
-     * @param key the key.
-     * @param seconds the seconds type: long.
-     * @param value the value.
-     * @return String simple-string-reply.
-     */
-    suspend fun setex(key: K, seconds: Long, value: V): String?
-
-    /**
-     * Set the value and expiration in milliseconds of a key.
-     *
-     * @param key the key.
-     * @param milliseconds the milliseconds type: long.
-     * @param value the value.
-     * @return String simple-string-reply.
-     */
-    suspend fun psetex(key: K, milliseconds: Long, value: V): String?
-
-    /**
-     * Set the value of a key, only if the key does not exist.
-     *
-     * @param key the key.
-     * @param value the value.
-     * @return Boolean integer-reply specifically:
-     *
-     *         `1` if the key was set `0` if the key was not set.
-     */
-    suspend fun setnx(key: K, value: V): Boolean?
 
     /**
      * Overwrite part of a string at key starting at the specified offset.

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisStringCoroutinesCommandsImpl.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisStringCoroutinesCommandsImpl.kt
@@ -81,9 +81,6 @@ internal class RedisStringCoroutinesCommandsImpl<K : Any, V : Any>(internal val 
     override suspend fun getrange(key: K, start: Long, end: Long): V? =
         ops.getrange(key, start, end).awaitFirstOrNull()
 
-    override suspend fun getset(key: K, value: V): V? =
-        ops.getset(key, value).awaitFirstOrNull()
-
     override suspend fun incr(key: K): Long? = ops.incr(key).awaitFirstOrNull()
 
     override suspend fun incrby(key: K, amount: Long): Long? =
@@ -109,12 +106,6 @@ internal class RedisStringCoroutinesCommandsImpl<K : Any, V : Any>(internal val 
     override suspend fun setGet(key: K, value: V, setArgs: SetArgs): V? = ops.setGet(key, value, setArgs).awaitFirstOrNull()
 
     override suspend fun setbit(key: K, offset: Long, value: Int): Long? = ops.setbit(key, offset, value).awaitFirstOrNull()
-
-    override suspend fun setex(key: K, seconds: Long, value: V): String? = ops.setex(key, seconds, value).awaitFirstOrNull()
-
-    override suspend fun psetex(key: K, milliseconds: Long, value: V): String? = ops.psetex(key, milliseconds, value).awaitFirstOrNull()
-
-    override suspend fun setnx(key: K, value: V): Boolean? = ops.setnx(key, value).awaitFirstOrNull()
 
     override suspend fun setrange(key: K, offset: Long, value: V): Long? = ops.setrange(key, offset, value).awaitFirstOrNull()
 

--- a/src/main/templates/io/lettuce/core/api/RedisGeoCommands.java
+++ b/src/main/templates/io/lettuce/core/api/RedisGeoCommands.java
@@ -153,8 +153,9 @@ public interface RedisGeoCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
-     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
-     *             command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.7, use
+     *             {@link #geosearchstore(Object, Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs, boolean)} instead.
+     *             This command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     Long georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit,
@@ -202,8 +203,9 @@ public interface RedisGeoCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
-     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
-     *             command is deprecated by Redis since version 6.2.0.
+     * @deprecated since 7.7, use
+     *             {@link #geosearchstore(Object, Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs, boolean)} instead.
+     *             This command is deprecated by Redis since version 6.2.0.
      */
     @Deprecated
     Long georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit, GeoRadiusStoreArgs<K> geoRadiusStoreArgs);

--- a/src/main/templates/io/lettuce/core/api/RedisGeoCommands.java
+++ b/src/main/templates/io/lettuce/core/api/RedisGeoCommands.java
@@ -119,7 +119,10 @@ public interface RedisGeoCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return bulk reply.
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Set<V> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit);
 
     /**
@@ -132,7 +135,10 @@ public interface RedisGeoCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     List<GeoWithin<V>> georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit, GeoArgs geoArgs);
 
     /**
@@ -147,7 +153,10 @@ public interface RedisGeoCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Long georadius(K key, double longitude, double latitude, double distance, GeoArgs.Unit unit,
             GeoRadiusStoreArgs<K> geoRadiusStoreArgs);
 
@@ -160,7 +169,10 @@ public interface RedisGeoCommands<K, V> {
      * @param distance radius distance.
      * @param unit distance unit.
      * @return set of members.
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Set<V> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit);
 
     /**
@@ -173,7 +185,10 @@ public interface RedisGeoCommands<K, V> {
      * @param unit distance unit.
      * @param geoArgs args to control the result.
      * @return nested multi-bulk reply. The {@link GeoWithin} contains only fields which were requested by {@link GeoArgs}.
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     List<GeoWithin<V>> georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit, GeoArgs geoArgs);
 
     /**
@@ -187,7 +202,10 @@ public interface RedisGeoCommands<K, V> {
      * @param geoRadiusStoreArgs args to store either the resulting elements with their distance or the resulting elements with
      *        their locations a sorted set.
      * @return Long integer-reply the number of elements in the result.
+     * @deprecated since 7.7, use {@link #geosearch(Object, GeoSearch.GeoRef, GeoSearch.GeoPredicate, GeoArgs)} instead. This
+     *             command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     Long georadiusbymember(K key, V member, double distance, GeoArgs.Unit unit, GeoRadiusStoreArgs<K> geoRadiusStoreArgs);
 
     /**

--- a/src/main/templates/io/lettuce/core/api/RedisHashCommands.java
+++ b/src/main/templates/io/lettuce/core/api/RedisHashCommands.java
@@ -171,6 +171,7 @@ public interface RedisHashCommands<K, V> {
      * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead. This command is deprecated by Redis
      *             since version 4.0.0.
      */
+    @Deprecated
     String hmset(K key, Map<K, V> map);
 
     /**

--- a/src/main/templates/io/lettuce/core/api/RedisHashCommands.java
+++ b/src/main/templates/io/lettuce/core/api/RedisHashCommands.java
@@ -168,6 +168,8 @@ public interface RedisHashCommands<K, V> {
      * @param key the key.
      * @param map the hash to apply.
      * @return String simple-string-reply.
+     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead.
+     * This command is deprecated by Redis since version 4.0.0.
      */
     String hmset(K key, Map<K, V> map);
 

--- a/src/main/templates/io/lettuce/core/api/RedisHashCommands.java
+++ b/src/main/templates/io/lettuce/core/api/RedisHashCommands.java
@@ -168,8 +168,8 @@ public interface RedisHashCommands<K, V> {
      * @param key the key.
      * @param map the hash to apply.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead.
-     * This command is deprecated by Redis since version 4.0.0.
+     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead. This command is deprecated by Redis
+     *             since version 4.0.0.
      */
     String hmset(K key, Map<K, V> map);
 

--- a/src/main/templates/io/lettuce/core/api/RedisHashCommands.java
+++ b/src/main/templates/io/lettuce/core/api/RedisHashCommands.java
@@ -168,7 +168,7 @@ public interface RedisHashCommands<K, V> {
      * @param key the key.
      * @param map the hash to apply.
      * @return String simple-string-reply.
-     * @deprecated since 7.4.0, use {@link #hset(java.lang.Object, java.util.Map)} instead. This command is deprecated by Redis
+     * @deprecated since 7.7, use {@link #hset(java.lang.Object, java.util.Map)} instead. This command is deprecated by Redis
      *             since version 4.0.0.
      */
     @Deprecated

--- a/src/main/templates/io/lettuce/core/api/RedisListCommands.java
+++ b/src/main/templates/io/lettuce/core/api/RedisListCommands.java
@@ -153,7 +153,10 @@ public interface RedisListCommands<K, V> {
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
+     * @deprecated since 7.7, use {@link #blmove(Object, Object, LMoveArgs, long)} instead. This command is deprecated by Redis
+     *             since version 6.2.0.
      */
+    @Deprecated
     V brpoplpush(long timeout, K source, K destination);
 
     /**
@@ -165,7 +168,10 @@ public interface RedisListCommands<K, V> {
      * @return V bulk-string-reply the element being popped from {@code source} and pushed to {@code destination}. If
      *         {@code timeout} is reached, a.
      * @since 6.1.3
+     * @deprecated since 7.7, use {@link #blmove(Object, Object, LMoveArgs, double)} instead. This command is deprecated by
+     *             Redis since version 6.2.0.
      */
+    @Deprecated
     V brpoplpush(double timeout, K source, K destination);
 
     /**
@@ -391,7 +397,10 @@ public interface RedisListCommands<K, V> {
      * @param source the source key.
      * @param destination the destination type: key.
      * @return V bulk-string-reply the element being popped and pushed.
+     * @deprecated since 7.7, use {@link #lmove(Object, Object, LMoveArgs)} instead. This command is deprecated by Redis since
+     *             version 6.2.0.
      */
+    @Deprecated
     V rpoplpush(K source, K destination);
 
     /**

--- a/src/main/templates/io/lettuce/core/api/RedisStringCommands.java
+++ b/src/main/templates/io/lettuce/core/api/RedisStringCommands.java
@@ -292,7 +292,9 @@ public interface RedisStringCommands<K, V> {
      * @param key the key.
      * @param value the value.
      * @return V bulk-string-reply the old value stored at {@code key}, or {@code null} when {@code key} did not exist.
+     * @deprecated since 7.7, use {@link #set(K, V, SetArgs)} instead. This command is deprecated by Redis since version 6.2.0.
      */
+    @Deprecated
     V getset(K key, V value);
 
     /**
@@ -424,7 +426,9 @@ public interface RedisStringCommands<K, V> {
      * @param seconds the seconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
+     * @deprecated since 7.7, use {@link #set(K, V, SetArgs)} instead.
      */
+    @Deprecated
     String setex(K key, long seconds, V value);
 
     /**
@@ -434,7 +438,9 @@ public interface RedisStringCommands<K, V> {
      * @param milliseconds the milliseconds type: long.
      * @param value the value.
      * @return String simple-string-reply.
+     * @deprecated since 7.7, use {@link #set(K, V, SetArgs)} instead.
      */
+    @Deprecated
     String psetex(K key, long milliseconds, V value);
 
     /**
@@ -445,7 +451,9 @@ public interface RedisStringCommands<K, V> {
      * @return Boolean integer-reply specifically:
      *
      *         {@code 1} if the key was set {@code 0} if the key was not set.
+     * @deprecated since 7.7, use {@link #set(K, V, SetArgs)} instead.
      */
+    @Deprecated
     Boolean setnx(K key, V value);
 
     /**


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->
Issue #3615 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide public API surface change: Java callers get compile-time warnings but unchanged behavior, while Kotlin coroutine code may fail to compile until migrated to replacement APIs.
> 
> **Overview**
> Marks **Redis-deprecated** command APIs as `@Deprecated` in Lettuce **7.7** across sync, async, reactive, cluster node-selection, command templates, and the abstract async/reactive implementations. Javadoc now cites **since 7.7** and points to replacements: **`geosearch` / `geosearchstore`** instead of **`georadius*`**, **`lmove` / `blmove`** instead of **`rpoplpush` / `brpoplpush`**, **`set` with `SetArgs`** instead of **`getset` / `setex` / `psetex` / `setnx`**, and **`hset(Map)`** instead of **`hmset`**.
> 
> The **Kotlin coroutines** layer goes further: it **drops** those deprecated methods (including **`georadius*`**, list move helpers, legacy string setters, **`hmset`**, and **`keysLegacy`**) so coroutine users must use the newer APIs only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa2e781c9b88732a6f726e1521f45a6f79ba8130. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->