### PR TITLE
Fix links in README for Streaming API and Native Transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ This version of Lettuce has been tested against the latest Redis source-build.
 * [Redis Sentinel](https://redis.github.io/lettuce/ha-sharding/#redis-sentinel_1)
 * [Redis Cluster](https://redis.github.io/lettuce/ha-sharding/#redis-cluster)
 * [SSL](https://redis.github.io/lettuce/advanced-usage/#ssl-connections) and [Unix Domain Socket](https://redis.github.io/lettuce/advanced-usage/#unix-domain-sockets) connections
-* [Streaming API](https://redis.github.io/lettuce/advanced-usage/#streaming-api)
+* [Streaming API](https://redis.github.io/lettuce/advanced-usage/streaming-api)
 * [Codecs](https://redis.github.io/lettuce/integration-extension/#codecss) (for UTF8/bit/JSON etc. representation of your data)
 * multiple [Command Interfaces](https://github.com/redis/lettuce/wiki/Command-Interfaces-%284.0%29)
-* Support for [Native Transports](https://redis.github.io/lettuce/advanced-usage/#native-transports)
+* Support for [Native Transports](https://redis.github.io/lettuce/advanced-usage/native-transports)
 * Support [RediSearch](https://redis.github.io/lettuce/user-guide/redis-search/), [RedisJSON](https://redis.github.io/lettuce/user-guide/redis-json/) and [Redis Vector Sets](https://redis.github.io/lettuce/user-guide/vector-sets/)
 * Compatible with Java 8++ (implicit automatic module w/o descriptors)
 


### PR DESCRIPTION
resolves #3706 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates two README URLs; no runtime or API behavior is affected.
> 
> **Overview**
> Fixes outdated README links for **Streaming API** and **Native Transports** by pointing them to the new `advanced-usage/streaming-api` and `advanced-usage/native-transports` documentation pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6aa8ad98fb2caa67d5f94e20f7757030f95f947. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->