### PR TITLE
Some more flakes that were happening tha last few days

### DIFF
--- a/src/test/java/io/lettuce/authx/TokenBasedRedisCredentialsProviderTest.java
+++ b/src/test/java/io/lettuce/authx/TokenBasedRedisCredentialsProviderTest.java
@@ -1,8 +1,10 @@
 package io.lettuce.authx;
 
+import io.lettuce.TestTags;
 import io.lettuce.core.RedisCredentials;
 import io.lettuce.core.TestTokenManager;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
@@ -18,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@Tag(TestTags.UNIT_TEST)
 public class TokenBasedRedisCredentialsProviderTest {
 
     private TestTokenManager tokenManager;

--- a/src/test/java/io/lettuce/core/AbstractRedisAsyncCommandsTest.java
+++ b/src/test/java/io/lettuce/core/AbstractRedisAsyncCommandsTest.java
@@ -15,12 +15,14 @@ import io.lettuce.core.protocol.Command;
 import io.lettuce.core.protocol.CommandType;
 import io.lettuce.core.protocol.RedisCommand;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.concurrent.CompletableFuture;
 
+import static io.lettuce.TestTags.UNIT_TEST;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -30,6 +32,7 @@ import static org.mockito.Mockito.*;
  *
  * @author Aleksandar Todorov
  */
+@Tag(UNIT_TEST)
 class AbstractRedisAsyncCommandsTest {
 
     @Mock

--- a/src/test/java/io/lettuce/core/AbstractRedisReactiveCommandsTest.java
+++ b/src/test/java/io/lettuce/core/AbstractRedisReactiveCommandsTest.java
@@ -6,6 +6,7 @@
  */
 package io.lettuce.core;
 
+import io.lettuce.TestTags;
 import io.lettuce.core.cluster.RedisAdvancedClusterReactiveCommandsImpl;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.codec.StringCodec;
@@ -13,6 +14,7 @@ import io.lettuce.core.protocol.RedisCommand;
 import io.lettuce.core.resource.ClientResources;
 import io.lettuce.core.tracing.Tracing;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -29,6 +31,7 @@ import static org.mockito.Mockito.*;
  *
  * @author Aleksandar Todorov
  */
+@Tag(TestTags.UNIT_TEST)
 class AbstractRedisReactiveCommandsTest {
 
     @Mock

--- a/src/test/java/io/lettuce/core/MaintNotificationsConfigUnitTests.java
+++ b/src/test/java/io/lettuce/core/MaintNotificationsConfigUnitTests.java
@@ -13,13 +13,16 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 
 import io.lettuce.core.MaintNotificationsConfig.EndpointTypeSource;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.lettuce.TestTags;
 import io.lettuce.core.MaintNotificationsConfig.EndpointType;
 
 /**
  * Unit tests for {@link MaintNotificationsConfig}.
  */
+@Tag(TestTags.UNIT_TEST)
 class MaintNotificationsConfigUnitTests {
 
     @Test

--- a/src/test/java/io/lettuce/core/MtlsClientAuthIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/MtlsClientAuthIntegrationTests.java
@@ -16,8 +16,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Path;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.lettuce.TestTags;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.test.condition.RedisConditions;
@@ -30,6 +32,7 @@ import io.lettuce.test.condition.RedisConditions;
  *
  * @author Aleksandar Todorov
  */
+@Tag(TestTags.INTEGRATION_TEST)
 class MtlsClientAuthIntegrationTests extends AbstractMtlsClientAuthIntegrationTests {
 
     private RedisClient redisClient;

--- a/src/test/java/io/lettuce/core/MtlsClientAuthResp2IntegrationTests.java
+++ b/src/test/java/io/lettuce/core/MtlsClientAuthResp2IntegrationTests.java
@@ -6,6 +6,9 @@
  */
 package io.lettuce.core;
 
+import org.junit.jupiter.api.Tag;
+
+import io.lettuce.TestTags;
 import io.lettuce.core.protocol.ProtocolVersion;
 
 /**
@@ -16,6 +19,7 @@ import io.lettuce.core.protocol.ProtocolVersion;
  *
  * @author Aleksandar Todorov
  */
+@Tag(TestTags.INTEGRATION_TEST)
 class MtlsClientAuthResp2IntegrationTests extends MtlsClientAuthIntegrationTests {
 
     @Override

--- a/src/test/java/io/lettuce/core/RedisHandshakeUnitTests.java
+++ b/src/test/java/io/lettuce/core/RedisHandshakeUnitTests.java
@@ -148,9 +148,7 @@ class RedisHandshakeUnitTests {
         CompletionStage<Void> handshakeInit = handshake.initialize(channel);
         cp.completeCredentials(RedisCredentials.just("foo", "bar"));
 
-        Awaitility.await().atMost(100, MILLISECONDS) // Wait up to 5 seconds
-                .pollInterval(5, MILLISECONDS) // Poll every 50 milliseconds
-                .until(() -> !channel.outboundMessages().isEmpty());
+        Awaitility.await().atMost(5, SECONDS).pollInterval(50, MILLISECONDS).until(() -> !channel.outboundMessages().isEmpty());
 
         AsyncCommand<String, String, Map<String, String>> hello = channel.readOutbound();
         helloResponse(hello.getOutput());

--- a/src/test/java/io/lettuce/core/cluster/ClusterMtlsClientAuthIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/ClusterMtlsClientAuthIntegrationTests.java
@@ -6,6 +6,7 @@
  */
 package io.lettuce.core.cluster;
 
+import static io.lettuce.TestTags.INTEGRATION_TEST;
 import static io.lettuce.test.settings.TestSettings.host;
 import static io.lettuce.test.settings.TestSettings.mtlsClusterPort;
 import static io.lettuce.test.settings.TlsSettings.ClientCertificate;
@@ -17,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.file.Path;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.lettuce.core.AbstractMtlsClientAuthIntegrationTests;
@@ -39,6 +41,7 @@ import io.lettuce.test.condition.RedisConditions;
  *
  * @author Aleksandar Todorov
  */
+@Tag(INTEGRATION_TEST)
 class ClusterMtlsClientAuthIntegrationTests extends AbstractMtlsClientAuthIntegrationTests {
 
     private RedisClusterClient redisClusterClient;

--- a/src/test/java/io/lettuce/core/cluster/RedisAdvancedClusterAsyncCommandsImplTest.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisAdvancedClusterAsyncCommandsImplTest.java
@@ -17,6 +17,7 @@ import io.lettuce.core.protocol.ConnectionIntent;
 import io.lettuce.core.search.AggregationReply;
 import io.lettuce.core.search.arguments.AggregateArgs;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -34,10 +35,12 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
+import static io.lettuce.TestTags.UNIT_TEST;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+@Tag(UNIT_TEST)
 class RedisAdvancedClusterAsyncCommandsImplTest {
 
     @Spy

--- a/src/test/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImplTest.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImplTest.java
@@ -3,6 +3,7 @@
  */
 package io.lettuce.core.cluster;
 
+import io.lettuce.TestTags;
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
@@ -18,6 +19,7 @@ import io.lettuce.core.search.arguments.AggregateArgs;
 import io.lettuce.test.LoggingTestUtils;
 import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -34,6 +36,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+@Tag(TestTags.UNIT_TEST)
 class RedisAdvancedClusterReactiveCommandsImplTest {
 
     private RedisAdvancedClusterReactiveCommandsImpl<String, String> reactive;

--- a/src/test/java/io/lettuce/core/cluster/RedisClusterSetupIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisClusterSetupIntegrationTests.java
@@ -273,7 +273,7 @@ public class RedisClusterSetupIntegrationTests extends TestSupport {
                 }
 
                 return false;
-            }).waitOrTimeout();
+            }).during(Duration.ofSeconds(30)).waitOrTimeout();
 
             assertThat(partitions.getPartitionBySlot(0).getSlots().size()).isEqualTo(16384);
 

--- a/src/test/java/io/lettuce/core/cluster/pubsub/RedisClusterPubSubConnectionIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/pubsub/RedisClusterPubSubConnectionIntegrationTests.java
@@ -184,6 +184,7 @@ class RedisClusterPubSubConnectionIntegrationTests extends TestSupport {
     void publishToShardChannelViaNewClient() throws Exception {
         pubSubConnection.addListener(connectionListener);
         pubSubConnection.async().ssubscribe(shardChannel);
+        Wait.untilEquals(shardChannel, connectionListener.getShardChannels()::poll).waitOrTimeout();
 
         StatefulRedisClusterPubSubConnection<String, String> newPubsub = clusterClientWithNoRedirects.connectPubSub();
         newPubsub.async().spublish(shardChannel, shardMessage);

--- a/src/test/java/io/lettuce/core/datastructure/queue/HashIndexedQueueTests.java
+++ b/src/test/java/io/lettuce/core/datastructure/queue/HashIndexedQueueTests.java
@@ -4,8 +4,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.NoSuchElementException;
 
+import io.lettuce.TestTags;
 import io.lettuce.test.LettuceExtension;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tag(TestTags.UNIT_TEST)
 @SuppressWarnings("ConstantValue")
 @ExtendWith(LettuceExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/src/test/java/io/lettuce/core/failover/ConnectionInitializationContextUnitTests.java
+++ b/src/test/java/io/lettuce/core/failover/ConnectionInitializationContextUnitTests.java
@@ -9,9 +9,11 @@ import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import io.lettuce.TestTags;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.failover.AbstractRedisMultiDbConnectionBuilder.DatabaseFutureMap;
@@ -27,6 +29,7 @@ import io.lettuce.core.failover.health.HealthStatus;
  * @author Ali Takavci
  * @since 7.4
  */
+@Tag(TestTags.UNIT_TEST)
 @DisplayName("ConnectionInitializationContext Unit Tests")
 class ConnectionInitializationContextUnitTests {
 

--- a/src/test/java/io/lettuce/core/failover/MultiDbClientIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/failover/MultiDbClientIntegrationTests.java
@@ -13,8 +13,10 @@ import java.util.stream.StreamSupport;
 
 import org.awaitility.Durations;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.lettuce.TestTags;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.failover.api.DatabaseConfig;
@@ -40,6 +42,7 @@ import io.lettuce.core.failover.api.StatefulRedisMultiDbConnection;
  * @author Ivo Gaydazhiev (original)
  * @author Ali Takavci (adapted)
  */
+@Tag(TestTags.INTEGRATION_TEST)
 class MultiDbClientIntegrationTests {
 
     private MultiDbClient client;

--- a/src/test/java/io/lettuce/core/failover/api/InitializationPolicyUnitTests.java
+++ b/src/test/java/io/lettuce/core/failover/api/InitializationPolicyUnitTests.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.lettuce.TestTags;
 import io.lettuce.core.failover.api.InitializationPolicy.Decision;
 
 /**
@@ -22,6 +24,7 @@ import io.lettuce.core.failover.api.InitializationPolicy.Decision;
  * @author Ali Takavci
  * @since 7.4
  */
+@Tag(TestTags.UNIT_TEST)
 @DisplayName("InitializationPolicy Unit Tests")
 class InitializationPolicyUnitTests {
 

--- a/src/test/java/io/lettuce/core/failover/health/HealthCheckCollectionUnitTests.java
+++ b/src/test/java/io/lettuce/core/failover/health/HealthCheckCollectionUnitTests.java
@@ -4,10 +4,12 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import io.lettuce.TestTags;
 import io.lettuce.core.RedisURI;
 
 /**
@@ -15,6 +17,7 @@ import io.lettuce.core.RedisURI;
  *
  * @author Ivo Gaydazhiev
  */
+@Tag(TestTags.UNIT_TEST)
 class HealthCheckCollectionUnitTests {
 
     @Mock

--- a/src/test/java/io/lettuce/core/failover/health/HealthCheckImplProbingPolicyUnitTests.java
+++ b/src/test/java/io/lettuce/core/failover/health/HealthCheckImplProbingPolicyUnitTests.java
@@ -7,9 +7,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import io.lettuce.TestTags;
 import io.lettuce.core.RedisURI;
 
 /**
@@ -18,6 +20,7 @@ import io.lettuce.core.RedisURI;
  * @author Ali Takavci
  * @author Ivo Gaydazhiev
  */
+@Tag(TestTags.UNIT_TEST)
 class HealthCheckImplProbingPolicyUnitTests {
 
     private RedisURI testEndpoint;

--- a/src/test/java/io/lettuce/core/failover/health/HealthCheckImplRetryLogicUnitTests.java
+++ b/src/test/java/io/lettuce/core/failover/health/HealthCheckImplRetryLogicUnitTests.java
@@ -12,8 +12,10 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.lettuce.TestTags;
 import io.lettuce.core.RedisURI;
 
 /**
@@ -21,6 +23,7 @@ import io.lettuce.core.RedisURI;
  *
  * @author Ivo Gaydazhiev
  */
+@Tag(TestTags.UNIT_TEST)
 class HealthCheckImplRetryLogicUnitTests {
 
     private RedisURI testEndpoint;

--- a/src/test/java/io/lettuce/core/failover/health/HealthCheckImplUnitTests.java
+++ b/src/test/java/io/lettuce/core/failover/health/HealthCheckImplUnitTests.java
@@ -11,10 +11,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import io.lettuce.TestTags;
 import io.lettuce.core.RedisURI;
 
 /**
@@ -22,6 +24,7 @@ import io.lettuce.core.RedisURI;
  *
  * @author Ivo Gaydazhiev
  */
+@Tag(TestTags.UNIT_TEST)
 class HealthCheckImplUnitTests {
 
     @Mock

--- a/src/test/java/io/lettuce/core/failover/health/PingStrategyTest.java
+++ b/src/test/java/io/lettuce/core/failover/health/PingStrategyTest.java
@@ -6,11 +6,13 @@ import static org.mockito.Mockito.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import io.lettuce.TestTags;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.sync.RedisCommands;
@@ -21,6 +23,7 @@ import io.lettuce.core.failover.api.RawConnectionFactory;
  *
  * @author Ivo Gaydazhiev
  */
+@Tag(TestTags.UNIT_TEST)
 @ExtendWith(MockitoExtension.class)
 @DisplayName("PingStrategy Unit Tests")
 class PingStrategyTest {

--- a/src/test/java/io/lettuce/core/internal/NetUtilsUnitTests.java
+++ b/src/test/java/io/lettuce/core/internal/NetUtilsUnitTests.java
@@ -13,11 +13,15 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import io.lettuce.TestTags;
 
 /**
  * Unit tests for {@link NetUtils}.
  */
+@Tag(TestTags.UNIT_TEST)
 class NetUtilsUnitTests {
 
     @Test

--- a/src/test/java/io/lettuce/core/models/stream/StreamEntryDeletionResultUnitTests.java
+++ b/src/test/java/io/lettuce/core/models/stream/StreamEntryDeletionResultUnitTests.java
@@ -9,11 +9,15 @@ package io.lettuce.core.models.stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import io.lettuce.TestTags;
 
 /**
  * Unit tests for {@link StreamEntryDeletionResult}.
  */
+@Tag(TestTags.UNIT_TEST)
 class StreamEntryDeletionResultUnitTests {
 
     @Test

--- a/src/test/java/io/lettuce/core/output/StreamEntryDeletionResultListOutputUnitTests.java
+++ b/src/test/java/io/lettuce/core/output/StreamEntryDeletionResultListOutputUnitTests.java
@@ -11,14 +11,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Collection;
 import java.util.List;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.lettuce.TestTags;
 import io.lettuce.core.codec.StringCodec;
 import io.lettuce.core.models.stream.StreamEntryDeletionResult;
 
 /**
  * Unit tests for {@link StreamEntryDeletionResultListOutput}.
  */
+@Tag(TestTags.UNIT_TEST)
 class StreamEntryDeletionResultListOutputUnitTests {
 
     private StreamEntryDeletionResultListOutput<String, String> output = new StreamEntryDeletionResultListOutput<>(

--- a/src/test/java/io/lettuce/core/output/StringMatchResultOutputUnitTests.java
+++ b/src/test/java/io/lettuce/core/output/StringMatchResultOutputUnitTests.java
@@ -10,13 +10,16 @@ import java.util.List;
 import java.util.Map;
 
 import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.lettuce.TestTags;
 import io.lettuce.core.StringMatchResult;
 import io.lettuce.core.codec.StringCodec;
 import io.lettuce.core.protocol.ProtocolVersion;
 import io.lettuce.core.protocol.RedisStateMachine;
 
+@Tag(TestTags.UNIT_TEST)
 public class StringMatchResultOutputUnitTests {
 
     @Test

--- a/src/test/java/io/lettuce/core/resource/Netty42CompatibilityTest.java
+++ b/src/test/java/io/lettuce/core/resource/Netty42CompatibilityTest.java
@@ -6,8 +6,10 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.lettuce.TestTags;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
@@ -26,10 +28,11 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 
 /**
  * Test to reproduce Netty 4.2 compatibility issues between application event loops and Lettuce's internal event loops.
- * 
+ *
  * This test simulates a real-world scenario where an application (e.g., a Netty server) uses Netty event loops and also uses
  * Lettuce to connect to Redis.
  */
+@Tag(TestTags.INTEGRATION_TEST)
 class Netty42CompatibilityTest {
 
     private static final String host = TestSettings.host();

--- a/src/test/java/io/lettuce/core/search/RediSearchAggregateIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/search/RediSearchAggregateIntegrationTests.java
@@ -19,11 +19,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import io.lettuce.TestTags;
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.TestSupport;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.lettuce.core.api.StatefulRedisConnection;
@@ -47,6 +49,7 @@ import io.lettuce.core.search.arguments.TextFieldArgs;
  *
  * @author Tihomir Mateev
  */
+@Tag(TestTags.INTEGRATION_TEST)
 class RediSearchAggregateIntegrationTests extends TestSupport {
 
     private final RedisClient client;

--- a/src/test/java/io/lettuce/core/search/SearchResultsTest.java
+++ b/src/test/java/io/lettuce/core/search/SearchResultsTest.java
@@ -12,13 +12,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import io.lettuce.TestTags;
 
 /**
  * Unit tests for {@link SearchReply}.
  *
  * @author Tihomir Mateev
  */
+@Tag(TestTags.UNIT_TEST)
 class SearchResultsTest {
 
     @Test

--- a/src/test/java/io/lettuce/core/search/arguments/SearchArgsTest.java
+++ b/src/test/java/io/lettuce/core/search/arguments/SearchArgsTest.java
@@ -11,8 +11,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.lettuce.TestTags;
 import io.lettuce.core.codec.StringCodec;
 import io.lettuce.core.protocol.CommandArgs;
 
@@ -21,6 +23,7 @@ import io.lettuce.core.protocol.CommandArgs;
  *
  * @author Tihomir Mateev
  */
+@Tag(TestTags.UNIT_TEST)
 class SearchArgsTest {
 
     @Test


### PR DESCRIPTION
These happened during the last few days, both issues are related to timeouts happening in the CI due to the slower infrastructure.

#### Flaky test `RedisClusterPubSubConnectionIntegrationTests#publishToShardChannelViaNewClient`
```java
[INFO] Running io.lettuce.core.cluster.pubsub.RedisClusterPubSubConnectionIntegrationTests
Error:  Tests run: 22, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 10.57 s <<< FAILURE! -- in io.lettuce.core.cluster.pubsub.RedisClusterPubSubConnectionIntegrationTests
Error:  io.lettuce.core.cluster.pubsub.RedisClusterPubSubConnectionIntegrationTests.publishToShardChannelViaNewClient -- Time elapsed: 10.02 s <<< ERROR!
java.lang.IllegalStateException: java.util.concurrent.TimeoutException: Objects are not equal: shard msg! and null
	at io.lettuce.test.Wait$Waiter.waitOrTimeout(Wait.java:251)
	at io.lettuce.test.Wait$Waiter.access$900(Wait.java:233)
	at io.lettuce.test.Wait$WaitBuilder.waitOrTimeout(Wait.java:224)
	at io.lettuce.core.cluster.pubsub.RedisClusterPubSubConnectionIntegrationTests.publishToShardChannelViaNewClient(RedisClusterPubSubConnectionIntegrationTests.java:191)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
Caused by: java.util.concurrent.TimeoutException: Objects are not equal: shard msg! and null
	at io.lettuce.test.Wait$Waiter.waitOrTimeout(Wait.java:246)
	... 6 more
```

#### Flaky test `RedisClusterSetupIntegrationTests#changeTopologyWhileOperations`
```java
Error:  Tests run: 18, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 23.74 s <<< FAILURE! -- in io.lettuce.core.cluster.RedisClusterSetupIntegrationTests
Error:  io.lettuce.core.cluster.RedisClusterSetupIntegrationTests.changeTopologyWhileOperations -- Time elapsed: 10.86 s <<< ERROR!
java.lang.IllegalStateException: java.util.concurrent.TimeoutException: Condition not satisfied for: false
	at io.lettuce.test.Wait$Waiter.waitOrTimeout(Wait.java:251)
	at io.lettuce.test.Wait$Waiter.access$900(Wait.java:233)
	at io.lettuce.test.Wait$WaitBuilder.waitOrTimeout(Wait.java:224)
	at io.lettuce.core.cluster.RedisClusterSetupIntegrationTests.changeTopologyWhileOperations(RedisClusterSetupIntegrationTests.java:276)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
Caused by: java.util.concurrent.TimeoutException: Condition not satisfied for: false
	at io.lettuce.test.Wait$Waiter.waitOrTimeout(Wait.java:248)
	... 6 more
```

#### Flaky test `RedisHandshakeUnitTests#handshakeDelayedCredentialProvider`
```java

```


<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test code, mainly adding JUnit `@Tag`s and loosening/widening waits/timeouts to reduce CI flakes. Low risk aside from potentially masking real timing issues by waiting longer.
> 
> **Overview**
> Reduces CI flakes by standardizing JUnit 5 tagging across many test classes using `@Tag(TestTags.UNIT_TEST)`/`@Tag(TestTags.INTEGRATION_TEST)` (including static import usage where appropriate).
> 
> Adjusts a few timing-sensitive tests to be more tolerant on slow CI: increases Awaitility wait/poll settings in `RedisHandshakeUnitTests`, adds an explicit `during(Duration.ofSeconds(30))` window for a cluster topology wait in `RedisClusterSetupIntegrationTests`, and ensures shard-channel subscription is observed before publishing in `RedisClusterPubSubConnectionIntegrationTests`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdd1ea6985aa00abec8f6acf3b558b54b21788f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->