### PR TITLE
Add subkeyspace notifications integration tests

### DIFF
--- a/src/test/java/io/lettuce/core/cluster/pubsub/ClusterSubkeyNotificationsIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/pubsub/ClusterSubkeyNotificationsIntegrationTests.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2024-Present, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ */
+package io.lettuce.core.cluster.pubsub;
+
+import static io.lettuce.TestTags.INTEGRATION_TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.lettuce.core.RedisCommandExecutionException;
+import io.lettuce.core.TestSupport;
+import io.lettuce.core.cluster.ClusterTestUtil;
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
+import io.lettuce.core.cluster.pubsub.api.sync.NodeSelectionPubSubCommands;
+import io.lettuce.core.cluster.pubsub.api.sync.PubSubNodeSelection;
+import io.lettuce.core.support.CapturingPubSubListener;
+import io.lettuce.core.support.CapturingPubSubListener.Notification;
+import io.lettuce.test.LettuceExtension;
+
+/**
+ * Cluster integration tests for Redis 8.8 Subkey Notifications. Subkey notifications are published locally on the slot owner,
+ * so the test enables node message propagation and subscribes on every upstream via {@link PubSubNodeSelection}. Server gating
+ * mirrors {@link io.lettuce.core.pubsub.SubkeyNotificationsIntegrationTests}, applied to every upstream.
+ *
+ * @author Aleksandar Todorov
+ */
+@Tag(INTEGRATION_TEST)
+@ExtendWith(LettuceExtension.class)
+class ClusterSubkeyNotificationsIntegrationTests extends TestSupport {
+
+    private final RedisClusterClient clusterClient;
+
+    private StatefulRedisClusterConnection<String, String> connection;
+
+    private StatefulRedisClusterPubSubConnection<String, String> pubSubConnection;
+
+    private CapturingPubSubListener<String, String> listener;
+
+    @Inject
+    ClusterSubkeyNotificationsIntegrationTests(RedisClusterClient clusterClient) {
+        this.clusterClient = clusterClient;
+    }
+
+    @BeforeEach
+    void openPubSubConnection() {
+        connection = clusterClient.connect();
+        pubSubConnection = clusterClient.connectPubSub();
+        pubSubConnection.setNodeMessagePropagation(true);
+        listener = new CapturingPubSubListener<>();
+        pubSubConnection.addListener(listener);
+
+        try {
+            for (RedisClusterNode node : connection.getPartitions()) {
+                if (node.is(RedisClusterNode.NodeFlag.UPSTREAM)) {
+                    connection.getConnection(node.getNodeId()).sync().configSet("notify-keyspace-events", "AKEhSTIV");
+                }
+            }
+        } catch (RedisCommandExecutionException e) {
+            Assumptions.abort("Cluster does not support subkey notification flags (STIV): " + e.getMessage());
+        }
+    }
+
+    @AfterEach
+    void closePubSubConnection() {
+        if (connection != null) {
+            for (RedisClusterNode node : connection.getPartitions()) {
+                try {
+                    connection.getConnection(node.getNodeId()).sync().configSet("notify-keyspace-events", "");
+                } catch (Exception ignore) {
+                    // best-effort restore
+                }
+            }
+            ClusterTestUtil.flushDatabaseOfAllNodes(connection);
+            connection.close();
+        }
+        if (pubSubConnection != null) {
+            pubSubConnection.close();
+        }
+    }
+
+    @Test
+    void subkeyspace_clusterWide() {
+        String hashKey = "cl-subkeyspace-" + System.nanoTime();
+        String channel = "__subkeyspace@0__:" + hashKey;
+
+        subscribeOnAllUpstreams(channel, false);
+
+        connection.sync().hset(hashKey, "fld", "v1");
+
+        Notification<String, String> n = listener.expectMessageOn(channel);
+        assertThat(n.getChannel()).isEqualTo(channel);
+        assertThat(n.getPattern()).isNull();
+        assertThat(n.getMessage()).isEqualTo("hset|3:fld");
+    }
+
+    @Test
+    void subkeyevent_clusterWide() {
+        String hashKey = "cl-subkeyevent-" + System.nanoTime();
+        String channel = "__subkeyevent@0__:hset";
+
+        subscribeOnAllUpstreams(channel, false);
+
+        connection.sync().hset(hashKey, "fld", "v1");
+
+        Notification<String, String> n = listener.expectMessageOn(channel);
+        assertThat(n.getChannel()).isEqualTo(channel);
+        assertThat(n.getPattern()).isNull();
+        assertThat(n.getMessage()).isEqualTo(hashKey.length() + ":" + hashKey + "|3:fld");
+    }
+
+    @Test
+    void subkeyspaceitem_clusterWide() {
+        String hashKey = "cl-subkeyspaceitem-" + System.nanoTime();
+        String field = "fld";
+        String pattern = "__subkeyspaceitem@0__:" + hashKey + "\n*";
+        String expectedChannel = "__subkeyspaceitem@0__:" + hashKey + "\n" + field;
+
+        subscribeOnAllUpstreams(pattern, true);
+
+        connection.sync().hset(hashKey, field, "v1");
+
+        Notification<String, String> n = listener.expectMessageOn(expectedChannel);
+        assertThat(n.getChannel()).isEqualTo(expectedChannel);
+        assertThat(n.getPattern()).isEqualTo(pattern);
+        assertThat(n.getMessage()).isEqualTo("hset");
+    }
+
+    @Test
+    void subkeyspaceevent_clusterWide() {
+        String hashKey = "cl-subkeyspaceevent-" + System.nanoTime();
+        String channel = "__subkeyspaceevent@0__:hset|" + hashKey;
+
+        subscribeOnAllUpstreams(channel, false);
+
+        connection.sync().hset(hashKey, "fld", "v1");
+
+        Notification<String, String> n = listener.expectMessageOn(channel);
+        assertThat(n.getChannel()).isEqualTo(channel);
+        assertThat(n.getPattern()).isNull();
+        assertThat(n.getMessage()).isEqualTo("3:fld");
+    }
+
+    private void subscribeOnAllUpstreams(String channelOrPattern, boolean usePattern) {
+        PubSubNodeSelection<String, String> upstream = pubSubConnection.sync().upstream();
+        NodeSelectionPubSubCommands<String, String> commands = upstream.commands();
+        if (usePattern) {
+            commands.psubscribe(channelOrPattern);
+        } else {
+            commands.subscribe(channelOrPattern);
+        }
+    }
+
+}

--- a/src/test/java/io/lettuce/core/pubsub/SubkeyNotificationsBinaryIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/pubsub/SubkeyNotificationsBinaryIntegrationTests.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2024-Present, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ */
+package io.lettuce.core.pubsub;
+
+import static io.lettuce.TestTags.INTEGRATION_TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.lettuce.core.AbstractRedisClientTest;
+import io.lettuce.core.RedisCommandExecutionException;
+import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.core.codec.ByteArrayCodec;
+import io.lettuce.core.pubsub.api.sync.RedisPubSubCommands;
+import io.lettuce.core.support.CapturingPubSubListener;
+import io.lettuce.core.support.CapturingPubSubListener.Notification;
+
+/**
+ * Binary integration tests for Redis 8.8 Subkey Notifications, exchanging keys, channels and payloads as raw {@code byte[]} via
+ * {@link ByteArrayCodec} to cover bytes that would be lost or corrupted by {@code StringCodec.UTF8} — non-ASCII bytes and the
+ * channel-internal {@code |} and {@code \n} separators. Server gating mirrors {@link SubkeyNotificationsIntegrationTests}.
+ *
+ * @author Aleksandar Todorov
+ */
+@Tag(INTEGRATION_TEST)
+class SubkeyNotificationsBinaryIntegrationTests extends AbstractRedisClientTest {
+
+    private StatefulRedisPubSubConnection<byte[], byte[]> pubSubConnection;
+
+    private RedisPubSubCommands<byte[], byte[]> pubsub;
+
+    private RedisCommands<byte[], byte[]> binaryRedis;
+
+    private String originalNotifyConfig;
+
+    @BeforeEach
+    void openPubSubConnection() {
+        pubSubConnection = client.connectPubSub(ByteArrayCodec.INSTANCE);
+        pubsub = pubSubConnection.sync();
+        binaryRedis = client.connect(ByteArrayCodec.INSTANCE).sync();
+
+        originalNotifyConfig = redis.configGet("notify-keyspace-events").getOrDefault("notify-keyspace-events", "");
+        try {
+            redis.configSet("notify-keyspace-events", "AKEhSTIV");
+        } catch (RedisCommandExecutionException e) {
+            Assumptions.abort("Server does not support subkey notification flags (STIV): " + e.getMessage());
+        }
+    }
+
+    @AfterEach
+    void closePubSubConnection() {
+        if (redis != null) {
+            try {
+                redis.configSet("notify-keyspace-events", originalNotifyConfig == null ? "" : originalNotifyConfig);
+            } catch (Exception ignore) {
+                // best-effort restore
+            }
+        }
+        if (pubSubConnection != null) {
+            pubSubConnection.close();
+        }
+    }
+
+    @Test
+    void subkeyspace_subkeyContainingPipeAndNonUtf8() {
+        // Field contains '|' (the payload separator) plus a non-UTF-8 byte; length-prefixed parsing must round-trip it intact.
+        byte[] hashKey = ("bin-subkeyspace-" + System.nanoTime()).getBytes(StandardCharsets.UTF_8);
+        byte[] field = new byte[] { 'a', '|', 'b', (byte) 0xFE, 'c' };
+        byte[] channel = concat(prefix("__subkeyspace@0__:"), hashKey);
+
+        CapturingPubSubListener<byte[], byte[]> listener = new CapturingPubSubListener<>();
+        pubSubConnection.addListener(listener);
+        pubsub.subscribe(channel);
+
+        binaryRedis.hset(hashKey, field, "v1".getBytes(StandardCharsets.UTF_8));
+
+        Notification<byte[], byte[]> n = listener.expectMessageOn(channel);
+        byte[] expected = concat("hset|".getBytes(StandardCharsets.UTF_8),
+                (field.length + ":").getBytes(StandardCharsets.UTF_8), field);
+        assertThat(n.getChannel()).isEqualTo(channel);
+        assertThat(n.getPattern()).isNull();
+        assertThat(n.getMessage()).isEqualTo(expected);
+    }
+
+    @Test
+    void subkeyevent_keyAndSubkeyContainingPipe() {
+        // Both key and subkey contain the '|' separator; only the length-prefixed format lets a parser recover the parts.
+        byte[] hashKey = new byte[] { 'h', '|', 'k', (byte) 0x80 };
+        byte[] field = new byte[] { 'f', '|', 'd' };
+        byte[] channel = "__subkeyevent@0__:hset".getBytes(StandardCharsets.UTF_8);
+
+        CapturingPubSubListener<byte[], byte[]> listener = new CapturingPubSubListener<>();
+        pubSubConnection.addListener(listener);
+        pubsub.subscribe(channel);
+
+        binaryRedis.hset(hashKey, field, "v1".getBytes(StandardCharsets.UTF_8));
+
+        Notification<byte[], byte[]> n = listener.expectMessageOn(channel);
+        byte[] expected = concat((hashKey.length + ":").getBytes(StandardCharsets.UTF_8), hashKey,
+                "|".getBytes(StandardCharsets.UTF_8), (field.length + ":").getBytes(StandardCharsets.UTF_8), field);
+        assertThat(n.getChannel()).isEqualTo(channel);
+        assertThat(n.getPattern()).isNull();
+        assertThat(n.getMessage()).isEqualTo(expected);
+    }
+
+    @Test
+    void subkeyspaceitem_channelContainsBinaryBytes() {
+        // Channel name __subkeyspaceitem@0__:<key>\n<subkey> with arbitrary bytes in both key and subkey.
+        byte[] hashKey = new byte[] { 'i', (byte) 0xC3, (byte) 0xA9 };
+        byte[] field = new byte[] { 'f', (byte) 0x80, 'd' };
+        byte[] pattern = concat(prefix("__subkeyspaceitem@0__:"), hashKey, "\n*".getBytes(StandardCharsets.UTF_8));
+        byte[] expectedChannel = concat(prefix("__subkeyspaceitem@0__:"), hashKey, "\n".getBytes(StandardCharsets.UTF_8),
+                field);
+
+        CapturingPubSubListener<byte[], byte[]> listener = new CapturingPubSubListener<>();
+        pubSubConnection.addListener(listener);
+        pubsub.psubscribe(pattern);
+
+        binaryRedis.hset(hashKey, field, "v1".getBytes(StandardCharsets.UTF_8));
+
+        Notification<byte[], byte[]> n = listener.expectMessageOn(expectedChannel);
+        assertThat(n.getChannel()).isEqualTo(expectedChannel);
+        assertThat(n.getPattern()).isEqualTo(pattern);
+        assertThat(n.getMessage()).isEqualTo("hset".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void subkeyevent_keyAndSubkeyContainingNewline() {
+        // LF is a channel delimiter for subkeyspaceitem but is plain data for subkeyevent; both must round-trip intact.
+        byte[] hashKey = new byte[] { 'h', '\n', 'k' };
+        byte[] field = new byte[] { 'f', '\n', 'd' };
+        byte[] channel = "__subkeyevent@0__:hset".getBytes(StandardCharsets.UTF_8);
+
+        CapturingPubSubListener<byte[], byte[]> listener = new CapturingPubSubListener<>();
+        pubSubConnection.addListener(listener);
+        pubsub.subscribe(channel);
+
+        binaryRedis.hset(hashKey, field, "v1".getBytes(StandardCharsets.UTF_8));
+
+        Notification<byte[], byte[]> n = listener.expectMessageOn(channel);
+        byte[] expected = concat((hashKey.length + ":").getBytes(StandardCharsets.UTF_8), hashKey,
+                "|".getBytes(StandardCharsets.UTF_8), (field.length + ":").getBytes(StandardCharsets.UTF_8), field);
+        assertThat(n.getChannel()).isEqualTo(channel);
+        assertThat(n.getPattern()).isNull();
+        assertThat(n.getMessage()).isEqualTo(expected);
+    }
+
+    @Test
+    void subkeyspaceevent_keyContainingPipeInChannel() {
+        // Key is embedded in the channel name and may contain '|'; only ByteArrayCodec preserves the exact bytes for SUBSCRIBE.
+        byte[] hashKey = new byte[] { 'k', '|', 'k', (byte) 0xFF };
+        byte[] field = new byte[] { 'f', 'l', 'd' };
+        byte[] channel = concat("__subkeyspaceevent@0__:hset|".getBytes(StandardCharsets.UTF_8), hashKey);
+
+        CapturingPubSubListener<byte[], byte[]> listener = new CapturingPubSubListener<>();
+        pubSubConnection.addListener(listener);
+        pubsub.subscribe(channel);
+
+        binaryRedis.hset(hashKey, field, "v1".getBytes(StandardCharsets.UTF_8));
+
+        Notification<byte[], byte[]> n = listener.expectMessageOn(channel);
+        byte[] expected = concat((field.length + ":").getBytes(StandardCharsets.UTF_8), field);
+        assertThat(n.getChannel()).isEqualTo(channel);
+        assertThat(n.getPattern()).isNull();
+        assertThat(n.getMessage()).isEqualTo(expected);
+    }
+
+    private static byte[] prefix(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static byte[] concat(byte[]... parts) {
+        int total = 0;
+        for (byte[] p : parts) {
+            total += p.length;
+        }
+        byte[] out = new byte[total];
+        int off = 0;
+        for (byte[] p : parts) {
+            System.arraycopy(p, 0, out, off, p.length);
+            off += p.length;
+        }
+        return out;
+    }
+
+}

--- a/src/test/java/io/lettuce/core/pubsub/SubkeyNotificationsIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/pubsub/SubkeyNotificationsIntegrationTests.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2024-Present, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ */
+package io.lettuce.core.pubsub;
+
+import static io.lettuce.TestTags.INTEGRATION_TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.lettuce.core.AbstractRedisClientTest;
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.RedisCommandExecutionException;
+import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.core.support.CapturingPubSubListener;
+import io.lettuce.core.support.CapturingPubSubListener.Notification;
+
+/**
+ * Integration tests for the Redis 8.8 Subkey Notifications feature: four new keyspace channel families gated by the {@code S},
+ * {@code T}, {@code I}, {@code V} flags. Tests are skipped via a {@code CONFIG SET notify-keyspace-events AKEhSTIV} probe; this
+ * is intentional, since the feature adds no new RESP command and the development image misreports {@code redis_version}.
+ *
+ * @author Aleksandar Todorov
+ */
+@Tag(INTEGRATION_TEST)
+class SubkeyNotificationsIntegrationTests extends AbstractRedisClientTest {
+
+    static final String CHANNEL_PREFIX_SUBKEYSPACE = "__subkeyspace@0__:";
+
+    static final String CHANNEL_PREFIX_SUBKEYEVENT = "__subkeyevent@0__:";
+
+    static final String CHANNEL_PREFIX_SUBKEYSPACEITEM = "__subkeyspaceitem@0__:";
+
+    static final String CHANNEL_PREFIX_SUBKEYSPACEEVENT = "__subkeyspaceevent@0__:";
+
+    private StatefulRedisPubSubConnection<String, String> pubSubConnection;
+
+    private CapturingPubSubListener<String, String> listener;
+
+    private String originalNotifyConfig;
+
+    protected ClientOptions getOptions() {
+        return ClientOptions.builder().build();
+    }
+
+    @BeforeEach
+    void openPubSubConnection() {
+        client.setOptions(getOptions());
+        pubSubConnection = client.connectPubSub();
+        listener = new CapturingPubSubListener<>();
+        pubSubConnection.addListener(listener);
+
+        RedisCommands<String, String> sync = redis;
+        originalNotifyConfig = sync.configGet("notify-keyspace-events").getOrDefault("notify-keyspace-events", "");
+
+        try {
+            sync.configSet("notify-keyspace-events", "AKEhSTIV");
+        } catch (RedisCommandExecutionException e) {
+            Assumptions.abort("Server does not support subkey notification flags (STIV): " + e.getMessage());
+        }
+    }
+
+    @AfterEach
+    void closePubSubConnection() {
+        if (redis != null) {
+            try {
+                redis.configSet("notify-keyspace-events", originalNotifyConfig == null ? "" : originalNotifyConfig);
+            } catch (Exception ignore) {
+                // best-effort restore
+            }
+        }
+        if (pubSubConnection != null) {
+            pubSubConnection.close();
+        }
+    }
+
+    // -------------------------------------------------------------------- subkeyspace (flag S)
+
+    @Test
+    void subkeyspace_singleHashField() {
+        String hashKey = "subkeyspace-basic-" + System.nanoTime();
+        String channel = CHANNEL_PREFIX_SUBKEYSPACE + hashKey;
+
+        pubSubConnection.sync().subscribe(channel);
+
+        redis.hset(hashKey, "fld", "v1");
+
+        Notification<String, String> n = listener.expectMessageOn(channel);
+        assertThat(n.getChannel()).isEqualTo(channel);
+        assertThat(n.getPattern()).isNull();
+        assertThat(n.getMessage()).isEqualTo("hset|3:fld");
+    }
+
+    @Test
+    void subkeyspace_multipleFields() {
+        String hashKey = "subkeyspace-multi-" + System.nanoTime();
+        String channel = CHANNEL_PREFIX_SUBKEYSPACE + hashKey;
+
+        pubSubConnection.sync().subscribe(channel);
+
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put("f1", "v1");
+        fields.put("f22", "v2");
+        redis.hmset(hashKey, fields);
+
+        Notification<String, String> n = listener.expectMessageOn(channel);
+        assertThat(n.getChannel()).isEqualTo(channel);
+        assertThat(n.getPattern()).isNull();
+        assertThat(n.getMessage()).isEqualTo("hset|2:f1,3:f22");
+    }
+
+    @Test
+    void subkeyspace_psubscribePrefix() {
+        String prefix = "subkeyspace-pattern-" + System.nanoTime() + "-";
+        String hashKey1 = prefix + "a";
+        String hashKey2 = prefix + "b";
+        String pattern = CHANNEL_PREFIX_SUBKEYSPACE + prefix + "*";
+        String channel1 = CHANNEL_PREFIX_SUBKEYSPACE + hashKey1;
+        String channel2 = CHANNEL_PREFIX_SUBKEYSPACE + hashKey2;
+
+        pubSubConnection.sync().psubscribe(pattern);
+
+        redis.hset(hashKey1, "fld", "v1");
+        redis.hset(hashKey2, "fld", "v2");
+
+        Notification<String, String> n1 = listener.expectMessageOn(channel1);
+        Notification<String, String> n2 = listener.expectMessageOn(channel2);
+        assertThat(n1.getChannel()).isEqualTo(channel1);
+        assertThat(n2.getChannel()).isEqualTo(channel2);
+        assertThat(n1.getPattern()).isEqualTo(pattern);
+        assertThat(n2.getPattern()).isEqualTo(pattern);
+        assertThat(n1.getMessage()).isEqualTo("hset|3:fld");
+        assertThat(n2.getMessage()).isEqualTo("hset|3:fld");
+    }
+
+    // -------------------------------------------------------------------- subkeyevent (flag T)
+
+    @Test
+    void subkeyevent_singleHashField() {
+        String hashKey = "subkeyevent-basic-" + System.nanoTime();
+        String channel = CHANNEL_PREFIX_SUBKEYEVENT + "hset";
+
+        pubSubConnection.sync().subscribe(channel);
+
+        redis.hset(hashKey, "fld", "v1");
+
+        Notification<String, String> n = listener.expectMessageOn(channel);
+        assertThat(n.getChannel()).isEqualTo(channel);
+        assertThat(n.getPattern()).isNull();
+        assertThat(n.getMessage()).isEqualTo(hashKey.length() + ":" + hashKey + "|3:fld");
+    }
+
+    @Test
+    void subkeyevent_multipleFields() {
+        String hashKey = "subkeyevent-multi-" + System.nanoTime();
+        String channel = CHANNEL_PREFIX_SUBKEYEVENT + "hset";
+
+        pubSubConnection.sync().subscribe(channel);
+
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put("f1", "v1");
+        fields.put("f22", "v2");
+        redis.hmset(hashKey, fields);
+
+        Notification<String, String> n = listener.expectMessageOn(channel);
+        assertThat(n.getChannel()).isEqualTo(channel);
+        assertThat(n.getPattern()).isNull();
+        assertThat(n.getMessage()).isEqualTo(hashKey.length() + ":" + hashKey + "|2:f1,3:f22");
+    }
+
+    // -------------------------------------------------------------------- subkeyspaceitem (flag I)
+
+    @Test
+    void subkeyspaceitem_singleHashField() {
+        String hashKey = "subkeyspaceitem-basic-" + System.nanoTime();
+        String field = "fld";
+        String channel = CHANNEL_PREFIX_SUBKEYSPACEITEM + hashKey + "\n" + field;
+
+        pubSubConnection.sync().subscribe(channel);
+
+        redis.hset(hashKey, field, "v1");
+
+        Notification<String, String> n = listener.expectMessageOn(channel);
+        assertThat(n.getChannel()).isEqualTo(channel);
+        assertThat(n.getPattern()).isNull();
+        assertThat(n.getMessage()).isEqualTo("hset");
+    }
+
+    @Test
+    void subkeyspaceitem_filtersToTargetFieldOnly() {
+        String hashKey = "subkeyspaceitem-filter-" + System.nanoTime();
+        String targetChannel = CHANNEL_PREFIX_SUBKEYSPACEITEM + hashKey + "\nf2";
+
+        pubSubConnection.sync().subscribe(targetChannel);
+
+        redis.hset(hashKey, "f1", "v1");
+        redis.hset(hashKey, "f2", "v2");
+        redis.hset(hashKey, "f3", "v3");
+
+        Notification<String, String> n = listener.expectMessageOn(targetChannel);
+        assertThat(n.getChannel()).isEqualTo(targetChannel);
+        assertThat(n.getPattern()).isNull();
+        assertThat(n.getMessage()).isEqualTo("hset");
+
+        listener.expectNoMessageOn(targetChannel, 250, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    void subkeyspaceitem_multipleFieldsEmitOneEventPerField() {
+        String hashKey = "subkeyspaceitem-multi-" + System.nanoTime();
+        String pattern = CHANNEL_PREFIX_SUBKEYSPACEITEM + hashKey + "\n*";
+        String channelF1 = CHANNEL_PREFIX_SUBKEYSPACEITEM + hashKey + "\nf1";
+        String channelF22 = CHANNEL_PREFIX_SUBKEYSPACEITEM + hashKey + "\nf22";
+
+        pubSubConnection.sync().psubscribe(pattern);
+
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put("f1", "v1");
+        fields.put("f22", "v2");
+        redis.hmset(hashKey, fields);
+
+        Notification<String, String> n1 = listener.expectMessageOn(channelF1);
+        Notification<String, String> n2 = listener.expectMessageOn(channelF22);
+        assertThat(n1.getChannel()).isEqualTo(channelF1);
+        assertThat(n2.getChannel()).isEqualTo(channelF22);
+        assertThat(n1.getPattern()).isEqualTo(pattern);
+        assertThat(n2.getPattern()).isEqualTo(pattern);
+        assertThat(n1.getMessage()).isEqualTo("hset");
+        assertThat(n2.getMessage()).isEqualTo("hset");
+    }
+
+    // -------------------------------------------------------------------- subkeyspaceevent (flag V)
+
+    @Test
+    void subkeyspaceevent_singleHashField() {
+        String hashKey = "subkeyspaceevent-basic-" + System.nanoTime();
+        String channel = CHANNEL_PREFIX_SUBKEYSPACEEVENT + "hset|" + hashKey;
+
+        pubSubConnection.sync().subscribe(channel);
+
+        redis.hset(hashKey, "fld", "v1");
+
+        Notification<String, String> n = listener.expectMessageOn(channel);
+        assertThat(n.getChannel()).isEqualTo(channel);
+        assertThat(n.getPattern()).isNull();
+        assertThat(n.getMessage()).isEqualTo("3:fld");
+    }
+
+    @Test
+    void subkeyspaceevent_multipleFields() {
+        String hashKey = "subkeyspaceevent-multi-" + System.nanoTime();
+        String channel = CHANNEL_PREFIX_SUBKEYSPACEEVENT + "hset|" + hashKey;
+
+        pubSubConnection.sync().subscribe(channel);
+
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put("f1", "v1");
+        fields.put("f22", "v2");
+        redis.hmset(hashKey, fields);
+
+        Notification<String, String> n = listener.expectMessageOn(channel);
+        assertThat(n.getChannel()).isEqualTo(channel);
+        assertThat(n.getPattern()).isNull();
+        assertThat(n.getMessage()).isEqualTo("2:f1,3:f22");
+    }
+
+}

--- a/src/test/java/io/lettuce/core/pubsub/SubkeyNotificationsReactiveIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/pubsub/SubkeyNotificationsReactiveIntegrationTests.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2024-Present, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ */
+package io.lettuce.core.pubsub;
+
+import static io.lettuce.TestTags.INTEGRATION_TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.BlockingQueue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import reactor.core.Disposable;
+import io.lettuce.core.AbstractRedisClientTest;
+import io.lettuce.core.RedisCommandExecutionException;
+import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.core.internal.LettuceFactories;
+import io.lettuce.core.pubsub.api.reactive.ChannelMessage;
+import io.lettuce.core.pubsub.api.reactive.PatternMessage;
+import io.lettuce.core.pubsub.api.reactive.RedisPubSubReactiveCommands;
+import io.lettuce.test.Wait;
+
+/**
+ * Reactive integration tests for the Redis 8.8 Subkey Notifications feature.
+ * <p>
+ * Validates that the same wire-format notifications are observable through {@link RedisPubSubReactiveCommands} for each of the
+ * four channel families. Assertions are limited to one representative test per family since the wire format itself is
+ * exhaustively covered by {@link SubkeyNotificationsIntegrationTests}.
+ *
+ * @author Aleksandar Todorov
+ */
+@Tag(INTEGRATION_TEST)
+class SubkeyNotificationsReactiveIntegrationTests extends AbstractRedisClientTest {
+
+    private StatefulRedisPubSubConnection<String, String> pubSubConnection;
+
+    private RedisPubSubReactiveCommands<String, String> pubsub;
+
+    private String originalNotifyConfig;
+
+    @BeforeEach
+    void openPubSubConnection() {
+        pubSubConnection = client.connectPubSub();
+        pubsub = pubSubConnection.reactive();
+
+        RedisCommands<String, String> sync = redis;
+        originalNotifyConfig = sync.configGet("notify-keyspace-events").getOrDefault("notify-keyspace-events", "");
+
+        try {
+            sync.configSet("notify-keyspace-events", "AKEhSTIV");
+        } catch (RedisCommandExecutionException e) {
+            Assumptions.abort("Server does not support subkey notification flags (STIV): " + e.getMessage());
+        }
+    }
+
+    @AfterEach
+    void closePubSubConnection() {
+        if (redis != null) {
+            try {
+                redis.configSet("notify-keyspace-events", originalNotifyConfig == null ? "" : originalNotifyConfig);
+            } catch (Exception ignore) {
+                // best-effort restore
+            }
+        }
+        if (pubSubConnection != null) {
+            pubSubConnection.close();
+        }
+    }
+
+    @Test
+    void subkeyspace_observable() {
+        String hashKey = "rx-subkeyspace-" + System.nanoTime();
+        String channel = SubkeyNotificationsIntegrationTests.CHANNEL_PREFIX_SUBKEYSPACE + hashKey;
+        BlockingQueue<ChannelMessage<String, String>> received = LettuceFactories.newBlockingQueue();
+        Disposable d = pubsub.observeChannels().doOnNext(received::add).subscribe();
+
+        pubsub.subscribe(channel).block();
+        redis.hset(hashKey, "fld", "v1");
+
+        Wait.untilTrue(() -> received.stream().anyMatch(m -> channel.equals(m.getChannel()))).waitOrTimeout();
+        ChannelMessage<String, String> m = received.stream().filter(x -> channel.equals(x.getChannel())).findFirst().get();
+        assertThat(m.getChannel()).isEqualTo(channel);
+        assertThat(m.getMessage()).isEqualTo("hset|3:fld");
+        d.dispose();
+    }
+
+    @Test
+    void subkeyevent_observable() {
+        String hashKey = "rx-subkeyevent-" + System.nanoTime();
+        String channel = SubkeyNotificationsIntegrationTests.CHANNEL_PREFIX_SUBKEYEVENT + "hset";
+        BlockingQueue<ChannelMessage<String, String>> received = LettuceFactories.newBlockingQueue();
+        Disposable d = pubsub.observeChannels().doOnNext(received::add).subscribe();
+
+        pubsub.subscribe(channel).block();
+        redis.hset(hashKey, "fld", "v1");
+
+        Wait.untilTrue(() -> received.stream().anyMatch(m -> channel.equals(m.getChannel()))).waitOrTimeout();
+        ChannelMessage<String, String> m = received.stream().filter(x -> channel.equals(x.getChannel())).findFirst().get();
+        assertThat(m.getChannel()).isEqualTo(channel);
+        assertThat(m.getMessage()).isEqualTo(hashKey.length() + ":" + hashKey + "|3:fld");
+        d.dispose();
+    }
+
+    @Test
+    void subkeyspaceitem_observable() {
+        String hashKey = "rx-subkeyspaceitem-" + System.nanoTime();
+        String field = "fld";
+        String pattern = SubkeyNotificationsIntegrationTests.CHANNEL_PREFIX_SUBKEYSPACEITEM + hashKey + "\n*";
+        String expectedChannel = SubkeyNotificationsIntegrationTests.CHANNEL_PREFIX_SUBKEYSPACEITEM + hashKey + "\n" + field;
+
+        BlockingQueue<PatternMessage<String, String>> received = LettuceFactories.newBlockingQueue();
+        Disposable d = pubsub.observePatterns().doOnNext(received::add).subscribe();
+
+        pubsub.psubscribe(pattern).block();
+        redis.hset(hashKey, field, "v1");
+
+        Wait.untilTrue(() -> received.stream().anyMatch(m -> expectedChannel.equals(m.getChannel()))).waitOrTimeout();
+        PatternMessage<String, String> m = received.stream().filter(x -> expectedChannel.equals(x.getChannel())).findFirst()
+                .get();
+        assertThat(m.getChannel()).isEqualTo(expectedChannel);
+        assertThat(m.getPattern()).isEqualTo(pattern);
+        assertThat(m.getMessage()).isEqualTo("hset");
+        d.dispose();
+    }
+
+    @Test
+    void subkeyspaceevent_observable() {
+        String hashKey = "rx-subkeyspaceevent-" + System.nanoTime();
+        String channel = SubkeyNotificationsIntegrationTests.CHANNEL_PREFIX_SUBKEYSPACEEVENT + "hset|" + hashKey;
+        BlockingQueue<ChannelMessage<String, String>> received = LettuceFactories.newBlockingQueue();
+        Disposable d = pubsub.observeChannels().doOnNext(received::add).subscribe();
+
+        pubsub.subscribe(channel).block();
+        redis.hset(hashKey, "fld", "v1");
+
+        Wait.untilTrue(() -> received.stream().anyMatch(m -> channel.equals(m.getChannel()))).waitOrTimeout();
+        ChannelMessage<String, String> m = received.stream().filter(x -> channel.equals(x.getChannel())).findFirst().get();
+        assertThat(m.getChannel()).isEqualTo(channel);
+        assertThat(m.getMessage()).isEqualTo("3:fld");
+        d.dispose();
+    }
+
+}

--- a/src/test/java/io/lettuce/core/pubsub/SubkeyNotificationsResp2IntegrationTests.java
+++ b/src/test/java/io/lettuce/core/pubsub/SubkeyNotificationsResp2IntegrationTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024-Present, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ */
+package io.lettuce.core.pubsub;
+
+import static io.lettuce.TestTags.INTEGRATION_TEST;
+
+import org.junit.jupiter.api.Tag;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.protocol.ProtocolVersion;
+
+/**
+ * Subkey Notifications integration tests using RESP2.
+ * <p>
+ * The notification wire format is independent of the protocol version, so the inherited tests are sufficient to validate that a
+ * RESP2 client receives the same notifications.
+ *
+ * @author Aleksandar Todorov
+ */
+@Tag(INTEGRATION_TEST)
+class SubkeyNotificationsResp2IntegrationTests extends SubkeyNotificationsIntegrationTests {
+
+    @Override
+    protected ClientOptions getOptions() {
+        return ClientOptions.builder().protocolVersion(ProtocolVersion.RESP2).build();
+    }
+
+}

--- a/src/test/java/io/lettuce/core/support/CapturingPubSubListener.java
+++ b/src/test/java/io/lettuce/core/support/CapturingPubSubListener.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2024-Present, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ */
+package io.lettuce.core.support;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+
+import io.lettuce.core.internal.LettuceFactories;
+import io.lettuce.core.pubsub.RedisPubSubAdapter;
+
+/**
+ * Test listener that routes each received pub/sub message into a per-channel {@link BlockingQueue}, preserving the
+ * channel/pattern/message tuple per delivery. This is the alternative to {@link PubSubTestListener} for tests that need to
+ * assert which message arrived on which channel — typically multi-channel pattern subscriptions, exact-match channel routing,
+ * or binary-channel assertions where {@link PubSubTestListener}'s independent {@code channels}/{@code messages} queues lose the
+ * pairing.
+ * <p>
+ * Per-channel queues also enable cheap negative assertions such as {@link #expectNoMessageOn(Object, long, TimeUnit)}.
+ * <p>
+ * For {@code byte[]} key types the per-channel map keys are wrapped in {@link ByteBuffer} so equality is content-based.
+ *
+ * @param <K> Key type. Typically {@link String} or {@code byte[]}.
+ * @param <V> Value type. Typically {@link String} or {@code byte[]}.
+ * @author Aleksandar Todorov
+ */
+public class CapturingPubSubListener<K, V> extends RedisPubSubAdapter<K, V> {
+
+    /** Default per-call timeout for {@link #expectMessageOn(Object)}. */
+    public static final long DEFAULT_AWAIT_MILLIS = 10_000;
+
+    private final ConcurrentMap<Object, BlockingQueue<Notification<K, V>>> byChannel = new ConcurrentHashMap<>();
+
+    @Override
+    public void message(K channel, V message) {
+        queueFor(channel).add(new Notification<>(null, channel, message));
+    }
+
+    @Override
+    public void message(K pattern, K channel, V message) {
+        queueFor(channel).add(new Notification<>(pattern, channel, message));
+    }
+
+    /** Wait for the next message on {@code channel}, up to {@link #DEFAULT_AWAIT_MILLIS} ms. */
+    public Notification<K, V> expectMessageOn(K channel) {
+        return expectMessageOn(channel, DEFAULT_AWAIT_MILLIS, TimeUnit.MILLISECONDS);
+    }
+
+    /** Wait for the next message on {@code channel}, up to {@code timeout} {@code unit}. */
+    public Notification<K, V> expectMessageOn(K channel, long timeout, TimeUnit unit) {
+        try {
+            Notification<K, V> n = queueFor(channel).poll(timeout, unit);
+            if (n == null) {
+                throw new AssertionError(
+                        "did not receive notification on channel '" + channel + "' within " + timeout + " " + unit);
+            }
+            return n;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("interrupted while waiting for notification on channel '" + channel + "'", e);
+        }
+    }
+
+    /** Assert that no message arrives on {@code channel} within {@code timeout} {@code unit}. */
+    public void expectNoMessageOn(K channel, long timeout, TimeUnit unit) {
+        try {
+            Notification<K, V> n = queueFor(channel).poll(timeout, unit);
+            if (n != null) {
+                throw new AssertionError(
+                        "expected no message on channel '" + channel + "' but received message: " + n.getMessage());
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("interrupted while waiting for absence of notification on channel '" + channel + "'", e);
+        }
+    }
+
+    /** Drop all captured notifications. */
+    public void clear() {
+        byChannel.clear();
+    }
+
+    private BlockingQueue<Notification<K, V>> queueFor(K channel) {
+        return byChannel.computeIfAbsent(keyOf(channel), k -> LettuceFactories.newBlockingQueue());
+    }
+
+    private static Object keyOf(Object channel) {
+        if (channel instanceof byte[]) {
+            return ByteBuffer.wrap((byte[]) channel);
+        }
+        return channel;
+    }
+
+    /** Captured pub/sub event carrying the originating pattern (when any), channel, and message together. */
+    public static final class Notification<K, V> {
+
+        private final K pattern;
+
+        private final K channel;
+
+        private final V message;
+
+        Notification(K pattern, K channel, V message) {
+            this.pattern = pattern;
+            this.channel = channel;
+            this.message = message;
+        }
+
+        public K getPattern() {
+            return pattern;
+        }
+
+        public K getChannel() {
+            return channel;
+        }
+
+        public V getMessage() {
+            return message;
+        }
+
+    }
+
+}


### PR DESCRIPTION
Adds integration coverage for the four new keyspace channel families introduced
in Redis 8.8 (`__subkeyspace@0__`, `__subkeyevent@0__`, `__subkeyspaceitem@0__`,
`__subkeyspaceevent@0__`), gated by the `S`, `T`, `I`, `V` flags of
`notify-keyspace-events`. No production code changes.

## What's covered

- **Standalone (sync)** — `SubkeyNotificationsIntegrationTests`: per-family
  `SUBSCRIBE` and `PSUBSCRIBE` round-trips, multi-field `HMSET` payloads,
  and field-level routing via the `subkeyspaceitem` `\n`-delimited channel.
- **RESP2 parity** — `SubkeyNotificationsResp2IntegrationTests`: same matrix
  forced onto RESP2 to lock in protocol-version compatibility.
- **Binary safety (FR.9)** — `SubkeyNotificationsBinaryIntegrationTests`:
  uses `ByteArrayCodec` to exercise keys, fields and channels containing
  non-UTF-8 bytes and the channel-internal `|` and `\n` separators.
- **Reactive** — `SubkeyNotificationsReactiveIntegrationTests`: one
  representative test per family through `RedisPubSubReactiveCommands`.
- **Cluster** — `ClusterSubkeyNotificationsIntegrationTests`: subscribes on
  every upstream via `PubSubNodeSelection` with node message propagation,
  since subkey notifications are published locally on the slot owner.

Every test asserts the full `(channel, pattern, message)` tuple, so the
SUBSCRIBE-vs-PSUBSCRIBE callback distinction (`pattern == null` vs
`pattern == subscribed pattern`) is verified end-to-end alongside the wire
payload.

## Test infrastructure

- New shared utility `CapturingPubSubListener<K, V>` under
  `src/test/java/io/lettuce/core/support/`. Routes each notification into a
  per-channel `BlockingQueue` so tests can assert "the next message **on this
  channel**" instead of "the next message anywhere", and supports cheap
  negative assertions via `expectNoMessageOn(channel, timeout, unit)`.
  `byte[]` channel keys are wrapped in `ByteBuffer` so map equality is
  content-based.

## Server gating

All suites probe the server with
`CONFIG SET notify-keyspace-events AKEhSTIV` in `@BeforeEach`; if it fails,
the test class is skipped via `Assumptions.abort`. The probe is required
because the Redis 8.8 development image misreports `redis_version`, so a
version check would not be reliable.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are test-only, but they add new integration suites that tweak `notify-keyspace-events` and rely on pub/sub timing, which could introduce CI flakiness or environment coupling.
> 
> **Overview**
> Adds comprehensive integration test coverage for Redis 8.8 *Subkey Notifications* across all four new channel families (including multi-field payloads, pattern subscriptions, and field-level routing).
> 
> Extends coverage to **RESP2 parity**, **reactive pub/sub observation**, **binary-safe channel/payload round-trips** (via `ByteArrayCodec` for `|`/`\n` and non-UTF-8 bytes), and **cluster-wide behavior** by subscribing on all upstream nodes with node message propagation.
> 
> Introduces `CapturingPubSubListener` to capture notifications per-channel (including pattern vs non-pattern) and support negative assertions, improving determinism of pub/sub assertions in the new tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 816901de761d9a311c5c24d2ba3fdcb3ae2592f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->