### PR TITLE
Fix recursive update in AsyncConnectionProvider

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/PooledClusterConnectionProvider.java
+++ b/src/main/java/io/lettuce/core/cluster/PooledClusterConnectionProvider.java
@@ -19,6 +19,8 @@
  */
 package io.lettuce.core.cluster;
 
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -96,7 +98,7 @@ class PooledClusterConnectionProvider<K, V>
 
     private final RedisCodec<K, V> redisCodec;
 
-    private final AsyncConnectionProvider<ConnectionKey, StatefulRedisConnection<K, V>, ConnectionFuture<StatefulRedisConnection<K, V>>> connectionProvider;
+    private final AsyncConnectionProvider<ConnectionKey, StatefulRedisConnection<K, V>> connectionProvider;
 
     private Partitions partitions;
 
@@ -113,7 +115,8 @@ class PooledClusterConnectionProvider<K, V>
         this.clusterWriter = clusterWriter;
         this.clusterEventListener = clusterEventListener;
         this.connectionFactory = new NodeConnectionPostProcessor(getConnectionFactory(redisClusterClient));
-        this.connectionProvider = new AsyncConnectionProvider<>(this.connectionFactory);
+        this.connectionProvider = new AsyncConnectionProvider<>(this.connectionFactory,
+                redisClusterClient.getResources().eventExecutorGroup());
     }
 
     @Override
@@ -442,6 +445,7 @@ class PooledClusterConnectionProvider<K, V>
             logger.debug("getConnection(" + connectionIntent + ", " + nodeId + ")");
         }
 
+        beforeGetConnection(nodeId);
         return getConnection(new ConnectionKey(connectionIntent, nodeId));
     }
 
@@ -453,20 +457,21 @@ class PooledClusterConnectionProvider<K, V>
             logger.debug("getConnection(" + connectionIntent + ", " + nodeId + ")");
         }
 
+        beforeGetConnection(nodeId);
         return getConnectionAsync(new ConnectionKey(connectionIntent, nodeId)).toCompletableFuture();
     }
 
     protected ConnectionFuture<StatefulRedisConnection<K, V>> getConnectionAsync(ConnectionKey key) {
 
-        ConnectionFuture<StatefulRedisConnection<K, V>> connectionFuture = connectionProvider.getConnection(key);
+        SocketAddress remoteAddress = getRemoteAddress(key);
+        CompletableFuture<StatefulRedisConnection<K, V>> connectionFuture = connectionProvider.getConnection(key);
         CompletableFuture<StatefulRedisConnection<K, V>> result = new CompletableFuture<>();
 
         connectionFuture.handle((connection, throwable) -> {
 
             if (throwable != null) {
 
-                result.completeExceptionally(
-                        RedisConnectionException.create(connectionFuture.getRemoteAddress(), Exceptions.bubble(throwable)));
+                result.completeExceptionally(RedisConnectionException.create(remoteAddress, Exceptions.bubble(throwable)));
             } else {
                 result.complete(connection);
             }
@@ -474,7 +479,7 @@ class PooledClusterConnectionProvider<K, V>
             return null;
         });
 
-        return ConnectionFuture.from(connectionFuture.getRemoteAddress(), result);
+        return ConnectionFuture.from(remoteAddress, result);
     }
 
     @Override
@@ -510,12 +515,39 @@ class PooledClusterConnectionProvider<K, V>
         try {
             beforeGetConnection(connectionIntent, host, port);
 
-            return connectionProvider.getConnection(new ConnectionKey(connectionIntent, host, port)).toCompletableFuture();
+            return connectionProvider.getConnection(new ConnectionKey(connectionIntent, host, port));
         } catch (RedisException e) {
             throw e;
         } catch (RuntimeException e) {
             throw new RedisException(e);
         }
+    }
+
+    private void beforeGetConnection(String nodeId) {
+
+        RedisClusterNode redisClusterNode = partitions.getPartitionByNodeId(nodeId);
+
+        if (redisClusterNode == null) {
+            clusterEventListener.onUnknownNode();
+            throw connectionAttemptRejected("node id " + nodeId);
+        }
+    }
+
+    private SocketAddress getRemoteAddress(ConnectionKey key) {
+
+        if (key.host != null) {
+            return InetSocketAddress.createUnresolved(key.host, key.port);
+        }
+
+        if (key.nodeId != null && partitions != null) {
+            RedisClusterNode partition = partitions.getPartitionByNodeId(key.nodeId);
+            if (partition != null) {
+                RedisURI uri = partition.getUri();
+                return InetSocketAddress.createUnresolved(uri.getHost(), uri.getPort());
+            }
+        }
+
+        return null;
     }
 
     private void beforeGetConnection(ConnectionIntent connectionIntent, String host, int port) {

--- a/src/main/java/io/lettuce/core/internal/AsyncConnectionProvider.java
+++ b/src/main/java/io/lettuce/core/internal/AsyncConnectionProvider.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.BiConsumer;
@@ -26,14 +27,15 @@ import java.util.function.Function;
  * @author Mark Paluch
  * @param <T> connection type.
  * @param <K> connection key type.
- * @param <F> type of the {@link CompletionStage} handle of the connection progress.
  * @since 5.1
  */
-public class AsyncConnectionProvider<K, T extends AsyncCloseable, F extends CompletionStage<T>> {
+public class AsyncConnectionProvider<K, T extends AsyncCloseable> {
 
-    private final Function<K, F> connectionFactory;
+    private final Function<K, ? extends CompletionStage<T>> connectionFactory;
 
-    private final Map<K, Sync<K, T, F>> connections = new ConcurrentHashMap<>();
+    private final Executor connectStarter;
+
+    private final Map<K, Sync<K, T>> connections = new ConcurrentHashMap<>();
 
     private volatile boolean closed;
 
@@ -41,12 +43,17 @@ public class AsyncConnectionProvider<K, T extends AsyncCloseable, F extends Comp
      * Create a new {@link AsyncConnectionProvider}.
      *
      * @param connectionFactory must not be {@code null}.
+     * @param connectStarter executor used to start new connection attempts, must not be {@code null}.
      */
     @SuppressWarnings("unchecked")
-    public AsyncConnectionProvider(Function<? extends K, ? extends F> connectionFactory) {
+    public AsyncConnectionProvider(Function<? extends K, ? extends CompletionStage<T>> connectionFactory,
+            Executor connectStarter) {
 
         LettuceAssert.notNull(connectionFactory, "AsyncConnectionProvider must not be null");
-        this.connectionFactory = (Function<K, F>) connectionFactory;
+        LettuceAssert.notNull(connectStarter, "ConnectStarter must not be null");
+
+        this.connectionFactory = (Function<K, ? extends CompletionStage<T>>) connectionFactory;
+        this.connectStarter = connectStarter;
     }
 
     /**
@@ -56,8 +63,8 @@ public class AsyncConnectionProvider<K, T extends AsyncCloseable, F extends Comp
      * @param key the connection {@code key}, must not be {@code null}.
      * @return
      */
-    public F getConnection(K key) {
-        return getSynchronizer(key).getConnection();
+    public CompletableFuture<T> getConnection(K key) {
+        return getSynchronizer(key).createWaiter();
     }
 
     /**
@@ -66,42 +73,67 @@ public class AsyncConnectionProvider<K, T extends AsyncCloseable, F extends Comp
      * @param key the connection {@code key}.
      * @return
      */
-    private Sync<K, T, F> getSynchronizer(K key) {
+    private Sync<K, T> getSynchronizer(K key) {
 
         if (closed) {
             throw new IllegalStateException("ConnectionProvider is already closed");
         }
 
-        Sync<K, T, F> sync = connections.get(key);
+        Sync<K, T> sync = connections.get(key);
 
         if (sync != null) {
             return sync;
         }
 
-        AtomicBoolean atomicBoolean = new AtomicBoolean();
+        Sync<K, T> placeholder = new Sync<>(key);
+        Sync<K, T> existing = connections.putIfAbsent(key, placeholder);
 
-        sync = connections.computeIfAbsent(key, connectionKey -> {
-
-            Sync<K, T, F> createdSync = new Sync<>(key, connectionFactory.apply(key));
-
-            if (closed) {
-                createdSync.cancel();
-            }
-
-            return createdSync;
-        });
-
-        if (atomicBoolean.compareAndSet(false, true)) {
-
-            sync.getConnection().whenComplete((c, t) -> {
-
-                if (t != null) {
-                    connections.remove(key);
-                }
-            });
+        if (existing != null) {
+            return existing;
         }
 
-        return sync;
+        placeholder.getSharedConnection().whenComplete((value, error) -> {
+            if (error != null) {
+                connections.remove(key, placeholder);
+            }
+        });
+
+        if (closed) {
+            connections.remove(key, placeholder);
+            placeholder.close();
+            return placeholder;
+        }
+
+        try {
+            connectStarter.execute(() -> startConnect(key, placeholder));
+        } catch (Throwable t) {
+            placeholder.completeExceptionally(t);
+        }
+
+        return placeholder;
+    }
+
+    private void startConnect(K key, Sync<K, T> sync) {
+
+        if (closed || sync.isCloseRequested()) {
+            sync.completeCloseWithoutConnection();
+            return;
+        }
+
+        sync.markConnectStarted();
+
+        if (closed || sync.isCloseRequested()) {
+            sync.completeCloseWithoutConnection();
+            return;
+        }
+
+        try {
+            CompletionStage<T> connection = connectionFactory.apply(key);
+            LettuceAssert.notNull(connection, "ConnectionFuture must not be null");
+            sync.attach(connection);
+        } catch (Throwable t) {
+            sync.completeExceptionally(t);
+        }
     }
 
     /**
@@ -135,17 +167,16 @@ public class AsyncConnectionProvider<K, T extends AsyncCloseable, F extends Comp
     /**
      * Close all connections. Pending connections are closed using future chaining.
      */
-    @SuppressWarnings("unchecked")
     public CompletableFuture<Void> close() {
 
         this.closed = true;
 
         List<CompletableFuture<Void>> futures = new ArrayList<>();
 
-        forEach((connectionKey, closeable) -> {
-
-            futures.add(closeable.closeAsync());
-            connections.remove(connectionKey);
+        connections.forEach((connectionKey, sync) -> {
+            if (connections.remove(connectionKey, sync)) {
+                futures.add(sync.close());
+            }
         });
 
         return Futures.allOf(futures);
@@ -160,10 +191,9 @@ public class AsyncConnectionProvider<K, T extends AsyncCloseable, F extends Comp
 
         LettuceAssert.notNull(key, "ConnectionKey must not be null!");
 
-        Sync<K, T, F> sync = connections.get(key);
+        Sync<K, T> sync = connections.remove(key);
         if (sync != null) {
-            connections.remove(key);
-            sync.doWithConnection(AsyncCloseable::closeAsync);
+            sync.close();
         }
     }
 
@@ -192,7 +222,7 @@ public class AsyncConnectionProvider<K, T extends AsyncCloseable, F extends Comp
         connections.forEach((key, sync) -> sync.doWithConnection(action));
     }
 
-    static class Sync<K, T extends AsyncCloseable, F extends CompletionStage<T>> {
+    static class Sync<K, T extends AsyncCloseable> {
 
         private static final int PHASE_IN_PROGRESS = 0;
 
@@ -211,23 +241,61 @@ public class AsyncConnectionProvider<K, T extends AsyncCloseable, F extends Comp
 
         private volatile T connection;
 
+        private volatile CompletableFuture<T> delegate;
+
         private final K key;
 
-        private final F future;
+        private final CompletableFuture<T> sharedConnection = new CompletableFuture<>();
 
-        @SuppressWarnings("unchecked")
-        public Sync(K key, F future) {
+        private final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
+
+        private final AtomicBoolean closeRequested = new AtomicBoolean();
+
+        private final AtomicBoolean closeStarted = new AtomicBoolean();
+
+        private final AtomicBoolean connectStarted = new AtomicBoolean();
+
+        public Sync(K key) {
+            this.key = key;
+        }
+
+        public Sync(K key, T value) {
 
             this.key = key;
-            this.future = (F) future.whenComplete((connection, throwable) -> {
+            this.connection = value;
+            this.sharedConnection.complete(value);
+            PHASE.set(this, PHASE_COMPLETE);
+        }
+
+        public void markConnectStarted() {
+            connectStarted.set(true);
+        }
+
+        public void attach(CompletionStage<T> future) {
+
+            CompletableFuture<T> delegate = future.toCompletableFuture();
+            this.delegate = delegate;
+
+            if (closeRequested.get()) {
+                delegate.cancel(false);
+            }
+
+            future.whenComplete((connection, throwable) -> {
 
                 if (throwable != null) {
 
                     if (throwable instanceof CancellationException) {
-                        PHASE.compareAndSet(this, PHASE_IN_PROGRESS, PHASE_CANCELED);
+                        if (PHASE.compareAndSet(this, PHASE_IN_PROGRESS, PHASE_CANCELED)) {
+                            sharedConnection.cancel(false);
+                        }
+                    } else if (PHASE.compareAndSet(this, PHASE_IN_PROGRESS, PHASE_FAILED)) {
+                        sharedConnection.completeExceptionally(throwable);
                     }
 
-                    PHASE.compareAndSet(this, PHASE_IN_PROGRESS, PHASE_FAILED);
+                    if (closeRequested.get()) {
+                        closeFuture.complete(null);
+                    }
+                    return;
                 }
 
                 if (PHASE.compareAndSet(this, PHASE_IN_PROGRESS, PHASE_COMPLETE)) {
@@ -235,26 +303,99 @@ public class AsyncConnectionProvider<K, T extends AsyncCloseable, F extends Comp
                     if (connection != null) {
                         Sync.this.connection = connection;
                     }
+
+                    sharedConnection.complete(connection);
+
+                    if (closeRequested.get()) {
+                        closeConnection(connection);
+                    }
+                    return;
                 }
+
+                closeConnection(connection);
             });
         }
 
-        @SuppressWarnings("unchecked")
-        public Sync(K key, T value) {
+        public void completeExceptionally(Throwable throwable) {
 
-            this.key = key;
-            this.connection = value;
-            this.future = (F) CompletableFuture.completedFuture(value);
-            PHASE.set(this, PHASE_COMPLETE);
+            if (throwable instanceof CancellationException) {
+                if (PHASE.compareAndSet(this, PHASE_IN_PROGRESS, PHASE_CANCELED)) {
+                    sharedConnection.cancel(false);
+                }
+            } else if (PHASE.compareAndSet(this, PHASE_IN_PROGRESS, PHASE_FAILED)) {
+                sharedConnection.completeExceptionally(throwable);
+            }
+
+            if (closeRequested.get()) {
+                closeFuture.complete(null);
+            }
         }
 
-        public void cancel() {
-            future.toCompletableFuture().cancel(false);
-            doWithConnection(AsyncCloseable::closeAsync);
+        public CompletableFuture<T> getSharedConnection() {
+            return sharedConnection;
         }
 
-        public F getConnection() {
-            return future;
+        public CompletableFuture<T> createWaiter() {
+
+            CompletableFuture<T> waiter = new CompletableFuture<>();
+
+            sharedConnection.whenComplete((connection, throwable) -> {
+                if (throwable != null) {
+                    if (throwable instanceof CancellationException) {
+                        waiter.cancel(false);
+                    } else {
+                        waiter.completeExceptionally(throwable);
+                    }
+                } else {
+                    waiter.complete(connection);
+                }
+            });
+
+            return waiter;
+        }
+
+        public CompletableFuture<Void> close() {
+
+            closeRequested.set(true);
+
+            while (true) {
+                int phase = PHASE.get(this);
+
+                if (phase == PHASE_COMPLETE) {
+                    closeConnection(connection);
+                    return closeFuture;
+                }
+
+                if (phase != PHASE_IN_PROGRESS) {
+                    closeFuture.complete(null);
+                    return closeFuture;
+                }
+
+                if (PHASE.compareAndSet(this, PHASE_IN_PROGRESS, PHASE_CANCELED)) {
+                    sharedConnection.cancel(false);
+                    break;
+                }
+            }
+
+            CompletableFuture<T> delegate = this.delegate;
+            if (delegate != null) {
+                delegate.cancel(false);
+            } else if (!connectStarted.get()) {
+                closeFuture.complete(null);
+            }
+
+            return closeFuture;
+        }
+
+        public boolean isCloseRequested() {
+            return closeRequested.get();
+        }
+
+        public void completeCloseWithoutConnection() {
+            if (PHASE.compareAndSet(this, PHASE_IN_PROGRESS, PHASE_CANCELED)) {
+                sharedConnection.cancel(false);
+            }
+            closeFuture.complete(null);
         }
 
         void doWithConnection(Consumer<? super T> action) {
@@ -262,7 +403,7 @@ public class AsyncConnectionProvider<K, T extends AsyncCloseable, F extends Comp
             if (isComplete()) {
                 action.accept(connection);
             } else {
-                future.thenAccept(action);
+                sharedConnection.thenAccept(action);
             }
         }
 
@@ -271,8 +412,28 @@ public class AsyncConnectionProvider<K, T extends AsyncCloseable, F extends Comp
             if (isComplete()) {
                 action.accept(key, connection);
             } else {
-                future.thenAccept(c -> action.accept(key, c));
+                sharedConnection.thenAccept(c -> action.accept(key, c));
             }
+        }
+
+        private void closeConnection(T connection) {
+
+            if (connection == null) {
+                closeFuture.complete(null);
+                return;
+            }
+
+            if (!closeStarted.compareAndSet(false, true)) {
+                return;
+            }
+
+            connection.closeAsync().whenComplete((unused, closeThrowable) -> {
+                if (closeThrowable != null) {
+                    closeFuture.completeExceptionally(closeThrowable);
+                } else {
+                    closeFuture.complete(null);
+                }
+            });
         }
 
         private boolean isComplete() {

--- a/src/main/java/io/lettuce/core/masterreplica/MasterReplicaConnectionProvider.java
+++ b/src/main/java/io/lettuce/core/masterreplica/MasterReplicaConnectionProvider.java
@@ -50,7 +50,7 @@ class MasterReplicaConnectionProvider<K, V> {
 
     private final RedisURI initialRedisUri;
 
-    private final AsyncConnectionProvider<ConnectionKey, StatefulRedisConnection<K, V>, CompletionStage<StatefulRedisConnection<K, V>>> connectionProvider;
+    private final AsyncConnectionProvider<ConnectionKey, StatefulRedisConnection<K, V>> connectionProvider;
 
     private List<RedisNodeDescription> knownNodes = new ArrayList<>();
 
@@ -68,7 +68,8 @@ class MasterReplicaConnectionProvider<K, V> {
         Function<ConnectionKey, CompletionStage<StatefulRedisConnection<K, V>>> connectionFactory = new DefaultConnectionFactory(
                 redisClient, redisCodec);
 
-        this.connectionProvider = new AsyncConnectionProvider<>(connectionFactory);
+        this.connectionProvider = new AsyncConnectionProvider<>(connectionFactory,
+                redisClient.getResources().eventExecutorGroup());
 
         for (Map.Entry<RedisURI, StatefulRedisConnection<K, V>> entry : initialConnections.entrySet()) {
             connectionProvider.register(toConnectionKey(entry.getKey()), entry.getValue());

--- a/src/test/java/io/lettuce/core/cluster/AsyncConnectionProviderIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/AsyncConnectionProviderIntegrationTests.java
@@ -71,7 +71,7 @@ class AsyncConnectionProviderIntegrationTests {
 
     private CountDownLatch connectInitiated = new CountDownLatch(1);
 
-    private AsyncConnectionProvider<ConnectionKey, StatefulRedisConnection<String, String>, ConnectionFuture<StatefulRedisConnection<String, String>>> sut;
+    private AsyncConnectionProvider<ConnectionKey, StatefulRedisConnection<String, String>> sut;
 
     @Inject
     AsyncConnectionProviderIntegrationTests(ClientResources resources) {
@@ -101,7 +101,7 @@ class AsyncConnectionProviderIntegrationTests {
                 return future;
             }
 
-        });
+        }, resources.eventExecutorGroup());
     }
 
     @AfterEach

--- a/src/test/java/io/lettuce/core/cluster/PooledClusterConnectionProviderUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/PooledClusterConnectionProviderUnitTests.java
@@ -61,6 +61,7 @@ import io.lettuce.core.protocol.Command;
 import io.lettuce.core.protocol.CommandType;
 import io.lettuce.core.protocol.ConnectionIntent;
 import io.lettuce.core.resource.ClientResources;
+import io.netty.util.concurrent.ImmediateEventExecutor;
 
 /**
  * Unit tests for {@link PooledClusterConnectionProvider}.
@@ -106,6 +107,9 @@ class PooledClusterConnectionProviderUnitTests {
     void before() {
 
         nodeConnectionMock = (StatefulRedisConnection) channelHandlerMock;
+
+        when(clientMock.getResources()).thenReturn(clientResourcesMock);
+        when(clientResourcesMock.eventExecutorGroup()).thenReturn(ImmediateEventExecutor.INSTANCE);
 
         sut = new PooledClusterConnectionProvider<>(clientMock, writerMock, StringCodec.UTF8, clusterEventListener);
 
@@ -417,6 +421,43 @@ class PooledClusterConnectionProviderUnitTests {
         sut.close();
 
         verify(channelHandlerMock).closeAsync();
+    }
+
+    @Test
+    void shouldNotPropagateCancellationToUnderlyingConnectionAttempt() {
+
+        CompletableFuture<StatefulRedisConnection<String, String>> actualConnection = new CompletableFuture<>();
+
+        when(clientMock.connectToNodeAsync(eq(StringCodec.UTF8), eq("localhost:1"), any(), any()))
+                .thenReturn(ConnectionFuture.from(socketAddressMock, actualConnection));
+
+        ConnectionFuture<StatefulRedisConnection<String, String>> future = sut
+                .getConnectionAsync(new ClusterNodeConnectionFactory.ConnectionKey(ConnectionIntent.WRITE, "localhost", 1));
+
+        assertThat(future.cancel(false)).isTrue();
+        assertThat(actualConnection.isCancelled()).isFalse();
+    }
+
+    @Test
+    void shouldAllowOtherWaitersToSucceedWhenOneIsCancelled() {
+
+        CompletableFuture<StatefulRedisConnection<String, String>> actualConnection = new CompletableFuture<>();
+
+        when(clientMock.connectToNodeAsync(eq(StringCodec.UTF8), eq("localhost:1"), any(), any()))
+                .thenReturn(ConnectionFuture.from(socketAddressMock, actualConnection));
+
+        ConnectionFuture<StatefulRedisConnection<String, String>> first = sut
+                .getConnectionAsync(new ClusterNodeConnectionFactory.ConnectionKey(ConnectionIntent.WRITE, "localhost", 1));
+        ConnectionFuture<StatefulRedisConnection<String, String>> second = sut
+                .getConnectionAsync(new ClusterNodeConnectionFactory.ConnectionKey(ConnectionIntent.WRITE, "localhost", 1));
+
+        assertThat(first.cancel(false)).isTrue();
+        assertThat(actualConnection.isCancelled()).isFalse();
+
+        actualConnection.complete(nodeConnectionMock);
+
+        assertThat(second.join()).isSameAs(nodeConnectionMock);
+        verify(clientMock, times(1)).connectToNodeAsync(eq(StringCodec.UTF8), eq("localhost:1"), any(), any());
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/internal/AsyncConnectionProviderUnitTests.java
+++ b/src/test/java/io/lettuce/core/internal/AsyncConnectionProviderUnitTests.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2011-Present, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ *
+ * This file contains contributions from third-party contributors
+ * licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.lettuce.core.internal;
+
+import static io.lettuce.TestTags.UNIT_TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link AsyncConnectionProvider}.
+ */
+@Tag(UNIT_TEST)
+class AsyncConnectionProviderUnitTests {
+
+    @Test
+    void shouldShareAcquisitionWhenConnectionFactoryReentersGetConnectionForSameKey() {
+
+        ManualExecutor connectStarter = new ManualExecutor();
+        AtomicInteger creations = new AtomicInteger();
+        CompletableFuture<TestConnection> actualConnection = new CompletableFuture<>();
+        AtomicReference<CompletableFuture<TestConnection>> reentrantLookup = new AtomicReference<>();
+        AtomicReference<AsyncConnectionProvider<String, TestConnection>> provider = new AtomicReference<>();
+
+        provider.set(new AsyncConnectionProvider<>(key -> {
+            creations.incrementAndGet();
+
+            // Simulate the connection factory requesting the same key again while the first acquisition
+            // is still in progress. Both callers should observe the same underlying connection attempt.
+            reentrantLookup.set(provider.get().getConnection(key));
+            return actualConnection;
+        }, connectStarter));
+
+        CompletableFuture<TestConnection> initialLookup = provider.get().getConnection("key");
+
+        assertThat(creations).hasValue(0);
+
+        connectStarter.runNext();
+
+        assertThat(creations).hasValue(1);
+        assertThat(reentrantLookup.get()).isNotNull();
+        assertThat(reentrantLookup.get()).isNotSameAs(initialLookup);
+
+        TestConnection connection = new TestConnection();
+        actualConnection.complete(connection);
+
+        assertThat(initialLookup).isCompletedWithValue(connection);
+        assertThat(reentrantLookup.get()).isCompletedWithValue(connection);
+    }
+
+    @Test
+    void shouldShareAcquisitionForConcurrentSameKeyCallers() throws Exception {
+
+        ManualExecutor connectStarter = new ManualExecutor();
+        AtomicInteger creations = new AtomicInteger();
+        CompletableFuture<TestConnection> actualConnection = new CompletableFuture<>();
+
+        AsyncConnectionProvider<String, TestConnection> sut = new AsyncConnectionProvider<>(key -> {
+            creations.incrementAndGet();
+            return actualConnection;
+        }, connectStarter);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<CompletableFuture<TestConnection>> first = executor.submit(() -> sut.getConnection("key"));
+            Future<CompletableFuture<TestConnection>> second = executor.submit(() -> sut.getConnection("key"));
+
+            CompletableFuture<TestConnection> firstLookup = first.get(5, TimeUnit.SECONDS);
+            CompletableFuture<TestConnection> secondLookup = second.get(5, TimeUnit.SECONDS);
+
+            assertThat(firstLookup).isNotSameAs(secondLookup);
+            assertThat(creations).hasValue(0);
+            assertThat(connectStarter.size()).isEqualTo(1);
+
+            connectStarter.runNext();
+
+            assertThat(creations).hasValue(1);
+
+            TestConnection connection = new TestConnection();
+            actualConnection.complete(connection);
+
+            assertThat(firstLookup).isCompletedWithValue(connection);
+            assertThat(secondLookup).isCompletedWithValue(connection);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void shouldRemovePlaceholderAfterSynchronousFailure() {
+
+        ManualExecutor connectStarter = new ManualExecutor();
+        AtomicInteger attempts = new AtomicInteger();
+        TestConnection connection = new TestConnection();
+
+        AsyncConnectionProvider<String, TestConnection> sut = new AsyncConnectionProvider<>(key -> {
+            if (attempts.getAndIncrement() == 0) {
+                throw new IllegalStateException("boom");
+            }
+
+            return CompletableFuture.completedFuture(connection);
+        }, connectStarter);
+
+        CompletableFuture<TestConnection> failedLookup = sut.getConnection("key");
+
+        connectStarter.runNext();
+
+        assertThatThrownBy(failedLookup::join).hasRootCauseInstanceOf(IllegalStateException.class).hasMessageContaining("boom");
+
+        CompletableFuture<TestConnection> retriedLookup = sut.getConnection("key");
+        connectStarter.runNext();
+
+        assertThat(retriedLookup).isCompletedWithValue(connection);
+        assertThat(attempts).hasValue(2);
+        assertThat(sut.getConnectionCount()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldRemovePlaceholderAfterAsynchronousFailure() {
+
+        ManualExecutor connectStarter = new ManualExecutor();
+        AtomicInteger attempts = new AtomicInteger();
+        TestConnection connection = new TestConnection();
+
+        AsyncConnectionProvider<String, TestConnection> sut = new AsyncConnectionProvider<>(key -> {
+            if (attempts.getAndIncrement() == 0) {
+                CompletableFuture<TestConnection> failed = new CompletableFuture<>();
+                failed.completeExceptionally(new IllegalStateException("boom"));
+                return failed;
+            }
+
+            return CompletableFuture.completedFuture(connection);
+        }, connectStarter);
+
+        CompletableFuture<TestConnection> failedLookup = sut.getConnection("key");
+
+        connectStarter.runNext();
+
+        assertThatThrownBy(failedLookup::join).hasRootCauseInstanceOf(IllegalStateException.class).hasMessageContaining("boom");
+
+        CompletableFuture<TestConnection> retriedLookup = sut.getConnection("key");
+        connectStarter.runNext();
+
+        assertThat(retriedLookup).isCompletedWithValue(connection);
+        assertThat(attempts).hasValue(2);
+        assertThat(sut.getConnectionCount()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldNotCancelSharedAcquisitionWhenCallerIsCancelled() {
+
+        CompletableFuture<TestConnection> actualConnection = new CompletableFuture<>();
+        AsyncConnectionProvider<String, TestConnection> sut = new AsyncConnectionProvider<>(key -> actualConnection,
+                Runnable::run);
+
+        CompletableFuture<TestConnection> first = sut.getConnection("key");
+        CompletableFuture<TestConnection> second = sut.getConnection("key");
+
+        assertThat(first.cancel(false)).isTrue();
+        assertThat(actualConnection.isCancelled()).isFalse();
+
+        TestConnection connection = new TestConnection();
+        actualConnection.complete(connection);
+
+        assertThat(first).isCancelled();
+        assertThat(second).isCompletedWithValue(connection);
+        assertThat(sut.getConnectionCount()).isEqualTo(1);
+    }
+
+    @Test
+    void closeShouldCancelPendingConnectionAttemptWhenPossible() {
+
+        CompletableFuture<TestConnection> actualConnection = new CompletableFuture<>();
+        AsyncConnectionProvider<String, TestConnection> sut = new AsyncConnectionProvider<>(key -> actualConnection,
+                Runnable::run);
+
+        CompletableFuture<TestConnection> lookup = sut.getConnection("key");
+
+        CompletableFuture<Void> closeFuture = sut.close();
+
+        assertThat(actualConnection).isCancelled();
+        assertThat(lookup).isCancelled();
+        assertThat(closeFuture).isCompleted();
+        assertThat(sut.getConnectionCount()).isEqualTo(0);
+    }
+
+    @Test
+    void closeShouldCompleteIfConnectStartAbortsAfterMarkingStarted() {
+
+        AsyncConnectionProvider.Sync<String, TestConnection> sync = new AsyncConnectionProvider.Sync<>("key");
+
+        sync.markConnectStarted();
+        sync.completeCloseWithoutConnection();
+
+        CompletableFuture<Void> closeFuture = sync.close();
+
+        assertThat(sync.getSharedConnection()).isCancelled();
+        assertThat(closeFuture).isCompleted();
+    }
+
+    @Test
+    void closeShouldWaitForPendingConnectionAndCloseIt() {
+
+        NonCancellableFuture<TestConnection> actualConnection = new NonCancellableFuture<>();
+        AsyncConnectionProvider<String, TestConnection> sut = new AsyncConnectionProvider<>(key -> actualConnection,
+                Runnable::run);
+
+        sut.getConnection("key");
+
+        CompletableFuture<Void> closeFuture = sut.close();
+
+        assertThat(closeFuture).isNotDone();
+
+        TestConnection connection = new TestConnection();
+        actualConnection.complete(connection);
+
+        assertThat(closeFuture).isCompleted();
+        assertThat(connection.closed).hasValue(1);
+        assertThat(sut.getConnectionCount()).isEqualTo(0);
+    }
+
+    static class TestConnection implements AsyncCloseable {
+
+        final AtomicInteger closed = new AtomicInteger();
+
+        @Override
+        public CompletableFuture<Void> closeAsync() {
+            closed.incrementAndGet();
+            return CompletableFuture.completedFuture(null);
+        }
+
+    }
+
+    static class NonCancellableFuture<T> extends CompletableFuture<T> {
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return false;
+        }
+
+    }
+
+    static class ManualExecutor implements Executor {
+
+        private final Queue<Runnable> tasks = new ConcurrentLinkedQueue<>();
+
+        @Override
+        public void execute(Runnable command) {
+            tasks.add(command);
+        }
+
+        int size() {
+            return tasks.size();
+        }
+
+        void runNext() {
+            Runnable task = tasks.poll();
+            assertThat(task).isNotNull();
+            task.run();
+        }
+
+    }
+
+}

--- a/src/test/java/io/lettuce/core/masterreplica/MasterReplicaConnectionProviderUnitTests.java
+++ b/src/test/java/io/lettuce/core/masterreplica/MasterReplicaConnectionProviderUnitTests.java
@@ -27,6 +27,8 @@ import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.codec.StringCodec;
 import io.lettuce.core.models.role.RedisInstance;
 import io.lettuce.core.protocol.ConnectionIntent;
+import io.lettuce.core.resource.ClientResources;
+import io.netty.util.concurrent.ImmediateEventExecutor;
 
 /**
  * @author Mark Paluch
@@ -49,10 +51,15 @@ class MasterReplicaConnectionProviderUnitTests {
     @Mock
     RedisCommands<String, String> commandsMock;
 
+    @Mock
+    ClientResources clientResourcesMock;
+
     @BeforeEach
     void before() {
 
         nodeConnectionMock = (StatefulRedisConnection) channelHandlerMock;
+        when(clientMock.getResources()).thenReturn(clientResourcesMock);
+        when(clientResourcesMock.eventExecutorGroup()).thenReturn(ImmediateEventExecutor.INSTANCE);
         sut = new MasterReplicaConnectionProvider<>(clientMock, StringCodec.UTF8, RedisURI.create("localhost", 1),
                 Collections.emptyMap());
         sut.setKnownNodes(Arrays.asList(
@@ -73,6 +80,40 @@ class MasterReplicaConnectionProviderUnitTests {
         sut.close();
 
         verify(channelHandlerMock).closeAsync();
+    }
+
+    @Test
+    void shouldNotPropagateCancellationToUnderlyingConnectionAttempt() {
+
+        CompletableFuture<StatefulRedisConnection<String, String>> actualConnection = new CompletableFuture<>();
+
+        when(clientMock.connectAsync(eq(StringCodec.UTF8), any()))
+                .thenReturn(ConnectionFuture.from(mock(java.net.SocketAddress.class), actualConnection));
+
+        CompletableFuture<StatefulRedisConnection<String, String>> future = sut.getConnectionAsync(ConnectionIntent.READ);
+
+        assertThat(future.cancel(false)).isTrue();
+        assertThat(actualConnection.isCancelled()).isFalse();
+    }
+
+    @Test
+    void shouldAllowOtherWaitersToSucceedWhenOneIsCancelled() {
+
+        CompletableFuture<StatefulRedisConnection<String, String>> actualConnection = new CompletableFuture<>();
+
+        when(clientMock.connectAsync(eq(StringCodec.UTF8), any()))
+                .thenReturn(ConnectionFuture.from(mock(java.net.SocketAddress.class), actualConnection));
+
+        CompletableFuture<StatefulRedisConnection<String, String>> first = sut.getConnectionAsync(ConnectionIntent.READ);
+        CompletableFuture<StatefulRedisConnection<String, String>> second = sut.getConnectionAsync(ConnectionIntent.READ);
+
+        assertThat(first.cancel(false)).isTrue();
+        assertThat(actualConnection.isCancelled()).isFalse();
+
+        actualConnection.complete(nodeConnectionMock);
+
+        assertThat(second.join()).isSameAs(nodeConnectionMock);
+        verify(clientMock, times(1)).connectAsync(eq(StringCodec.UTF8), any());
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

Fixes: #3691 

Prevent recursive update error being thrown during connection establishment when using this library via Spring Session. See the linked issue for more details. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core connection acquisition/closing and concurrency semantics used by cluster and master/replica modes; changes are well-covered by new unit/integration tests but could affect connection lifecycle edge cases under load.
> 
> **Overview**
> Fixes connection acquisition races/reentrancy by refactoring `AsyncConnectionProvider` to insert a per-key placeholder first and start the actual connect attempt asynchronously via a provided `Executor`, avoiding `computeIfAbsent`/recursive map update failures.
> 
> The provider API is simplified to always return `CompletableFuture` waiters so caller cancellation no longer cancels the shared underlying connection attempt; close behavior is updated to properly cancel/await pending connects and remove failed placeholders. Cluster and master/replica connection providers are updated to use the new provider API/executor and to preserve remote address information for connection errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95792bd6d436f8dee546673a9ec43b8dd9110436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->