### PR TITLE
Bump Netty 4.2.12.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <micrometer.version>1.14.2</micrometer.version>
         <micrometer-tracing.version>1.2.4</micrometer-tracing.version>
         <mockito.version>4.9.0</mockito.version>
-        <netty.version>4.2.5.Final</netty.version>
+        <netty.version>4.2.12.Final</netty.version>
         <openwebbeans.version>2.0.27</openwebbeans.version>
         <reactor.version>3.6.6</reactor.version>
         <rxjava.version>1.3.8</rxjava.version>


### PR DESCRIPTION
Closes #3722 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Netty is a core networking dependency, so even a patch upgrade can change runtime behavior/performance and should be validated with integration tests.
> 
> **Overview**
> Updates `pom.xml` to bump the managed Netty version from `4.2.5.Final` to `4.2.12.Final`, affecting all Netty artifacts pulled in via `netty-bom` and related dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b04cbf9a666f0e075852baae62dd8a9bf8126fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->