### PR TITLE
fix benchmark tests

### DIFF
--- a/src/test/jmh/io/lettuce/core/cluster/EmptyRedisClusterClient.java
+++ b/src/test/jmh/io/lettuce/core/cluster/EmptyRedisClusterClient.java
@@ -19,8 +19,9 @@ class EmptyRedisClusterClient extends RedisClusterClient {
         super(null, Collections.singleton(initialUri));
     }
 
+    @Override
     <K, V> StatefulRedisConnection<K, V> connectToNode(RedisCodec<K, V> codec, String nodeId, RedisChannelWriter clusterWriter,
-            final Supplier<SocketAddress> socketAddressSupplier) {
+            Mono<SocketAddress> socketAddressSupplier) {
         return EmptyStatefulRedisConnection.INSTANCE;
     }
 }


### PR DESCRIPTION
There is a regression introduced with the [commit](https://github.com/redis/lettuce/commit/8cfb2e80e1f58fd0d387180bbfbe96db9c956bbf) during the refactoring of _async  connect._
The intended overload `connectToNode` in `EmptyRedisClusterClient` left unchanged and has been missing ever since.
It just came out with failing benchmarks tests [here](https://github.com/redis/lettuce/actions/runs/24931566651/job/73010054669).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 788c4af4f47ffe78917923c049dfbe83479271dc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->