### PR TITLE
Fix 'occured' -> 'occurred' typo in Endpoint javadoc

### DIFF
--- a/src/main/java/io/lettuce/core/protocol/Endpoint.java
+++ b/src/main/java/io/lettuce/core/protocol/Endpoint.java
@@ -32,7 +32,7 @@ public interface Endpoint extends PushHandler {
     void notifyChannelInactive(Channel channel);
 
     /**
-     * Notify about an exception occured in channel/command processing
+     * Notify about an exception occurred in channel/command processing
      *
      * @param t the Exception
      */


### PR DESCRIPTION
The `Endpoint` interface javadoc on the channel/command exception notifier in `src/main/java/io/lettuce/core/protocol/Endpoint.java:35` used `an exception occured in channel/command processing`. Doc-only Java change inside a `/** */` block.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc-only change that corrects a spelling typo in a Javadoc comment; no functional or behavioral impact.
> 
> **Overview**
> Fixes a spelling typo in the `Endpoint` interface Javadoc by changing “exception occured” to “exception occurred” in the `notifyException` comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50db513418b2e18969caa2eca53b375253184ab8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->