### PR TITLE
Add missing Search languages

### DIFF
--- a/src/main/java/io/lettuce/core/search/arguments/DocumentLanguage.java
+++ b/src/main/java/io/lettuce/core/search/arguments/DocumentLanguage.java
@@ -27,6 +27,21 @@ public enum DocumentLanguage {
      */
     ARMENIAN("armenian", new Locale("hy")),
     /**
+     * Basque
+     */
+    BASQUE("basque", new Locale("eu")),
+    /**
+     * Catalan
+     */
+    CATALAN("catalan", new Locale("ca")),
+    /**
+     * Chinese
+     *
+     * @see <a href="https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/chinese/">Chinese
+     *      support</a>
+     */
+    CHINESE("chinese", Locale.CHINESE),
+    /**
      * Danish
      */
     DANISH("danish", new Locale("da")),
@@ -51,13 +66,37 @@ public enum DocumentLanguage {
      */
     GERMAN("german", Locale.GERMAN),
     /**
+     * Greek
+     */
+    GREEK("greek", new Locale("el")),
+    /**
+     * Hindi
+     */
+    HINDI("hindi", new Locale("hi")),
+    /**
      * Hungarian
      */
     HUNGARIAN("hungarian", new Locale("hu")),
     /**
+     * Indonesian
+     */
+    INDONESIAN("indonesian", new Locale("id")),
+    /**
+     * Irish
+     */
+    IRISH("irish", new Locale("ga")),
+    /**
      * Italian
      */
     ITALIAN("italian", Locale.ITALIAN),
+    /**
+     * Lithuanian
+     */
+    LITHUANIAN("lithuanian", new Locale("lt")),
+    /**
+     * Nepali
+     */
+    NEPALI("nepali", new Locale("ne")),
     /**
      * Norwegian
      */
@@ -97,14 +136,7 @@ public enum DocumentLanguage {
     /**
      * Yiddish
      */
-    YIDDISH("yiddish", new Locale("yi")),
-    /**
-     * Chinese
-     * 
-     * @see <a href="https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/chinese/">Chinese
-     *      support</a>
-     */
-    CHINESE("chinese", Locale.CHINESE);
+    YIDDISH("yiddish", new Locale("yi"));
 
     private final String language;
 


### PR DESCRIPTION
Add missing DocumentLanguage enum values to match Redis Search supported languages:

- Basque
- Catalan
- Greek
- Hindi
- Indonesian
- Irish
- Lithuanian
- Nepali

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds additional `DocumentLanguage` enum constants used for RediSearch indexing without changing any parsing or command-building logic.
> 
> **Overview**
> Extends `DocumentLanguage` with additional Redis Search-supported languages (Basque, Catalan, Greek, Hindi, Indonesian, Irish, Lithuanian, Nepali) and moves `CHINESE` earlier in the enum while preserving its doc link.
> 
> This expands the set of values accepted by `CreateArgs.Builder#defaultLanguage(...)`/`languageField(...)` without altering existing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 955c2196fa47f39ac1196d1d3dbe2d62783ad5f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->