### PR TITLE
Fix failing sort command test caused by data interference through shared key

### DIFF
--- a/src/test/java/io/lettuce/core/commands/SortCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/SortCommandIntegrationTests.java
@@ -50,6 +50,8 @@ public class SortCommandIntegrationTests extends TestSupport {
 
     private final RedisCommands<String, String> redis;
 
+    private final String key = "sort-command-key";
+
     @Inject
     protected SortCommandIntegrationTests(RedisCommands<String, String> redis) {
         this.redis = redis;


### PR DESCRIPTION
Sort commands test (`SortCommandIntegrationTests.sortGet` in particular) [consistently fails](https://github.com/redis/lettuce/actions/runs/24487440891/job/71565359402) on the pipeline, while there is no issue with local runs and debug sessions.

```
Error:  Tests run: 12, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.060 s <<< FAILURE! -- in io.lettuce.core.commands.SortCommandIntegrationTests
Error:  io.lettuce.core.commands.SortCommandIntegrationTests.sortGet -- Time elapsed: 0.005 s <<< FAILURE!
org.opentest4j.AssertionFailedError: 

expected: ["foo", "bar"]
 but was: ["bar"]
	at sun.reflect.GeneratedConstructorAccessor108.newInstance(Unknown Source)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at io.lettuce.core.commands.SortCommandIntegrationTests.sortGet(SortCommandIntegrationTests.java:112)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
```

Turns out it always fails due to missing first item in the [relevant list](https://github.com/redis/lettuce/blob/c294228a2cc99d61eb5f6b0a7717266b59c0bae0/src/test/java/io/lettuce/core/commands/SortCommandIntegrationTests.java#L109), issued in the test, which suggests the test data is affected by some other test/component in the env.

```java
    @Test
    void sortGet() {
        redis.rpush(key, "1", "2");
        redis.set("obj_1", "foo");
        redis.set("obj_2", "bar");
        assertThat(redis.sort(key, get("obj_*"))).isEqualTo(list("foo", "bar"));
    }
```
    
To avoid this, replacing the exsiting common key(from base class) with a distinct one looks like the quick fix.

**For the long term**, all async operations that changes data as part of test requirements should be tracked and either awaited to ensure completion before assertions, or rolled back after the test to leave the shared state clean for subsequent tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that only affects key naming; no production code or behavior is modified.
> 
> **Overview**
> Fixes flaky `SortCommandIntegrationTests` by switching the test data key from the shared `TestSupport.key` constant to a dedicated per-test class key (`"sort-command-key"`), reducing the chance of interference from other tests running in the same Redis instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6871fc51af41c5d1065c34b71675af55ea6943a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->