### PR TITLE
ERR unknown subcommand 'MYID' with Azure Managed Redis #3495 (#3693)

### DIFF
--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -22,7 +22,10 @@ package io.lettuce.core;
 import io.lettuce.core.GeoArgs.Unit;
 import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.api.async.*;
+import io.lettuce.core.cluster.PipelinedRedisFuture;
 import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
+import io.lettuce.core.cluster.models.partitions.ClusterPartitionParser;
+import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
 import io.lettuce.core.codec.Base16;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.internal.LettuceAssert;
@@ -76,6 +79,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static io.lettuce.core.ClientOptions.DEFAULT_JSON_PARSER;
@@ -549,9 +555,46 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
         return dispatch(commandBuilder.clusterMeet(ip, port));
     }
 
+    /**
+     * Obtain the nodeId for the currently connected node.
+     * <p>
+     * This implementation first attempts to use the {@code CLUSTER MYID} command. If that command is not supported, it falls
+     * back to parsing the {@code CLUSTER NODES} output to find the node marked with the {@code MYSELF} flag.
+     *
+     * @return String simple-string-reply
+     */
     @Override
     public RedisFuture<String> clusterMyId() {
-        return dispatch(commandBuilder.clusterMyId());
+        CompletableFuture<String> result = dispatch(commandBuilder.clusterMyId()).toCompletableFuture().handle((nodeId, ex) -> {
+            if (ex != null) {
+                // Only fall back for command execution errors (e.g., NOPERM, ERR unknown subcommand)
+                Throwable cause = ex instanceof CompletionException ? ex.getCause() : ex;
+                if (cause instanceof RedisCommandExecutionException) {
+                    return clusterMyIdFromClusterNodes();
+                }
+                CompletableFuture<String> failed = new CompletableFuture<>();
+                failed.completeExceptionally(cause);
+                return failed;
+            }
+            if (nodeId == null || nodeId.isEmpty()) {
+                return clusterMyIdFromClusterNodes();
+            }
+            return CompletableFuture.completedFuture(nodeId);
+        }).thenCompose(Function.identity());
+
+        return new PipelinedRedisFuture<>(result);
+    }
+
+    /**
+     * Extract the current node's ID by parsing {@code CLUSTER NODES} output.
+     *
+     * @return CompletableFuture containing the node ID if found, or failed future if no node has the MYSELF flag
+     */
+    private CompletableFuture<String> clusterMyIdFromClusterNodes() throws RedisException {
+        return clusterNodes().toCompletableFuture()
+                .thenApply(nodes -> ClusterPartitionParser.parse(nodes).stream()
+                        .filter(node -> node.is(RedisClusterNode.NodeFlag.MYSELF)).findFirst().map(RedisClusterNode::getNodeId)
+                        .orElseThrow(() -> new RedisException("Failed to determine cluster node id")));
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -23,6 +23,8 @@ import io.lettuce.core.GeoArgs.Unit;
 import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.api.reactive.*;
 import io.lettuce.core.cluster.api.reactive.RedisClusterReactiveCommands;
+import io.lettuce.core.cluster.models.partitions.ClusterPartitionParser;
+import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
 import io.lettuce.core.codec.Base16;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.internal.LettuceAssert;
@@ -572,9 +574,31 @@ public abstract class AbstractRedisReactiveCommands<K, V>
         return createMono(() -> commandBuilder.clusterMeet(ip, port));
     }
 
+    /**
+     * Obtain the nodeId for the currently connected node.
+     * <p>
+     * This implementation first attempts to use the {@code CLUSTER MYID} command. If that command is not supported, it falls
+     * back to parsing the {@code CLUSTER NODES} output to find the node marked with the {@code MYSELF} flag.
+     *
+     * @return Mono&lt;String&gt; simple-string-reply
+     */
     @Override
     public Mono<String> clusterMyId() {
-        return createMono(commandBuilder::clusterMyId);
+        return createMono(commandBuilder::clusterMyId)
+                .onErrorResume(RedisCommandExecutionException.class, ex -> clusterMyIdFromClusterNodes())
+                .filter(nodeId -> nodeId != null && !nodeId.isEmpty())
+                .switchIfEmpty(Mono.defer(this::clusterMyIdFromClusterNodes));
+    }
+
+    /**
+     * Extract the current node's ID by parsing {@code CLUSTER NODES} output.
+     *
+     * @return Mono containing the node ID if found, or error if no node has the MYSELF flag
+     */
+    private Mono<String> clusterMyIdFromClusterNodes() throws RedisException {
+        return clusterNodes().map(nodes -> ClusterPartitionParser.parse(nodes).stream()
+                .filter(node -> node.is(RedisClusterNode.NodeFlag.MYSELF)).findFirst().map(RedisClusterNode::getNodeId)
+                .orElseThrow(() -> new RedisException("Failed to determine cluster node id")));
     }
 
     @Override

--- a/src/test/java/io/lettuce/core/AbstractRedisAsyncCommandsTest.java
+++ b/src/test/java/io/lettuce/core/AbstractRedisAsyncCommandsTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2025, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ */
+package io.lettuce.core;
+
+import io.lettuce.core.cluster.RedisAdvancedClusterAsyncCommandsImpl;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.output.StatusOutput;
+import io.lettuce.core.protocol.AsyncCommand;
+import io.lettuce.core.protocol.Command;
+import io.lettuce.core.protocol.CommandType;
+import io.lettuce.core.protocol.RedisCommand;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link AbstractRedisAsyncCommands}.
+ *
+ * @author Aleksandar Todorov
+ */
+class AbstractRedisAsyncCommandsTest {
+
+    @Mock
+    private StatefulRedisClusterConnection<String, String> connection;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void clusterMyId_returnsNodeId_whenCommandSucceeds() {
+        AsyncCommand<String, String, String> myIdCmd = completedAsyncCommand("my-node-id");
+        doReturn(myIdCmd).when(connection).dispatch(any(RedisCommand.class));
+
+        RedisAdvancedClusterAsyncCommandsImpl<String, String> commands = new RedisAdvancedClusterAsyncCommandsImpl<>(connection,
+                StringCodec.UTF8);
+
+        String result = commands.clusterMyId().toCompletableFuture().join();
+        assertThat(result).isEqualTo("my-node-id");
+    }
+
+    @Test
+    void clusterMyId_fallsBackToClusterNodes_onCommandExecutionException() {
+        String clusterNodesOutput = "fallback-node 127.0.0.1:6379@16379 myself,master - 0 0 1 connected 0-16383\n"
+                + "other-node 127.0.0.1:6380@16380 slave fallback-node 0 0 0 connected";
+
+        AsyncCommand<String, String, String> failedMyId = failedAsyncCommand(
+                new RedisCommandExecutionException("ERR unknown subcommand 'MYID'"));
+        AsyncCommand<String, String, String> nodesCmd = completedAsyncCommand(clusterNodesOutput);
+
+        doReturn(failedMyId).doReturn(nodesCmd).when(connection).dispatch(any(RedisCommand.class));
+
+        RedisAdvancedClusterAsyncCommandsImpl<String, String> commands = new RedisAdvancedClusterAsyncCommandsImpl<>(connection,
+                StringCodec.UTF8);
+
+        String result = commands.clusterMyId().toCompletableFuture().join();
+        assertThat(result).isEqualTo("fallback-node");
+    }
+
+    @Test
+    void clusterMyId_fallsBackToClusterNodes_onEmptyResult() {
+        String clusterNodesOutput = "fallback-node 127.0.0.1:6379@16379 myself,master - 0 0 1 connected 0-16383\n";
+
+        AsyncCommand<String, String, String> emptyMyId = completedAsyncCommand("");
+        AsyncCommand<String, String, String> nodesCmd = completedAsyncCommand(clusterNodesOutput);
+
+        doReturn(emptyMyId).doReturn(nodesCmd).when(connection).dispatch(any(RedisCommand.class));
+
+        RedisAdvancedClusterAsyncCommandsImpl<String, String> commands = new RedisAdvancedClusterAsyncCommandsImpl<>(connection,
+                StringCodec.UTF8);
+
+        String result = commands.clusterMyId().toCompletableFuture().join();
+        assertThat(result).isEqualTo("fallback-node");
+    }
+
+    @Test
+    void clusterMyId_propagatesNonExecutionException() {
+        AsyncCommand<String, String, String> timedOut = failedAsyncCommand(
+                new RedisCommandTimeoutException("Command timed out"));
+
+        doReturn(timedOut).when(connection).dispatch(any(RedisCommand.class));
+
+        RedisAdvancedClusterAsyncCommandsImpl<String, String> commands = new RedisAdvancedClusterAsyncCommandsImpl<>(connection,
+                StringCodec.UTF8);
+
+        CompletableFuture<String> result = commands.clusterMyId().toCompletableFuture();
+        assertThatThrownBy(result::join).hasCauseInstanceOf(RedisCommandTimeoutException.class);
+    }
+
+    @Test
+    void clusterMyId_throwsWhenNoMyselfNodeInFallback() {
+        String clusterNodesOutput = "node-123 127.0.0.1:6379@16379 master - 0 0 1 connected 0-16383\n";
+
+        AsyncCommand<String, String, String> failedMyId = failedAsyncCommand(new RedisCommandExecutionException("NOPERM"));
+        AsyncCommand<String, String, String> nodesCmd = completedAsyncCommand(clusterNodesOutput);
+
+        doReturn(failedMyId).doReturn(nodesCmd).when(connection).dispatch(any(RedisCommand.class));
+
+        RedisAdvancedClusterAsyncCommandsImpl<String, String> commands = new RedisAdvancedClusterAsyncCommandsImpl<>(connection,
+                StringCodec.UTF8);
+
+        CompletableFuture<String> result = commands.clusterMyId().toCompletableFuture();
+        assertThatThrownBy(result::join).hasCauseInstanceOf(RedisException.class)
+                .hasMessageContaining("Failed to determine cluster node id");
+    }
+
+    private static AsyncCommand<String, String, String> completedAsyncCommand(String value) {
+        AsyncCommand<String, String, String> cmd = new AsyncCommand<>(
+                new Command<>(CommandType.CLUSTER, new StatusOutput<>(StringCodec.UTF8)));
+        cmd.complete(value);
+        return cmd;
+    }
+
+    private static AsyncCommand<String, String, String> failedAsyncCommand(Throwable ex) {
+        AsyncCommand<String, String, String> cmd = new AsyncCommand<>(
+                new Command<>(CommandType.CLUSTER, new StatusOutput<>(StringCodec.UTF8)));
+        cmd.completeExceptionally(ex);
+        return cmd;
+    }
+
+}

--- a/src/test/java/io/lettuce/core/AbstractRedisReactiveCommandsTest.java
+++ b/src/test/java/io/lettuce/core/AbstractRedisReactiveCommandsTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2025, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ */
+package io.lettuce.core;
+
+import io.lettuce.core.cluster.RedisAdvancedClusterReactiveCommandsImpl;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.protocol.RedisCommand;
+import io.lettuce.core.resource.ClientResources;
+import io.lettuce.core.tracing.Tracing;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import reactor.test.StepVerifier;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link AbstractRedisReactiveCommands}.
+ *
+ * @author Aleksandar Todorov
+ */
+class AbstractRedisReactiveCommandsTest {
+
+    @Mock
+    private StatefulRedisClusterConnection<String, String> connection;
+
+    @Mock
+    private ClientResources clientResources;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(clientResources.tracing()).thenReturn(Tracing.disabled());
+        when(connection.getResources()).thenReturn(clientResources);
+        when(connection.getOptions()).thenReturn(ClientOptions.builder().build());
+    }
+
+    @Test
+    void clusterMyId_returnsNodeId_whenCommandSucceeds() {
+        mockDispatch(completeWith("my-node-id"));
+
+        RedisAdvancedClusterReactiveCommandsImpl<String, String> commands = new RedisAdvancedClusterReactiveCommandsImpl<>(
+                connection, StringCodec.UTF8);
+
+        StepVerifier.create(commands.clusterMyId()).expectNext("my-node-id").verifyComplete();
+    }
+
+    @Test
+    void clusterMyId_fallsBackToClusterNodes_onCommandExecutionException() {
+        String clusterNodesOutput = "fallback-node 127.0.0.1:6379@16379 myself,master - 0 0 1 connected 0-16383\n"
+                + "other-node 127.0.0.1:6380@16380 slave fallback-node 0 0 0 connected";
+
+        mockDispatch(failWith(new RedisCommandExecutionException("ERR unknown subcommand 'MYID'")),
+                completeWith(clusterNodesOutput));
+
+        RedisAdvancedClusterReactiveCommandsImpl<String, String> commands = new RedisAdvancedClusterReactiveCommandsImpl<>(
+                connection, StringCodec.UTF8);
+
+        StepVerifier.create(commands.clusterMyId()).expectNext("fallback-node").verifyComplete();
+    }
+
+    @Test
+    void clusterMyId_fallsBackToClusterNodes_onEmptyResult() {
+        String clusterNodesOutput = "fallback-node 127.0.0.1:6379@16379 myself,master - 0 0 1 connected 0-16383\n";
+
+        mockDispatch(completeWith(""), completeWith(clusterNodesOutput));
+
+        RedisAdvancedClusterReactiveCommandsImpl<String, String> commands = new RedisAdvancedClusterReactiveCommandsImpl<>(
+                connection, StringCodec.UTF8);
+
+        StepVerifier.create(commands.clusterMyId()).expectNext("fallback-node").verifyComplete();
+    }
+
+    @Test
+    void clusterMyId_propagatesNonExecutionException() {
+        mockDispatch(failWith(new RedisCommandTimeoutException("Command timed out")));
+
+        RedisAdvancedClusterReactiveCommandsImpl<String, String> commands = new RedisAdvancedClusterReactiveCommandsImpl<>(
+                connection, StringCodec.UTF8);
+
+        StepVerifier.create(commands.clusterMyId()).expectError(RedisCommandTimeoutException.class).verify();
+    }
+
+    @Test
+    void clusterMyId_throwsWhenNoMyselfNodeInFallback() {
+        String clusterNodesOutput = "node-123 127.0.0.1:6379@16379 master - 0 0 1 connected 0-16383\n";
+
+        mockDispatch(failWith(new RedisCommandExecutionException("NOPERM")), completeWith(clusterNodesOutput));
+
+        RedisAdvancedClusterReactiveCommandsImpl<String, String> commands = new RedisAdvancedClusterReactiveCommandsImpl<>(
+                connection, StringCodec.UTF8);
+
+        StepVerifier.create(commands.clusterMyId()).expectErrorSatisfies(ex -> {
+            assertThat(ex).isInstanceOf(RedisException.class).hasMessageContaining("Failed to determine cluster node id");
+        }).verify();
+    }
+
+    /**
+     * Mocks {@code connection.dispatch(RedisCommand)} to complete the passed-in command with the given results in sequence.
+     * <p>
+     * The reactive pipeline dispatches a {@code SubscriptionCommand} wrapper and waits for it to complete. Unlike the async
+     * path, returning a pre-completed command does not work — we must complete the actual command that was dispatched.
+     */
+    @SuppressWarnings("unchecked")
+    private void mockDispatch(DispatchAction... actions) {
+        AtomicInteger callIndex = new AtomicInteger(0);
+        doAnswer(invocation -> {
+            RedisCommand<String, String, ?> cmd = invocation.getArgument(0);
+            int index = Math.min(callIndex.getAndIncrement(), actions.length - 1);
+            actions[index].apply(cmd);
+            return cmd;
+        }).when(connection).dispatch(any(RedisCommand.class));
+    }
+
+    private static DispatchAction completeWith(String value) {
+        return cmd -> {
+            cmd.getOutput().set(java.nio.ByteBuffer.wrap(value.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+            cmd.complete();
+        };
+    }
+
+    private static DispatchAction failWith(Throwable ex) {
+        return cmd -> cmd.completeExceptionally(ex);
+    }
+
+    @FunctionalInterface
+    private interface DispatchAction {
+
+        void apply(RedisCommand<String, String, ?> cmd);
+
+    }
+
+}

--- a/src/test/java/io/lettuce/core/cluster/ClusterCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/ClusterCommandIntegrationTests.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import io.lettuce.core.protocol.ProtocolKeyword;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,10 @@ import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
+import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
 import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
+import io.lettuce.core.AclSetuserArgs;
+import io.lettuce.core.cluster.api.async.RedisAdvancedClusterAsyncCommands;
 import io.lettuce.core.cluster.models.partitions.ClusterPartitionParser;
 import io.lettuce.core.cluster.models.partitions.Partitions;
 import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
@@ -287,6 +291,79 @@ class ClusterCommandIntegrationTests extends TestSupport {
 
     private static void waitUntilValueIsVisible(String key, RedisCommands<String, String> commands) {
         Wait.untilTrue(() -> commands.get(key) != null).waitOrTimeout();
+    }
+
+    /**
+     * Test that clusterMyId() falls back to CLUSTER NODES parsing when CLUSTER MYID command is not available. This simulates
+     * environments like Redis Enterprise OSS cluster mode where CLUSTER MYID is not supported.
+     */
+    @Test
+    @EnabledOnCommand("ACL") // Requires Redis 6+ for ACL support
+    void clusterMyIdFallsBackToClusterNodesWhenCommandDenied() {
+
+        String testUser = "noclustermyid";
+        String testPassword = "testpass123";
+
+        // Create a ProtocolKeyword for the MYID subcommand
+        ProtocolKeyword myidSubcommand = new ProtocolKeyword() {
+
+            @Override
+            public byte[] getBytes() {
+                return "MYID".getBytes();
+            }
+
+            @Override
+            public String toString() {
+                return "MYID";
+            }
+
+        };
+
+        // Use cluster connection to create user on ALL nodes
+        try (StatefulRedisClusterConnection<String, String> clusterConnection = clusterClient.connect()) {
+            RedisAdvancedClusterCommands<String, String> clusterSync = clusterConnection.sync();
+
+            try {
+                // Create a user on ALL cluster nodes so authentication works during topology refresh
+                AclSetuserArgs userArgs = AclSetuserArgs.Builder.on().addPassword(testPassword).allKeys().allChannels()
+                        .allCommands().removeCommand(io.lettuce.core.protocol.CommandType.CLUSTER, myidSubcommand);
+
+                // ACL commands are not exposed via NodeSelectionCommands, so we iterate over nodes manually
+                for (RedisClusterNode node : clusterConnection.getPartitions()) {
+                    clusterSync.getConnection(node.getNodeId()).aclSetuser(testUser, userArgs);
+                }
+
+                // Connect with the restricted user
+                RedisURI restrictedUri = RedisURI.Builder.redis(host, ClusterTestSettings.port1)
+                        .withAuthentication(testUser, testPassword.toCharArray()).build();
+
+                try (RedisClusterClient restrictedClient = RedisClusterClient.create(restrictedUri);
+                        StatefulRedisClusterConnection<String, String> restrictedConnection = restrictedClient.connect()) {
+
+                    RedisAdvancedClusterAsyncCommands<String, String> restrictedAsync = restrictedConnection.async();
+
+                    // This should trigger the fallback to CLUSTER NODES parsing
+                    String nodeId = TestFutures.getOrTimeout(restrictedAsync.clusterMyId());
+
+                    // Verify we got a valid node ID (the fallback worked)
+                    assertThat(nodeId).isNotNull();
+                    assertThat(nodeId).isNotEmpty();
+
+                    // Verify the node ID matches what we'd get from CLUSTER NODES parsing
+                    String clusterNodes = TestFutures.getOrTimeout(restrictedAsync.clusterNodes());
+                    Partitions partitions = ClusterPartitionParser.parse(clusterNodes);
+                    String expectedNodeId = partitions.stream().filter(n -> n.is(RedisClusterNode.NodeFlag.MYSELF)).findFirst()
+                            .map(RedisClusterNode::getNodeId).orElse(null);
+
+                    assertThat(nodeId).isEqualTo(expectedNodeId);
+                }
+            } finally {
+                // Always clean up the test user on ALL nodes
+                for (RedisClusterNode node : clusterConnection.getPartitions()) {
+                    clusterSync.getConnection(node.getNodeId()).aclDeluser(testUser);
+                }
+            }
+        }
     }
 
 }

--- a/src/test/java/io/lettuce/core/cluster/ClusterReactiveCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/ClusterReactiveCommandIntegrationTests.java
@@ -13,13 +13,22 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import reactor.test.StepVerifier;
+import io.lettuce.core.AclSetuserArgs;
+import io.lettuce.core.RedisURI;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
 import io.lettuce.core.cluster.api.reactive.RedisClusterReactiveCommands;
+import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
 import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
+import io.lettuce.core.cluster.models.partitions.ClusterPartitionParser;
+import io.lettuce.core.cluster.models.partitions.Partitions;
 import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
 import io.lettuce.core.cluster.models.slots.ClusterSlotRange;
 import io.lettuce.core.cluster.models.slots.ClusterSlotsParser;
+import io.lettuce.core.protocol.CommandType;
+import io.lettuce.core.protocol.ProtocolKeyword;
 import io.lettuce.test.LettuceExtension;
+import io.lettuce.test.condition.EnabledOnCommand;
 
 /**
  * @author Mark Paluch
@@ -30,6 +39,8 @@ class ClusterReactiveCommandIntegrationTests {
 
     private final RedisClusterClient clusterClient;
 
+    private final StatefulRedisClusterConnection<String, String> connection;
+
     private final RedisClusterReactiveCommands<String, String> reactive;
 
     private final RedisClusterCommands<String, String> sync;
@@ -38,6 +49,7 @@ class ClusterReactiveCommandIntegrationTests {
     ClusterReactiveCommandIntegrationTests(RedisClusterClient clusterClient,
             StatefulRedisClusterConnection<String, String> connection) {
         this.clusterClient = clusterClient;
+        this.connection = connection;
 
         this.reactive = connection.reactive();
         this.sync = connection.sync();
@@ -107,6 +119,78 @@ class ClusterReactiveCommandIntegrationTests {
         for (Map<String, Object> value : values) {
             assertThat(value).containsKeys("direction", "node", "create-time", "events", "send-buffer-allocated",
                     "send-buffer-used");
+        }
+    }
+
+    /**
+     * Test that clusterMyId() falls back to CLUSTER NODES parsing when CLUSTER MYID command is not available. This simulates
+     * environments like Redis Enterprise OSS cluster mode where CLUSTER MYID is not supported.
+     */
+    @Test
+    @EnabledOnCommand("ACL") // Requires Redis 6+ for ACL support
+    void clusterMyIdFallsBackToClusterNodesWhenCommandDenied() {
+
+        String testUser = "noclustermyid_reactive";
+        String testPassword = "testpass123";
+
+        // Create a ProtocolKeyword for the MYID subcommand
+        ProtocolKeyword myidSubcommand = new ProtocolKeyword() {
+
+            @Override
+            public byte[] getBytes() {
+                return "MYID".getBytes();
+            }
+
+            @Override
+            public String toString() {
+                return "MYID";
+            }
+
+        };
+
+        RedisAdvancedClusterCommands<String, String> advancedSync = connection.sync();
+
+        try {
+            // Create a user on ALL cluster nodes so authentication works during topology refresh
+            AclSetuserArgs userArgs = AclSetuserArgs.Builder.on().addPassword(testPassword).allKeys().allChannels()
+                    .allCommands().removeCommand(CommandType.CLUSTER, myidSubcommand);
+
+            for (RedisClusterNode node : connection.getPartitions()) {
+                advancedSync.getConnection(node.getNodeId()).aclSetuser(testUser, userArgs);
+            }
+
+            // Connect with the restricted user
+            RedisURI restrictedUri = RedisURI.Builder.redis(ClusterTestSettings.host, ClusterTestSettings.port1)
+                    .withAuthentication(testUser, testPassword.toCharArray()).build();
+
+            try (RedisClusterClient restrictedClient = RedisClusterClient.create(restrictedUri);
+                    StatefulRedisClusterConnection<String, String> restrictedConnection = restrictedClient.connect()) {
+
+                RedisAdvancedClusterReactiveCommands<String, String> restrictedReactive = restrictedConnection.reactive();
+
+                // This should trigger the fallback to CLUSTER NODES parsing
+                StepVerifier.create(restrictedReactive.clusterMyId().zipWith(restrictedReactive.clusterNodes()))
+                        .assertNext(tuple -> {
+                            String nodeId = tuple.getT1();
+                            String clusterNodes = tuple.getT2();
+
+                            // Verify we got a valid node ID (the fallback worked)
+                            assertThat(nodeId).isNotNull();
+                            assertThat(nodeId).isNotEmpty();
+
+                            // Verify the node ID matches what we'd get from CLUSTER NODES parsing
+                            Partitions partitions = ClusterPartitionParser.parse(clusterNodes);
+                            String expectedNodeId = partitions.stream().filter(n -> n.is(RedisClusterNode.NodeFlag.MYSELF))
+                                    .findFirst().map(RedisClusterNode::getNodeId).orElse(null);
+
+                            assertThat(nodeId).isEqualTo(expectedNodeId);
+                        }).verifyComplete();
+            }
+        } finally {
+            // Always clean up the test user on ALL nodes
+            for (RedisClusterNode node : connection.getPartitions()) {
+                advancedSync.getConnection(node.getNodeId()).aclDeluser(testUser);
+            }
         }
     }
 


### PR DESCRIPTION
* ERR unknown subcommand 'MYID' with Azure Managed Redis (High Availablity) #3495

* Adressed Cursor feedback

* Polishing

* Forgot to format

* Throw exception when cluster node info not present

* Make fallback logic throw. Fix tests.

* Move fallback on central place

* Add unit tests.

* Minor fixes

---------


(cherry picked from commit 8b5675fd5a89d8a468636c47bb5baef93792c989)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit e6da54f2cad02a6db6c3344dfa77ac4d9dbf7387. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->