### PR TITLE
JSON.GET never returns an array #3711

### DIFF
--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -1890,6 +1890,16 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
     }
 
     @Override
+    public RedisFuture<String> jsonGetValueRaw(K key, JsonGetArgs options, JsonPath... jsonPaths) {
+        return dispatch(jsonCommandBuilder.jsonGetValueRaw(key, options, jsonPaths));
+    }
+
+    @Override
+    public RedisFuture<String> jsonGetValueRaw(K key, JsonPath... jsonPaths) {
+        return dispatch(jsonCommandBuilder.jsonGetValueRaw(key, JsonGetArgs.Builder.defaults(), jsonPaths));
+    }
+
+    @Override
     public RedisFuture<Long> jsonDel(K key) {
         return dispatch(jsonCommandBuilder.jsonDel(key, JsonPath.ROOT_PATH));
     }
@@ -1907,6 +1917,16 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
     @Override
     public RedisFuture<List<JsonValue>> jsonGet(K key, JsonPath... jsonPaths) {
         return dispatch(jsonCommandBuilder.jsonGet(key, JsonGetArgs.Builder.defaults(), jsonPaths));
+    }
+
+    @Override
+    public RedisFuture<JsonValue> jsonGetValue(K key, JsonGetArgs options, JsonPath... jsonPaths) {
+        return dispatch(jsonCommandBuilder.jsonGetValue(key, options, jsonPaths));
+    }
+
+    @Override
+    public RedisFuture<JsonValue> jsonGetValue(K key, JsonPath... jsonPaths) {
+        return dispatch(jsonCommandBuilder.jsonGetValue(key, JsonGetArgs.Builder.defaults(), jsonPaths));
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -1955,6 +1955,17 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
+    public Mono<String> jsonGetValueRaw(K key, JsonGetArgs options, JsonPath... jsonPaths) {
+        return createMono(() -> jsonCommandBuilder.jsonGetValueRaw(key, options, jsonPaths));
+    }
+
+    @Override
+    public Mono<String> jsonGetValueRaw(K key, JsonPath... jsonPaths) {
+        final JsonGetArgs args = JsonGetArgs.Builder.defaults();
+        return createMono(() -> jsonCommandBuilder.jsonGetValueRaw(key, args, jsonPaths));
+    }
+
+    @Override
     public Mono<Long> jsonDel(K key) {
         return createMono(() -> jsonCommandBuilder.jsonDel(key, JsonPath.ROOT_PATH));
     }
@@ -1968,6 +1979,17 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     public Flux<JsonValue> jsonGet(K key, JsonPath... jsonPaths) {
         final JsonGetArgs args = JsonGetArgs.Builder.defaults();
         return createDissolvingFlux(() -> jsonCommandBuilder.jsonGet(key, args, jsonPaths));
+    }
+
+    @Override
+    public Mono<JsonValue> jsonGetValue(K key, JsonGetArgs options, JsonPath... jsonPaths) {
+        return createMono(() -> jsonCommandBuilder.jsonGetValue(key, options, jsonPaths));
+    }
+
+    @Override
+    public Mono<JsonValue> jsonGetValue(K key, JsonPath... jsonPaths) {
+        final JsonGetArgs args = JsonGetArgs.Builder.defaults();
+        return createMono(() -> jsonCommandBuilder.jsonGetValue(key, args, jsonPaths));
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/RedisJsonCommandBuilder.java
+++ b/src/main/java/io/lettuce/core/RedisJsonCommandBuilder.java
@@ -237,6 +237,28 @@ class RedisJsonCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
         return createCommand(JSON_GET, new JsonValueListOutput<>(codec, parser.get()), args);
     }
 
+    Command<K, V, JsonValue> jsonGetValue(K key, JsonGetArgs options, JsonPath... jsonPaths) {
+        notNullKey(key);
+
+        CommandArgs<K, V> args = new CommandArgs<>(codec).addKey(key);
+
+        if (options != null) {
+            // OPTIONAL as per API
+            options.build(args);
+        }
+
+        if (jsonPaths != null) {
+            // OPTIONAL as per API
+            for (JsonPath jsonPath : jsonPaths) {
+                if (jsonPath != null) {
+                    args.add(jsonPath.toString());
+                }
+            }
+        }
+
+        return createCommand(JSON_GET, new JsonValueOutput<>(codec, parser.get()), args);
+    }
+
     Command<K, V, List<String>> jsonGetRaw(K key, JsonGetArgs options, JsonPath... jsonPaths) {
         notNullKey(key);
 
@@ -257,6 +279,28 @@ class RedisJsonCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
         }
 
         return createCommand(JSON_GET, new StringListOutput<>(codec), args);
+    }
+
+    Command<K, V, String> jsonGetValueRaw(K key, JsonGetArgs options, JsonPath... jsonPaths) {
+        notNullKey(key);
+
+        CommandArgs<K, V> args = new CommandArgs<>(codec).addKey(key);
+
+        if (options != null) {
+            // OPTIONAL as per API
+            options.build(args);
+        }
+
+        if (jsonPaths != null) {
+            // OPTIONAL as per API
+            for (JsonPath jsonPath : jsonPaths) {
+                if (jsonPath != null) {
+                    args.add(jsonPath.toString());
+                }
+            }
+        }
+
+        return createCommand(JSON_GET, new StatusOutput<>(codec), args);
     }
 
     Command<K, V, String> jsonMerge(K key, JsonPath jsonPath, JsonValue value) {

--- a/src/main/java/io/lettuce/core/api/async/RedisJsonAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisJsonAsyncCommands.java
@@ -310,8 +310,31 @@ public interface RedisJsonAsyncCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
      * @since 6.5
+     * @deprecated since 7.6, use {@link #jsonGetValue(Object, JsonGetArgs, JsonPath...)} instead. The {@code JSON.GET} command
+     *             always returns a single bulk string reply regardless of the number of paths, so returning a {@code List} is
+     *             misleading.
      */
+    @Deprecated
     RedisFuture<List<JsonValue>> jsonGet(K key, JsonGetArgs options, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form.
+     * <p>
+     * When using a single JSONPath, the root of the matching values is a JSON string with a top-level array of serialized JSON
+     * value. In contrast, a legacy path returns a single value.
+     * <p>
+     * When using multiple JSONPath arguments, the root of the matching values is a JSON string with a top-level object, with
+     * each object value being a top-level array of serialized JSON value. In contrast, if all paths are legacy paths, each
+     * object value is a single serialized JSON value. If there are multiple paths that include both legacy path and JSONPath,
+     * the returned value conforms to the JSONPath version (an array of values).
+     *
+     * @param key the key holding the JSON document.
+     * @param options the {@link JsonGetArgs} to use.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    RedisFuture<JsonValue> jsonGetValue(K key, JsonGetArgs options, JsonPath... jsonPaths);
 
     /**
      * Return the value at the specified path in JSON serialized form as raw strings.
@@ -324,8 +347,26 @@ public interface RedisJsonAsyncCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return List<String> the value at path in JSON serialized form, or null if the path does not exist.
      * @since 7.0
+     * @deprecated since 7.6, use {@link #jsonGetValueRaw(Object, JsonGetArgs, JsonPath...)} instead. The {@code JSON.GET}
+     *             command always returns a single bulk string reply regardless of the number of paths, so returning a
+     *             {@code List} is misleading.
      */
+    @Deprecated
     RedisFuture<List<String>> jsonGetRaw(K key, JsonGetArgs options, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form as a raw string.
+     * <p>
+     * Behaves like {@link #jsonGetValue(Object, JsonGetArgs, JsonPath...)} but returns {@code String} with raw JSON instead of
+     * {@link JsonValue} wrapper.
+     *
+     * @param key the key holding the JSON document.
+     * @param options the {@link JsonGetArgs} to use.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return String the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    RedisFuture<String> jsonGetValueRaw(K key, JsonGetArgs options, JsonPath... jsonPaths);
 
     /**
      * Return the value at the specified path in JSON serialized form. Uses defaults for the {@link JsonGetArgs}.
@@ -342,8 +383,30 @@ public interface RedisJsonAsyncCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
      * @since 6.5
+     * @deprecated since 7.6, use {@link #jsonGetValue(Object, JsonPath...)} instead. The {@code JSON.GET} command always
+     *             returns a single bulk string reply regardless of the number of paths, so returning a {@code List} is
+     *             misleading.
      */
+    @Deprecated
     RedisFuture<List<JsonValue>> jsonGet(K key, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form. Uses defaults for the {@link JsonGetArgs}.
+     * <p>
+     * When using a single JSONPath, the root of the matching values is a JSON string with a top-level array of serialized JSON
+     * value. In contrast, a legacy path returns a single value.
+     * <p>
+     * When using multiple JSONPath arguments, the root of the matching values is a JSON string with a top-level object, with
+     * each object value being a top-level array of serialized JSON value. In contrast, if all paths are legacy paths, each
+     * object value is a single serialized JSON value. If there are multiple paths that include both legacy path and JSONPath,
+     * the returned value conforms to the JSONPath version (an array of values).
+     *
+     * @param key the key holding the JSON document.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    RedisFuture<JsonValue> jsonGetValue(K key, JsonPath... jsonPaths);
 
     /**
      * Return the value at the specified path in JSON serialized form as raw strings. Uses defaults for the {@link JsonGetArgs}.
@@ -355,8 +418,26 @@ public interface RedisJsonAsyncCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return List<String> the value at path in JSON serialized form, or null if the path does not exist.
      * @since 7.0
+     * @deprecated since 7.6, use {@link #jsonGetValueRaw(Object, JsonPath...)} instead. The {@code JSON.GET} command always
+     *             returns a single bulk string reply regardless of the number of paths, so returning a {@code List} is
+     *             misleading.
      */
+    @Deprecated
     RedisFuture<List<String>> jsonGetRaw(K key, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form as a raw string. Uses defaults for the
+     * {@link JsonGetArgs}.
+     * <p>
+     * Behaves like {@link #jsonGetValue(Object, JsonPath...)} but returns {@code String} with raw JSON instead of
+     * {@link JsonValue} wrapper.
+     *
+     * @param key the key holding the JSON document.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return String the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    RedisFuture<String> jsonGetValueRaw(K key, JsonPath... jsonPaths);
 
     /**
      * Merge a given {@link JsonValue} with the value matching {@link JsonPath}. Consequently, JSON values at matching paths are

--- a/src/main/java/io/lettuce/core/api/reactive/RedisJsonReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisJsonReactiveCommands.java
@@ -311,8 +311,31 @@ public interface RedisJsonReactiveCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
      * @since 6.5
+     * @deprecated since 7.6, use {@link #jsonGetValue(Object, JsonGetArgs, JsonPath...)} instead. The {@code JSON.GET} command
+     *             always returns a single bulk string reply regardless of the number of paths, so returning a {@code List} is
+     *             misleading.
      */
+    @Deprecated
     Flux<JsonValue> jsonGet(K key, JsonGetArgs options, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form.
+     * <p>
+     * When using a single JSONPath, the root of the matching values is a JSON string with a top-level array of serialized JSON
+     * value. In contrast, a legacy path returns a single value.
+     * <p>
+     * When using multiple JSONPath arguments, the root of the matching values is a JSON string with a top-level object, with
+     * each object value being a top-level array of serialized JSON value. In contrast, if all paths are legacy paths, each
+     * object value is a single serialized JSON value. If there are multiple paths that include both legacy path and JSONPath,
+     * the returned value conforms to the JSONPath version (an array of values).
+     *
+     * @param key the key holding the JSON document.
+     * @param options the {@link JsonGetArgs} to use.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    Mono<JsonValue> jsonGetValue(K key, JsonGetArgs options, JsonPath... jsonPaths);
 
     /**
      * Return the value at the specified path in JSON serialized form as raw strings.
@@ -325,8 +348,26 @@ public interface RedisJsonReactiveCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return List<String> the value at path in JSON serialized form, or null if the path does not exist.
      * @since 7.0
+     * @deprecated since 7.6, use {@link #jsonGetValueRaw(Object, JsonGetArgs, JsonPath...)} instead. The {@code JSON.GET}
+     *             command always returns a single bulk string reply regardless of the number of paths, so returning a
+     *             {@code List} is misleading.
      */
+    @Deprecated
     Flux<String> jsonGetRaw(K key, JsonGetArgs options, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form as a raw string.
+     * <p>
+     * Behaves like {@link #jsonGetValue(Object, JsonGetArgs, JsonPath...)} but returns {@code String} with raw JSON instead of
+     * {@link JsonValue} wrapper.
+     *
+     * @param key the key holding the JSON document.
+     * @param options the {@link JsonGetArgs} to use.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return String the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    Mono<String> jsonGetValueRaw(K key, JsonGetArgs options, JsonPath... jsonPaths);
 
     /**
      * Return the value at the specified path in JSON serialized form. Uses defaults for the {@link JsonGetArgs}.
@@ -343,8 +384,30 @@ public interface RedisJsonReactiveCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
      * @since 6.5
+     * @deprecated since 7.6, use {@link #jsonGetValue(Object, JsonPath...)} instead. The {@code JSON.GET} command always
+     *             returns a single bulk string reply regardless of the number of paths, so returning a {@code List} is
+     *             misleading.
      */
+    @Deprecated
     Flux<JsonValue> jsonGet(K key, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form. Uses defaults for the {@link JsonGetArgs}.
+     * <p>
+     * When using a single JSONPath, the root of the matching values is a JSON string with a top-level array of serialized JSON
+     * value. In contrast, a legacy path returns a single value.
+     * <p>
+     * When using multiple JSONPath arguments, the root of the matching values is a JSON string with a top-level object, with
+     * each object value being a top-level array of serialized JSON value. In contrast, if all paths are legacy paths, each
+     * object value is a single serialized JSON value. If there are multiple paths that include both legacy path and JSONPath,
+     * the returned value conforms to the JSONPath version (an array of values).
+     *
+     * @param key the key holding the JSON document.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    Mono<JsonValue> jsonGetValue(K key, JsonPath... jsonPaths);
 
     /**
      * Return the value at the specified path in JSON serialized form as raw strings. Uses defaults for the {@link JsonGetArgs}.
@@ -356,8 +419,26 @@ public interface RedisJsonReactiveCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return List<String> the value at path in JSON serialized form, or null if the path does not exist.
      * @since 7.0
+     * @deprecated since 7.6, use {@link #jsonGetValueRaw(Object, JsonPath...)} instead. The {@code JSON.GET} command always
+     *             returns a single bulk string reply regardless of the number of paths, so returning a {@code List} is
+     *             misleading.
      */
+    @Deprecated
     Flux<String> jsonGetRaw(K key, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form as a raw string. Uses defaults for the
+     * {@link JsonGetArgs}.
+     * <p>
+     * Behaves like {@link #jsonGetValue(Object, JsonPath...)} but returns {@code String} with raw JSON instead of
+     * {@link JsonValue} wrapper.
+     *
+     * @param key the key holding the JSON document.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return String the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    Mono<String> jsonGetValueRaw(K key, JsonPath... jsonPaths);
 
     /**
      * Merge a given {@link JsonValue} with the value matching {@link JsonPath}. Consequently, JSON values at matching paths are

--- a/src/main/java/io/lettuce/core/api/sync/RedisJsonCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisJsonCommands.java
@@ -309,8 +309,31 @@ public interface RedisJsonCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
      * @since 6.5
+     * @deprecated since 7.6, use {@link #jsonGetValue(Object, JsonGetArgs, JsonPath...)} instead. The {@code JSON.GET} command
+     *             always returns a single bulk string reply regardless of the number of paths, so returning a {@code List} is
+     *             misleading.
      */
+    @Deprecated
     List<JsonValue> jsonGet(K key, JsonGetArgs options, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form.
+     * <p>
+     * When using a single JSONPath, the root of the matching values is a JSON string with a top-level array of serialized JSON
+     * value. In contrast, a legacy path returns a single value.
+     * <p>
+     * When using multiple JSONPath arguments, the root of the matching values is a JSON string with a top-level object, with
+     * each object value being a top-level array of serialized JSON value. In contrast, if all paths are legacy paths, each
+     * object value is a single serialized JSON value. If there are multiple paths that include both legacy path and JSONPath,
+     * the returned value conforms to the JSONPath version (an array of values).
+     *
+     * @param key the key holding the JSON document.
+     * @param options the {@link JsonGetArgs} to use.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    JsonValue jsonGetValue(K key, JsonGetArgs options, JsonPath... jsonPaths);
 
     /**
      * Return the value at the specified path in JSON serialized form as raw strings.
@@ -323,8 +346,26 @@ public interface RedisJsonCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return List<String> the value at path in JSON serialized form, or null if the path does not exist.
      * @since 7.0
+     * @deprecated since 7.6, use {@link #jsonGetValueRaw(Object, JsonGetArgs, JsonPath...)} instead. The {@code JSON.GET}
+     *             command always returns a single bulk string reply regardless of the number of paths, so returning a
+     *             {@code List} is misleading.
      */
+    @Deprecated
     List<String> jsonGetRaw(K key, JsonGetArgs options, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form as a raw string.
+     * <p>
+     * Behaves like {@link #jsonGetValue(Object, JsonGetArgs, JsonPath...)} but returns {@code String} with raw JSON instead of
+     * {@link JsonValue} wrapper.
+     *
+     * @param key the key holding the JSON document.
+     * @param options the {@link JsonGetArgs} to use.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return String the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    String jsonGetValueRaw(K key, JsonGetArgs options, JsonPath... jsonPaths);
 
     /**
      * Return the value at the specified path in JSON serialized form. Uses defaults for the {@link JsonGetArgs}.
@@ -341,8 +382,30 @@ public interface RedisJsonCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
      * @since 6.5
+     * @deprecated since 7.6, use {@link #jsonGetValue(Object, JsonPath...)} instead. The {@code JSON.GET} command always
+     *             returns a single bulk string reply regardless of the number of paths, so returning a {@code List} is
+     *             misleading.
      */
+    @Deprecated
     List<JsonValue> jsonGet(K key, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form. Uses defaults for the {@link JsonGetArgs}.
+     * <p>
+     * When using a single JSONPath, the root of the matching values is a JSON string with a top-level array of serialized JSON
+     * value. In contrast, a legacy path returns a single value.
+     * <p>
+     * When using multiple JSONPath arguments, the root of the matching values is a JSON string with a top-level object, with
+     * each object value being a top-level array of serialized JSON value. In contrast, if all paths are legacy paths, each
+     * object value is a single serialized JSON value. If there are multiple paths that include both legacy path and JSONPath,
+     * the returned value conforms to the JSONPath version (an array of values).
+     *
+     * @param key the key holding the JSON document.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    JsonValue jsonGetValue(K key, JsonPath... jsonPaths);
 
     /**
      * Return the value at the specified path in JSON serialized form as raw strings. Uses defaults for the {@link JsonGetArgs}.
@@ -354,8 +417,26 @@ public interface RedisJsonCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return List<String> the value at path in JSON serialized form, or null if the path does not exist.
      * @since 7.0
+     * @deprecated since 7.6, use {@link #jsonGetValueRaw(Object, JsonPath...)} instead. The {@code JSON.GET} command always
+     *             returns a single bulk string reply regardless of the number of paths, so returning a {@code List} is
+     *             misleading.
      */
+    @Deprecated
     List<String> jsonGetRaw(K key, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form as a raw string. Uses defaults for the
+     * {@link JsonGetArgs}.
+     * <p>
+     * Behaves like {@link #jsonGetValue(Object, JsonPath...)} but returns {@code String} with raw JSON instead of
+     * {@link JsonValue} wrapper.
+     *
+     * @param key the key holding the JSON document.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return String the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    String jsonGetValueRaw(K key, JsonPath... jsonPaths);
 
     /**
      * Merge a given {@link JsonValue} with the value matching {@link JsonPath}. Consequently, JSON values at matching paths are

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionJsonAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionJsonAsyncCommands.java
@@ -308,8 +308,31 @@ public interface NodeSelectionJsonAsyncCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
      * @since 6.5
+     * @deprecated since 7.6, use {@link #jsonGetValue(Object, JsonGetArgs, JsonPath...)} instead. The {@code JSON.GET} command
+     *             always returns a single bulk string reply regardless of the number of paths, so returning a {@code List} is
+     *             misleading.
      */
+    @Deprecated
     AsyncExecutions<List<JsonValue>> jsonGet(K key, JsonGetArgs options, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form.
+     * <p>
+     * When using a single JSONPath, the root of the matching values is a JSON string with a top-level array of serialized JSON
+     * value. In contrast, a legacy path returns a single value.
+     * <p>
+     * When using multiple JSONPath arguments, the root of the matching values is a JSON string with a top-level object, with
+     * each object value being a top-level array of serialized JSON value. In contrast, if all paths are legacy paths, each
+     * object value is a single serialized JSON value. If there are multiple paths that include both legacy path and JSONPath,
+     * the returned value conforms to the JSONPath version (an array of values).
+     *
+     * @param key the key holding the JSON document.
+     * @param options the {@link JsonGetArgs} to use.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    AsyncExecutions<JsonValue> jsonGetValue(K key, JsonGetArgs options, JsonPath... jsonPaths);
 
     /**
      * Return the value at the specified path in JSON serialized form as raw strings.
@@ -322,8 +345,26 @@ public interface NodeSelectionJsonAsyncCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return List<String> the value at path in JSON serialized form, or null if the path does not exist.
      * @since 7.0
+     * @deprecated since 7.6, use {@link #jsonGetValueRaw(Object, JsonGetArgs, JsonPath...)} instead. The {@code JSON.GET}
+     *             command always returns a single bulk string reply regardless of the number of paths, so returning a
+     *             {@code List} is misleading.
      */
+    @Deprecated
     AsyncExecutions<List<String>> jsonGetRaw(K key, JsonGetArgs options, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form as a raw string.
+     * <p>
+     * Behaves like {@link #jsonGetValue(Object, JsonGetArgs, JsonPath...)} but returns {@code String} with raw JSON instead of
+     * {@link JsonValue} wrapper.
+     *
+     * @param key the key holding the JSON document.
+     * @param options the {@link JsonGetArgs} to use.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return String the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    AsyncExecutions<String> jsonGetValueRaw(K key, JsonGetArgs options, JsonPath... jsonPaths);
 
     /**
      * Return the value at the specified path in JSON serialized form. Uses defaults for the {@link JsonGetArgs}.
@@ -340,8 +381,30 @@ public interface NodeSelectionJsonAsyncCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
      * @since 6.5
+     * @deprecated since 7.6, use {@link #jsonGetValue(Object, JsonPath...)} instead. The {@code JSON.GET} command always
+     *             returns a single bulk string reply regardless of the number of paths, so returning a {@code List} is
+     *             misleading.
      */
+    @Deprecated
     AsyncExecutions<List<JsonValue>> jsonGet(K key, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form. Uses defaults for the {@link JsonGetArgs}.
+     * <p>
+     * When using a single JSONPath, the root of the matching values is a JSON string with a top-level array of serialized JSON
+     * value. In contrast, a legacy path returns a single value.
+     * <p>
+     * When using multiple JSONPath arguments, the root of the matching values is a JSON string with a top-level object, with
+     * each object value being a top-level array of serialized JSON value. In contrast, if all paths are legacy paths, each
+     * object value is a single serialized JSON value. If there are multiple paths that include both legacy path and JSONPath,
+     * the returned value conforms to the JSONPath version (an array of values).
+     *
+     * @param key the key holding the JSON document.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    AsyncExecutions<JsonValue> jsonGetValue(K key, JsonPath... jsonPaths);
 
     /**
      * Return the value at the specified path in JSON serialized form as raw strings. Uses defaults for the {@link JsonGetArgs}.
@@ -353,8 +416,26 @@ public interface NodeSelectionJsonAsyncCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return List<String> the value at path in JSON serialized form, or null if the path does not exist.
      * @since 7.0
+     * @deprecated since 7.6, use {@link #jsonGetValueRaw(Object, JsonPath...)} instead. The {@code JSON.GET} command always
+     *             returns a single bulk string reply regardless of the number of paths, so returning a {@code List} is
+     *             misleading.
      */
+    @Deprecated
     AsyncExecutions<List<String>> jsonGetRaw(K key, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form as a raw string. Uses defaults for the
+     * {@link JsonGetArgs}.
+     * <p>
+     * Behaves like {@link #jsonGetValue(Object, JsonPath...)} but returns {@code String} with raw JSON instead of
+     * {@link JsonValue} wrapper.
+     *
+     * @param key the key holding the JSON document.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return String the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    AsyncExecutions<String> jsonGetValueRaw(K key, JsonPath... jsonPaths);
 
     /**
      * Merge a given {@link JsonValue} with the value matching {@link JsonPath}. Consequently, JSON values at matching paths are

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionJsonCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionJsonCommands.java
@@ -308,8 +308,31 @@ public interface NodeSelectionJsonCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
      * @since 6.5
+     * @deprecated since 7.6, use {@link #jsonGetValue(Object, JsonGetArgs, JsonPath...)} instead. The {@code JSON.GET} command
+     *             always returns a single bulk string reply regardless of the number of paths, so returning a {@code List} is
+     *             misleading.
      */
+    @Deprecated
     Executions<List<JsonValue>> jsonGet(K key, JsonGetArgs options, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form.
+     * <p>
+     * When using a single JSONPath, the root of the matching values is a JSON string with a top-level array of serialized JSON
+     * value. In contrast, a legacy path returns a single value.
+     * <p>
+     * When using multiple JSONPath arguments, the root of the matching values is a JSON string with a top-level object, with
+     * each object value being a top-level array of serialized JSON value. In contrast, if all paths are legacy paths, each
+     * object value is a single serialized JSON value. If there are multiple paths that include both legacy path and JSONPath,
+     * the returned value conforms to the JSONPath version (an array of values).
+     *
+     * @param key the key holding the JSON document.
+     * @param options the {@link JsonGetArgs} to use.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    Executions<JsonValue> jsonGetValue(K key, JsonGetArgs options, JsonPath... jsonPaths);
 
     /**
      * Return the value at the specified path in JSON serialized form as raw strings.
@@ -322,8 +345,26 @@ public interface NodeSelectionJsonCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return List<String> the value at path in JSON serialized form, or null if the path does not exist.
      * @since 7.0
+     * @deprecated since 7.6, use {@link #jsonGetValueRaw(Object, JsonGetArgs, JsonPath...)} instead. The {@code JSON.GET}
+     *             command always returns a single bulk string reply regardless of the number of paths, so returning a
+     *             {@code List} is misleading.
      */
+    @Deprecated
     Executions<List<String>> jsonGetRaw(K key, JsonGetArgs options, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form as a raw string.
+     * <p>
+     * Behaves like {@link #jsonGetValue(Object, JsonGetArgs, JsonPath...)} but returns {@code String} with raw JSON instead of
+     * {@link JsonValue} wrapper.
+     *
+     * @param key the key holding the JSON document.
+     * @param options the {@link JsonGetArgs} to use.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return String the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    Executions<String> jsonGetValueRaw(K key, JsonGetArgs options, JsonPath... jsonPaths);
 
     /**
      * Return the value at the specified path in JSON serialized form. Uses defaults for the {@link JsonGetArgs}.
@@ -340,8 +381,30 @@ public interface NodeSelectionJsonCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
      * @since 6.5
+     * @deprecated since 7.6, use {@link #jsonGetValue(Object, JsonPath...)} instead. The {@code JSON.GET} command always
+     *             returns a single bulk string reply regardless of the number of paths, so returning a {@code List} is
+     *             misleading.
      */
+    @Deprecated
     Executions<List<JsonValue>> jsonGet(K key, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form. Uses defaults for the {@link JsonGetArgs}.
+     * <p>
+     * When using a single JSONPath, the root of the matching values is a JSON string with a top-level array of serialized JSON
+     * value. In contrast, a legacy path returns a single value.
+     * <p>
+     * When using multiple JSONPath arguments, the root of the matching values is a JSON string with a top-level object, with
+     * each object value being a top-level array of serialized JSON value. In contrast, if all paths are legacy paths, each
+     * object value is a single serialized JSON value. If there are multiple paths that include both legacy path and JSONPath,
+     * the returned value conforms to the JSONPath version (an array of values).
+     *
+     * @param key the key holding the JSON document.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    Executions<JsonValue> jsonGetValue(K key, JsonPath... jsonPaths);
 
     /**
      * Return the value at the specified path in JSON serialized form as raw strings. Uses defaults for the {@link JsonGetArgs}.
@@ -353,8 +416,26 @@ public interface NodeSelectionJsonCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return List<String> the value at path in JSON serialized form, or null if the path does not exist.
      * @since 7.0
+     * @deprecated since 7.6, use {@link #jsonGetValueRaw(Object, JsonPath...)} instead. The {@code JSON.GET} command always
+     *             returns a single bulk string reply regardless of the number of paths, so returning a {@code List} is
+     *             misleading.
      */
+    @Deprecated
     Executions<List<String>> jsonGetRaw(K key, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form as a raw string. Uses defaults for the
+     * {@link JsonGetArgs}.
+     * <p>
+     * Behaves like {@link #jsonGetValue(Object, JsonPath...)} but returns {@code String} with raw JSON instead of
+     * {@link JsonValue} wrapper.
+     *
+     * @param key the key holding the JSON document.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return String the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    Executions<String> jsonGetValueRaw(K key, JsonPath... jsonPaths);
 
     /**
      * Merge a given {@link JsonValue} with the value matching {@link JsonPath}. Consequently, JSON values at matching paths are

--- a/src/main/java/io/lettuce/core/output/JsonValueOutput.java
+++ b/src/main/java/io/lettuce/core/output/JsonValueOutput.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ */
+package io.lettuce.core.output;
+
+import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.json.JsonValue;
+import io.lettuce.core.json.JsonParser;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Single {@link JsonValue} output.
+ *
+ * @param <K> Key type.
+ * @param <V> Value type.
+ * @author Tihomir Mateev
+ * @since 7.6
+ */
+public class JsonValueOutput<K, V> extends CommandOutput<K, V, JsonValue> {
+
+    private final JsonParser parser;
+
+    public JsonValueOutput(RedisCodec<K, V> codec, JsonParser theParser) {
+        super(codec, null);
+        parser = theParser;
+    }
+
+    @Override
+    public void set(ByteBuffer bytes) {
+        ByteBuffer fetched = null;
+        if (bytes != null) {
+            fetched = ByteBuffer.allocate(bytes.remaining());
+            fetched.put(bytes);
+            fetched.flip();
+        }
+
+        output = parser.loadJsonValue(fetched);
+    }
+
+}

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisJsonCoroutinesCommands.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisJsonCoroutinesCommands.kt
@@ -307,23 +307,23 @@ interface RedisJsonCoroutinesCommands<K : Any, V : Any> {
      * @param options the [JsonGetArgs] to use.
      * @param jsonPaths the [JsonPath]s to use to identify the values to get.
      * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
-     * @since 6.5
+     * @since 7.6
      */
-    suspend fun jsonGet(key: K, options: JsonGetArgs, vararg jsonPaths: JsonPath): List<JsonValue>
+    suspend fun jsonGetValue(key: K, options: JsonGetArgs, vararg jsonPaths: JsonPath): JsonValue?
 
     /**
-     * Return the value at the specified path in JSON serialized form as raw strings.
+     * Return the value at the specified path in JSON serialized form as a raw string.
      * <p>
-     * Behaves like [jsonGet(Any, JsonGetArgs, JsonPath...)] but returns {@code List<String>} with raw JSON instead of
-     * [JsonValue] wrappers.
+     * Behaves like [jsonGetValue(Any, JsonGetArgs, JsonPath...)] but returns `String` with raw JSON instead of
+     * [JsonValue] wrapper.
      *
      * @param key the key holding the JSON document.
      * @param options the [JsonGetArgs] to use.
      * @param jsonPaths the [JsonPath]s to use to identify the values to get.
-     * @return List<String> the value at path in JSON serialized form, or null if the path does not exist.
-     * @since 7.0
+     * @return String the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
      */
-    suspend fun jsonGetRaw(key: K, options: JsonGetArgs, vararg jsonPaths: JsonPath): List<String>
+    suspend fun jsonGetValueRaw(key: K, options: JsonGetArgs, vararg jsonPaths: JsonPath): String?
 
     /**
      * Return the value at the specified path in JSON serialized form. Uses defaults for the [JsonGetArgs].
@@ -339,22 +339,23 @@ interface RedisJsonCoroutinesCommands<K : Any, V : Any> {
      * @param key the key holding the JSON document.
      * @param jsonPaths the [JsonPath]s to use to identify the values to get.
      * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
-     * @since 6.5
+     * @since 7.6
      */
-    suspend fun jsonGet(key: K, vararg jsonPaths: JsonPath): List<JsonValue>
+    suspend fun jsonGetValue(key: K, vararg jsonPaths: JsonPath): JsonValue?
 
     /**
-     * Return the value at the specified path in JSON serialized form as raw strings. Uses defaults for the [JsonGetArgs].
+     * Return the value at the specified path in JSON serialized form as a raw string. Uses defaults for the
+     * [JsonGetArgs].
      * <p>
-     * Behaves like [jsonGet(Any, JsonPath...)] but returns {@code List<String>} with raw JSON instead of
-     * [JsonValue] wrappers.
+     * Behaves like [jsonGetValue(Any, JsonPath...)] but returns `String` with raw JSON instead of
+     * [JsonValue] wrapper.
      *
      * @param key the key holding the JSON document.
      * @param jsonPaths the [JsonPath]s to use to identify the values to get.
-     * @return List<String> the value at path in JSON serialized form, or null if the path does not exist.
-     * @since 7.0
+     * @return String the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
      */
-    suspend fun jsonGetRaw(key: K, vararg jsonPaths: JsonPath): List<String>
+    suspend fun jsonGetValueRaw(key: K, vararg jsonPaths: JsonPath): String?
 
     /**
      * Merge a given [JsonValue] with the value matching [JsonPath]. Consequently, JSON values at matching paths are

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisJsonCoroutinesCommandsImpl.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisJsonCoroutinesCommandsImpl.kt
@@ -117,23 +117,23 @@ internal class RedisJsonCoroutinesCommandsImpl<K : Any, V : Any>(internal val op
 
     override suspend fun jsonDel(key: K): Long? = ops.jsonDel(key).awaitFirstOrNull()
 
-    override suspend fun jsonGet(key: K, options: JsonGetArgs, vararg jsonPaths: JsonPath): List<JsonValue> =
-        ops.jsonGet(key, options, *jsonPaths).asFlow().toList()
+    override suspend fun jsonGetValue(key: K, options: JsonGetArgs, vararg jsonPaths: JsonPath): JsonValue? =
+        ops.jsonGetValue(key, options, *jsonPaths).awaitFirstOrNull()
 
-    override suspend fun jsonGet(key: K, vararg jsonPaths: JsonPath): List<JsonValue> =
-        ops.jsonGet(key, *jsonPaths).asFlow().toList()
+    override suspend fun jsonGetValueRaw(key: K, options: JsonGetArgs, vararg jsonPaths: JsonPath): String? =
+        ops.jsonGetValueRaw(key, options, *jsonPaths).awaitFirstOrNull()
+
+    override suspend fun jsonGetValue(key: K, vararg jsonPaths: JsonPath): JsonValue? =
+        ops.jsonGetValue(key, *jsonPaths).awaitFirstOrNull()
+
+    override suspend fun jsonGetValueRaw(key: K, vararg jsonPaths: JsonPath): String? =
+        ops.jsonGetValueRaw(key, *jsonPaths).awaitFirstOrNull()
 
     override suspend fun jsonMerge(key: K, jsonPath: JsonPath, jsonString: String): String? =
         ops.jsonMerge(key, jsonPath, jsonString).awaitFirstOrNull()
 
     override suspend fun jsonMerge(key: K, jsonPath: JsonPath, value: JsonValue): String? =
         ops.jsonMerge(key, jsonPath, value).awaitFirstOrNull()
-
-    override suspend fun jsonGetRaw(key: K, options: JsonGetArgs, vararg jsonPaths: JsonPath): List<String> =
-        ops.jsonGetRaw(key, options, *jsonPaths).asFlow().toList()
-
-    override suspend fun jsonGetRaw(key: K, vararg jsonPaths: JsonPath): List<String> =
-        ops.jsonGetRaw(key, *jsonPaths).asFlow().toList()
 
     override suspend fun jsonMGet(jsonPath: JsonPath, vararg keys: K): List<JsonValue> =
         ops.jsonMGet(jsonPath, *keys).asFlow().toList()

--- a/src/main/templates/io/lettuce/core/api/RedisJsonCommands.java
+++ b/src/main/templates/io/lettuce/core/api/RedisJsonCommands.java
@@ -308,8 +308,31 @@ public interface RedisJsonCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
      * @since 6.5
+     * @deprecated since 7.6, use {@link #jsonGetValue(Object, JsonGetArgs, JsonPath...)} instead. The {@code JSON.GET} command
+     *             always returns a single bulk string reply regardless of the number of paths, so returning a {@code List} is
+     *             misleading.
      */
+    @Deprecated
     List<JsonValue> jsonGet(K key, JsonGetArgs options, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form.
+     * <p>
+     * When using a single JSONPath, the root of the matching values is a JSON string with a top-level array of serialized JSON
+     * value. In contrast, a legacy path returns a single value.
+     * <p>
+     * When using multiple JSONPath arguments, the root of the matching values is a JSON string with a top-level object, with
+     * each object value being a top-level array of serialized JSON value. In contrast, if all paths are legacy paths, each
+     * object value is a single serialized JSON value. If there are multiple paths that include both legacy path and JSONPath,
+     * the returned value conforms to the JSONPath version (an array of values).
+     *
+     * @param key the key holding the JSON document.
+     * @param options the {@link JsonGetArgs} to use.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    JsonValue jsonGetValue(K key, JsonGetArgs options, JsonPath... jsonPaths);
 
     /**
      * Return the value at the specified path in JSON serialized form as raw strings.
@@ -322,8 +345,26 @@ public interface RedisJsonCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return List<String> the value at path in JSON serialized form, or null if the path does not exist.
      * @since 7.0
+     * @deprecated since 7.6, use {@link #jsonGetValueRaw(Object, JsonGetArgs, JsonPath...)} instead. The {@code JSON.GET}
+     *             command always returns a single bulk string reply regardless of the number of paths, so returning a
+     *             {@code List} is misleading.
      */
+    @Deprecated
     List<String> jsonGetRaw(K key, JsonGetArgs options, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form as a raw string.
+     * <p>
+     * Behaves like {@link #jsonGetValue(Object, JsonGetArgs, JsonPath...)} but returns {@code String} with raw JSON instead of
+     * {@link JsonValue} wrapper.
+     *
+     * @param key the key holding the JSON document.
+     * @param options the {@link JsonGetArgs} to use.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return String the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    String jsonGetValueRaw(K key, JsonGetArgs options, JsonPath... jsonPaths);
 
     /**
      * Return the value at the specified path in JSON serialized form. Uses defaults for the {@link JsonGetArgs}.
@@ -340,8 +381,30 @@ public interface RedisJsonCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
      * @since 6.5
+     * @deprecated since 7.6, use {@link #jsonGetValue(Object, JsonPath...)} instead. The {@code JSON.GET} command always
+     *             returns a single bulk string reply regardless of the number of paths, so returning a {@code List} is
+     *             misleading.
      */
+    @Deprecated
     List<JsonValue> jsonGet(K key, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form. Uses defaults for the {@link JsonGetArgs}.
+     * <p>
+     * When using a single JSONPath, the root of the matching values is a JSON string with a top-level array of serialized JSON
+     * value. In contrast, a legacy path returns a single value.
+     * <p>
+     * When using multiple JSONPath arguments, the root of the matching values is a JSON string with a top-level object, with
+     * each object value being a top-level array of serialized JSON value. In contrast, if all paths are legacy paths, each
+     * object value is a single serialized JSON value. If there are multiple paths that include both legacy path and JSONPath,
+     * the returned value conforms to the JSONPath version (an array of values).
+     *
+     * @param key the key holding the JSON document.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return JsonValue the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    JsonValue jsonGetValue(K key, JsonPath... jsonPaths);
 
     /**
      * Return the value at the specified path in JSON serialized form as raw strings. Uses defaults for the {@link JsonGetArgs}.
@@ -353,8 +416,26 @@ public interface RedisJsonCommands<K, V> {
      * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
      * @return List<String> the value at path in JSON serialized form, or null if the path does not exist.
      * @since 7.0
+     * @deprecated since 7.6, use {@link #jsonGetValueRaw(Object, JsonPath...)} instead. The {@code JSON.GET} command always
+     *             returns a single bulk string reply regardless of the number of paths, so returning a {@code List} is
+     *             misleading.
      */
+    @Deprecated
     List<String> jsonGetRaw(K key, JsonPath... jsonPaths);
+
+    /**
+     * Return the value at the specified path in JSON serialized form as a raw string. Uses defaults for the
+     * {@link JsonGetArgs}.
+     * <p>
+     * Behaves like {@link #jsonGetValue(Object, JsonPath...)} but returns {@code String} with raw JSON instead of
+     * {@link JsonValue} wrapper.
+     *
+     * @param key the key holding the JSON document.
+     * @param jsonPaths the {@link JsonPath}s to use to identify the values to get.
+     * @return String the value at path in JSON serialized form, or null if the path does not exist.
+     * @since 7.6
+     */
+    String jsonGetValueRaw(K key, JsonPath... jsonPaths);
 
     /**
      * Merge a given {@link JsonValue} with the value matching {@link JsonPath}. Consequently, JSON values at matching paths are

--- a/src/test/java/io/lettuce/core/json/RedisJsonIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/json/RedisJsonIntegrationTests.java
@@ -17,6 +17,7 @@ import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.codec.ByteArrayCodec;
 import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.json.arguments.JsonGetArgs;
 import io.lettuce.core.json.arguments.JsonMsetArgs;
 import io.lettuce.core.json.arguments.JsonRangeArgs;
 import org.junit.jupiter.api.AfterAll;
@@ -752,6 +753,200 @@ public class RedisJsonIntegrationTests {
         List<String> result = redis.jsonArrpopRaw("myKey");
         assertThat(result.toString()).isEqualTo("[\"one\"]");
         assertThat(redis.jsonGetRaw("myKey").get(0)).isEqualTo("[]");
+    }
+
+    @Test
+    void jsonMGetReturnsMultipleElementsForMultipleKeys() {
+        // Setup: Create two separate JSON documents
+        JsonParser parser = redis.getJsonParser();
+        JsonValue bike1 = parser.createJsonValue("{\"id\":\"bike:100\",\"model\":\"Speedy\"}");
+        JsonValue bike2 = parser.createJsonValue("{\"id\":\"bike:200\",\"model\":\"Cruiser\"}");
+        JsonValue bike3 = parser.createJsonValue("{\"id\":\"bike:300\",\"model\":\"Racer\"}");
+
+        redis.jsonSet("test:bike1", JsonPath.ROOT_PATH, bike1);
+        redis.jsonSet("test:bike2", JsonPath.ROOT_PATH, bike2);
+        redis.jsonSet("test:bike3", JsonPath.ROOT_PATH, bike3);
+
+        // Query multiple keys
+        List<JsonValue> values = redis.jsonMGet(JsonPath.ROOT_PATH, "test:bike1", "test:bike2", "test:bike3");
+
+        // Verify that the list contains multiple elements (one per key)
+        assertThat(values).hasSize(3);
+        assertThat(values.get(0).toString()).contains("bike:100");
+        assertThat(values.get(1).toString()).contains("bike:200");
+        assertThat(values.get(2).toString()).contains("bike:300");
+    }
+
+    @Test
+    void jsonArrpopReturnsMultipleElementsForMultipleArrayMatches() {
+        // Path $..colors matches the colors array in both bike:1 and bike:2
+        JsonPath colorsPath = JsonPath.of("$..colors");
+
+        // Pop from all matching colors arrays
+        List<JsonValue> poppedValues = redis.jsonArrpop(BIKES_INVENTORY, colorsPath);
+
+        // Should return 2 elements (one from each colors array that exists)
+        // bike:1 colors: ["black", "silver"] -> pops "silver"
+        // bike:2 colors: ["black", "white"] -> pops "white"
+        assertThat(poppedValues).hasSize(2);
+        // The popped elements should be the last elements from each array
+        assertThat(poppedValues.get(0).toString()).isEqualTo("\"silver\"");
+        assertThat(poppedValues.get(1).toString()).isEqualTo("\"white\"");
+    }
+
+    @Test
+    void jsonArrpopWithIndexReturnsMultipleElementsForMultipleArrayMatches() {
+        // Path $..colors matches colors arrays
+        JsonPath colorsPath = JsonPath.of("$..colors");
+
+        // Pop from index 0 of all matching colors arrays
+        List<JsonValue> poppedValues = redis.jsonArrpop(BIKES_INVENTORY, colorsPath, 0);
+
+        // Should return 2 elements (one from each colors array)
+        // bike:1 colors: ["black", "silver"] -> pops "black"
+        // bike:2 colors: ["black", "white"] -> pops "black"
+        assertThat(poppedValues).hasSize(2);
+        assertThat(poppedValues.get(0).toString()).isEqualTo("\"black\"");
+        assertThat(poppedValues.get(1).toString()).isEqualTo("\"black\"");
+    }
+
+    @Test
+    void jsonGetWithMultiplePathsReturnsMultipleElements() {
+        // Query two different paths
+        JsonPath modelPath = JsonPath.of("$..model");
+        JsonPath idPath = JsonPath.of("$..id");
+
+        List<JsonValue> values = redis.jsonGet(BIKES_INVENTORY, modelPath, idPath);
+
+        // With multiple paths, jsonGet returns a single JSON object containing both paths' results
+        // The List<JsonValue> will have 1 element which is the combined result
+        assertThat(values).hasSize(1);
+        String result = values.get(0).toString();
+        // The result should contain both paths as keys
+        assertThat(result).contains("$..model");
+        assertThat(result).contains("$..id");
+    }
+
+    @Test
+    void jsonMGetWithMultipleKeysAndJsonPath() {
+        // Setup: Create documents with nested structure
+        JsonParser parser = redis.getJsonParser();
+        JsonValue doc1 = parser.createJsonValue("{\"items\":[{\"name\":\"a\"},{\"name\":\"b\"}]}");
+        JsonValue doc2 = parser.createJsonValue("{\"items\":[{\"name\":\"c\"},{\"name\":\"d\"}]}");
+
+        redis.jsonSet("test:doc1", JsonPath.ROOT_PATH, doc1);
+        redis.jsonSet("test:doc2", JsonPath.ROOT_PATH, doc2);
+
+        // Query multiple keys with a JSONPath
+        JsonPath namePath = JsonPath.of("$..name");
+        List<JsonValue> values = redis.jsonMGet(namePath, "test:doc1", "test:doc2");
+
+        // Should return 2 elements (one per key)
+        assertThat(values).hasSize(2);
+        // Each element should contain the array of names
+        assertThat(values.get(0).toString()).isEqualTo("[\"a\",\"b\"]");
+        assertThat(values.get(1).toString()).isEqualTo("[\"c\",\"d\"]");
+    }
+
+    @Test
+    void jsonMGetReturnsNullForMissingKeys() {
+        JsonParser parser = redis.getJsonParser();
+        JsonValue doc = parser.createJsonValue("{\"value\":42}");
+        redis.jsonSet("test:exists", JsonPath.ROOT_PATH, doc);
+
+        List<JsonValue> values = redis.jsonMGet(JsonPath.ROOT_PATH, "test:exists", "test:missing", "test:exists");
+
+        // Should return 3 elements
+        assertThat(values).hasSize(3);
+        assertThat(values.get(0).isNull()).isFalse();
+        assertThat(values.get(1).isNull()).isTrue(); // Missing key returns JSON null
+        assertThat(values.get(2).isNull()).isFalse();
+    }
+
+    @Test
+    void jsonArrpopReturnsNullForNonArrayPaths() {
+        // Create a document with multiple paths, some arrays, some not
+        JsonParser parser = redis.getJsonParser();
+        JsonValue doc = parser
+                .createJsonValue("{\"arr1\":[1,2,3],\"notArray\":\"string\",\"arr2\":[4,5,6],\"nested\":{\"arr3\":[7,8,9]}}");
+        redis.jsonSet("test:mixed", JsonPath.ROOT_PATH, doc);
+
+        // Use wildcard to match all top-level fields
+        JsonPath wildcardPath = JsonPath.of("$.*");
+        List<JsonValue> poppedValues = redis.jsonArrpop("test:mixed", wildcardPath);
+
+        // Should return results for all 4 matched paths
+        // arr1 -> 3, notArray -> null (not array), arr2 -> 6, nested -> null (not array)
+        assertThat(poppedValues).hasSize(4);
+        assertThat(poppedValues.get(0).toString()).isEqualTo("3"); // arr1
+        assertThat(poppedValues.get(1).isNull()).isTrue(); // notArray (string, not array)
+        assertThat(poppedValues.get(2).toString()).isEqualTo("6"); // arr2
+        assertThat(poppedValues.get(3).isNull()).isTrue(); // nested (object, not array)
+    }
+
+    @ParameterizedTest(name = "With {0} as path")
+    @ValueSource(strings = { "..mountain_bikes[0:2].model", "$..mountain_bikes[0:2].model" })
+    void jsonGetValueReturnsSingleJsonValue(String path) {
+        JsonPath myPath = JsonPath.of(path);
+
+        JsonValue value = redis.jsonGetValue(BIKES_INVENTORY, myPath);
+        assertThat(value).isNotNull();
+
+        if (path.startsWith("$")) {
+            assertThat(value.toString()).isEqualTo("[\"Phoebe\",\"Quaoar\"]");
+            assertThat(value.isJsonArray()).isTrue();
+            assertThat(value.asJsonArray().size()).isEqualTo(2);
+        } else {
+            assertThat(value.toString()).isEqualTo("\"Phoebe\"");
+        }
+    }
+
+    @Test
+    void jsonGetValueWithArgs() {
+        JsonPath myPath = JsonPath.of("$..model");
+        JsonGetArgs args = JsonGetArgs.Builder.defaults();
+
+        JsonValue value = redis.jsonGetValue(BIKES_INVENTORY, args, myPath);
+        assertThat(value).isNotNull();
+        assertThat(value.toString()).isEqualTo("[\"Phoebe\",\"Quaoar\",\"Weywot\"]");
+    }
+
+    @Test
+    void jsonGetValueWithMultiplePaths() {
+        JsonPath modelPath = JsonPath.of("$..model");
+        JsonPath idPath = JsonPath.of("$..id");
+
+        JsonValue value = redis.jsonGetValue(BIKES_INVENTORY, modelPath, idPath);
+        assertThat(value).isNotNull();
+        // The result should be a JSON object containing both paths as keys
+        assertThat(value.asJsonObject().get("$..model").isJsonArray()).isTrue();
+        assertThat(value.asJsonObject().get("$..id").isJsonArray()).isTrue();
+
+        assertThat(value.asJsonObject().get("$..model").asJsonArray().size()).isEqualTo(3);
+        assertThat(value.asJsonObject().get("$..id").asJsonArray().size()).isEqualTo(3);
+
+        assertThat(value.asJsonObject().get("$..model").asJsonArray().asList().get(0).toString()).isEqualTo("\"Phoebe\"");
+        assertThat(value.asJsonObject().get("$..id").asJsonArray().asList().get(0).toString()).isEqualTo("\"bike:1\"");
+    }
+
+    @Test
+    void jsonGetValueRawReturnsSingleString() {
+        JsonPath myPath = JsonPath.of("$..model");
+
+        String value = redis.jsonGetValueRaw(BIKES_INVENTORY, myPath);
+        assertThat(value).isNotNull();
+        assertThat(value).isEqualTo("[\"Phoebe\",\"Quaoar\",\"Weywot\"]");
+    }
+
+    @Test
+    void jsonGetValueRawWithArgs() {
+        JsonPath myPath = JsonPath.of("$..model");
+        JsonGetArgs args = JsonGetArgs.Builder.indent("  ").newline("\n");
+
+        String value = redis.jsonGetValueRaw(BIKES_INVENTORY, args, myPath);
+        assertThat(value).isNotNull();
+        // Should contain pretty-printed JSON
+        assertThat(value).isEqualTo("[\n  \"Phoebe\",\n  \"Quaoar\",\n  \"Weywot\"\n]");
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Deprecate the wrong API and provide a new one, based on how the JSON.GET works.

Closes #3711 

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new `jsonGetValue*` methods and deprecates existing `jsonGet*` list-returning APIs, which can impact downstream consumers (especially coroutines) despite being source-compatible for Java via deprecation only.
> 
> **Overview**
> Aligns the `JSON.GET` API with Redis behavior by **adding single-result methods**: `jsonGetValue(...)` returning `JsonValue` and `jsonGetValueRaw(...)` returning a raw `String`, implemented across async/reactive/sync, cluster node selection, and coroutines.
> 
> Marks the existing `jsonGet(...)`/`jsonGetRaw(...)` list-returning methods as **deprecated** (since they imply multiple bulk replies), adds a new `JsonValueOutput` for parsing a single reply, and expands integration tests to cover multi-key/multi-path behavior and the new single-value APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c07e1b4a1c00339e85436ae9a5da7201a3d4de95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->