### PR TITLE
Introduce RedisNoFunctionException to represent Redis NOFUNCTION response #3717

### DIFF
--- a/src/main/java/io/lettuce/core/RedisNoFunctionException.java
+++ b/src/main/java/io/lettuce/core/RedisNoFunctionException.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026-Present, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ *
+ * This file contains contributions from third-party contributors
+ * licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lettuce.core;
+
+/**
+ * Exception that gets thrown when Redis indicates absence of a function referenced by its name in an {@code FCALL} or
+ * {@code FCALL_RO} command with an {@code ERR Function not found} error response.
+ *
+ * @author Sunwoo Ho
+ * @since 7.6
+ */
+@SuppressWarnings("serial")
+public class RedisNoFunctionException extends RedisCommandExecutionException {
+
+    /**
+     * Create a {@code RedisNoFunctionException} with the specified detail message.
+     *
+     * @param msg the detail message.
+     */
+    public RedisNoFunctionException(String msg) {
+        super(msg);
+    }
+
+    /**
+     * Create a {@code RedisNoFunctionException} with the specified detail message and nested exception.
+     *
+     * @param msg the detail message.
+     * @param cause the nested exception.
+     */
+    public RedisNoFunctionException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+}

--- a/src/main/java/io/lettuce/core/internal/ExceptionFactory.java
+++ b/src/main/java/io/lettuce/core/internal/ExceptionFactory.java
@@ -29,6 +29,7 @@ import io.lettuce.core.RedisBusyException;
 import io.lettuce.core.RedisCommandExecutionException;
 import io.lettuce.core.RedisCommandTimeoutException;
 import io.lettuce.core.RedisLoadingException;
+import io.lettuce.core.RedisNoFunctionException;
 import io.lettuce.core.RedisNoScriptException;
 import io.lettuce.core.RedisReadOnlyException;
 
@@ -37,6 +38,7 @@ import io.lettuce.core.RedisReadOnlyException;
  *
  * @author Mark Paluch
  * @author Tobias Nehrlich
+ * @author Sunwoo Ho
  * @since 4.5
  */
 public abstract class ExceptionFactory {
@@ -146,6 +148,10 @@ public abstract class ExceptionFactory {
 
             if (message.startsWith("READONLY")) {
                 return cause != null ? new RedisReadOnlyException(message, cause) : new RedisReadOnlyException(message);
+            }
+
+            if (message.startsWith("ERR Function not found")) {
+                return cause != null ? new RedisNoFunctionException(message, cause) : new RedisNoFunctionException(message);
             }
 
             return cause != null ? new RedisCommandExecutionException(message, cause)

--- a/src/test/java/io/lettuce/core/ExceptionFactoryUnitTests.java
+++ b/src/test/java/io/lettuce/core/ExceptionFactoryUnitTests.java
@@ -34,6 +34,7 @@ import io.lettuce.core.internal.ExceptionFactory;
  *
  * @author Mark Paluch
  * @author Tobias Nehrlich
+ * @author Sunwoo Ho
  */
 @Tag(UNIT_TEST)
 class ExceptionFactoryUnitTests {
@@ -88,6 +89,25 @@ class ExceptionFactoryUnitTests {
         assertThat(ExceptionFactory.createExecutionException("READONLY foo bar", new IllegalStateException()))
                 .isInstanceOf(RedisReadOnlyException.class).hasMessage("READONLY foo bar")
                 .hasRootCauseInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldCreateNoFunctionException() {
+
+        assertThat(ExceptionFactory.createExecutionException("ERR Function not found"))
+                .isInstanceOf(RedisNoFunctionException.class).hasMessage("ERR Function not found").hasNoCause();
+        assertThat(ExceptionFactory.createExecutionException("ERR Function not found", new IllegalStateException()))
+                .isInstanceOf(RedisNoFunctionException.class).hasMessage("ERR Function not found")
+                .hasRootCauseInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldNotMisclassifyOtherErrMessagesAsNoFunction() {
+
+        assertThat(ExceptionFactory.createExecutionException("ERR Library not found"))
+                .isExactlyInstanceOf(RedisCommandExecutionException.class).hasMessage("ERR Library not found");
+        assertThat(ExceptionFactory.createExecutionException("ERR some random error"))
+                .isExactlyInstanceOf(RedisCommandExecutionException.class).hasMessage("ERR some random error");
     }
 
     @Test


### PR DESCRIPTION
## Description

Introduces `RedisNoFunctionException` extending `RedisCommandExecutionException`
for `ERR Function not found` replies from `FCALL` / `FCALL_RO`. Mirrors the
existing pattern of `RedisNoScriptException` (#620), `RedisLoadingException`
(#682), and `RedisReadOnlyException` (#1943 / #1944).

Resolves #3717

## Why a dedicated exception

Message string matching works functionally, but introduces several issues
that Lettuce has historically decided to solve with dedicated exception
types. The same reasoning applies here:

1. **Type safety**: Catching `RedisCommandExecutionException` forces users
   to catch an extremely broad supertype (covering `ERR`, `WRONGTYPE`,
   `OOM`, `MISCONF`, `CLUSTERDOWN`, etc.) and filter inside. Easy to
   accidentally swallow unrelated errors.

2. **Stability contract**: If the error literal is tracked in one place
   (`ExceptionFactory`), Lettuce can adapt to future Redis server changes
   without every user application breaking silently. Users who match
   messages themselves each maintain their own fragile copy.

3. **Consistency**: `NOSCRIPT`, `BUSY`, `LOADING`, `READONLY` all have
   dedicated subtypes. `NOFUNCTION` is conceptually the same (a recoverable
   error requiring a fallback pattern); leaving it out is an asymmetric gap.

4. **Enables higher-level abstractions**: Spring Data Redis's
   `DefaultScriptExecutor` currently uses
   `ScriptUtils.exceptionContainsNoScriptError` as a last resort because
   `RedisNoScriptException` exists. Without `RedisNoFunctionException`,
   any future `DefaultRedisFunction` in Spring Data Redis would have to
   reintroduce the same message-matching pattern. Providing the typed
   exception here keeps the ecosystem consistent.

5. **Testability**: Unit tests for fallback logic can mock by type rather
   than by exact message format, which is more robust to Lettuce/Redis
   version changes.

These are the same arguments that led to #620, #682, and #1943 being
accepted. This PR follows the established pattern rather than proposing
a new direction.

## Error message stability

The `"ERR Function not found"` literal originates from a single location in
Redis server (`src/functions.c` in `fcallCommandGeneric`) and has been
unchanged from Redis 7.0 through the current unstable branch. Verified
across Redis 7.0, 7.2, 7.4, and 8.0-M04. Other FUNCTION-related commands
emit distinct messages (`"Library not found"`, `"Engine '...' not found"`,
`"Library '...' already exists"`, `"Missing library metadata"`), so
`startsWith("ERR Function not found")` is precise with no false-positive
risk.

## Changes

- `RedisNoFunctionException.java` (new) — subtype of
  `RedisCommandExecutionException`, mirrors `RedisReadOnlyException`
- `ExceptionFactory.createExecutionException` — new mapping branch for
  `"ERR Function not found"` prefix
- `ExceptionFactoryUnitTests` — unit tests for the new mapping, including
  a negative test that other `ERR` messages are not misclassified

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/redis/lettuce/blob/main/.github/CONTRIBUTING.md) guide.
- [x] I have opened a feature request ticket before this pull request (#3717).
- [x] I have applied `mvn formatter:format`; no format-only changes are included.
- [x] I have added unit tests covering the new behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: introduces a new exception subtype and a narrow message-to-exception mapping (`ERR Function not found`), with unit tests to prevent misclassification of other `ERR` messages.
> 
> **Overview**
> Adds a new `RedisNoFunctionException` to represent Redis `ERR Function not found` errors from `FCALL`/`FCALL_RO`.
> 
> Updates `ExceptionFactory.createExecutionException` to return this new subtype when the error message starts with `ERR Function not found`, and extends `ExceptionFactoryUnitTests` to verify the mapping (including negative tests for other `ERR ... not found` messages).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9829ce772d8083b7df0e20f1127de0dcc758d5d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->