### PR TITLE
 Improve CI pipeline stability

### DIFF
--- a/src/test/java/io/lettuce/core/CommandListenerIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/CommandListenerIntegrationTests.java
@@ -38,6 +38,7 @@ import io.lettuce.core.event.command.CommandListener;
 import io.lettuce.core.event.command.CommandStartedEvent;
 import io.lettuce.core.event.command.CommandSucceededEvent;
 import io.lettuce.test.LettuceExtension;
+import io.lettuce.test.Wait;
 
 /**
  * Integration tests for {@link CommandListener}.
@@ -47,7 +48,6 @@ import io.lettuce.test.LettuceExtension;
  */
 @Tag(INTEGRATION_TEST)
 @ExtendWith(LettuceExtension.class)
-@SuppressWarnings({ "rawtypes", "unchecked" })
 public class CommandListenerIntegrationTests extends TestSupport {
 
     private final RedisClient client;
@@ -103,9 +103,14 @@ public class CommandListenerIntegrationTests extends TestSupport {
         } catch (RedisCommandExecutionException ignored) {
         }
 
-        assertThat(startedEvents).hasSize(3);
-        assertThat(succeededEvents).hasSize(2);
-        assertThat(failedEvents).hasSize(1);
+        // There is race condition here between command listener callback execution and the caller who blocks on command
+        // completion.
+        // Listener callbacks fire on the Netty I/O thread after the sync caller has already been
+        // unblocked by command.complete(), so the lists may not be populated yet at this point.
+        // That is why we need to 'wait' here.
+        Wait.untilEquals(3, startedEvents::size).waitOrTimeout();
+        Wait.untilEquals(2, succeededEvents::size).waitOrTimeout();
+        Wait.untilEquals(1, failedEvents::size).waitOrTimeout();
 
         client.removeListener(listener);
     }

--- a/src/test/java/io/lettuce/core/PipeliningIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/PipeliningIntegrationTests.java
@@ -41,7 +41,7 @@ class PipeliningIntegrationTests extends TestSupport {
 
     @BeforeEach
     void setUp() {
-        this.connection.async().flushall();
+        this.connection.sync().flushall();
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/ReactiveConnectionIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/ReactiveConnectionIntegrationTests.java
@@ -77,7 +77,7 @@ class ReactiveConnectionIntegrationTests extends TestSupport {
 
     @BeforeEach
     void setUp() {
-        this.connection.async().flushall();
+        this.redis.flushall();
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/cluster/AdvancedClusterClientIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/AdvancedClusterClientIntegrationTests.java
@@ -77,7 +77,6 @@ import io.lettuce.test.settings.TestSettings;
  * @author Hari Mani
  */
 @Tag(INTEGRATION_TEST)
-@SuppressWarnings("rawtypes")
 @ExtendWith(LettuceExtension.class)
 class AdvancedClusterClientIntegrationTests extends TestSupport {
 
@@ -431,9 +430,28 @@ class AdvancedClusterClientIntegrationTests extends TestSupport {
     @Test
     void randomKey() {
 
-        writeKeysToTwoNodes();
+        // RedisAdvancedClusterCommands#randomkey() queries one randomly picked partition. Seed every master partition
+        // so any random pick (or its replica) lands on a non-empty keyspace.
+        Set<String> writtenKeys = new HashSet<>();
+        for (RedisClusterNode partition : clusterClient.getPartitions()) {
+            if (partition.getSlots().isEmpty()) {
+                continue; // replicas have no owned slots
+            }
+            String partitionKey = keyForSlot(partition.getSlots().get(0));
+            sync.set(partitionKey, value);
+            writtenKeys.add(partitionKey);
+        }
 
-        assertThat(sync.randomkey()).isIn(KEY_ON_NODE_1, KEY_ON_NODE_2);
+        assertThat(sync.randomkey()).isIn(writtenKeys);
+    }
+
+    private static String keyForSlot(int targetSlot) {
+        for (int j = 0;; j++) {
+            String k = "rk:{rk-" + j + "}";
+            if (SlotHash.getSlot(k) == targetSlot) {
+                return k;
+            }
+        }
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/cluster/AdvancedClusterReactiveIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/AdvancedClusterReactiveIntegrationTests.java
@@ -341,10 +341,29 @@ class AdvancedClusterReactiveIntegrationTests extends TestSupport {
     @Test
     void randomKey() {
 
-        writeKeysToTwoNodes();
+        // RedisAdvancedClusterReactiveCommands#randomkey() queries one randomly picked partition. Seed every master
+        // partition so any random pick (or its replica) lands on a non-empty keyspace.
+        Set<String> writtenKeys = new HashSet<>();
+        for (RedisClusterNode partition : clusterClient.getPartitions()) {
+            if (partition.getSlots().isEmpty()) {
+                continue; // replicas have no owned slots
+            }
+            String partitionKey = keyForSlot(partition.getSlots().get(0));
+            syncCommands.set(partitionKey, value);
+            writtenKeys.add(partitionKey);
+        }
 
-        StepVerifier.create(commands.randomkey())
-                .consumeNextWith(actual -> assertThat(actual).isIn(KEY_ON_NODE_1, KEY_ON_NODE_2)).verifyComplete();
+        StepVerifier.create(commands.randomkey()).consumeNextWith(actual -> assertThat(actual).isIn(writtenKeys))
+                .verifyComplete();
+    }
+
+    private static String keyForSlot(int targetSlot) {
+        for (int j = 0;; j++) {
+            String k = "rk:{rk-" + j + "}";
+            if (SlotHash.getSlot(k) == targetSlot) {
+                return k;
+            }
+        }
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/protocol/CodecFailureIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/protocol/CodecFailureIntegrationTests.java
@@ -15,6 +15,9 @@ import java.nio.charset.StandardCharsets;
 
 import javax.inject.Inject;
 
+import io.lettuce.core.Delegating;
+import io.lettuce.core.RedisChannelHandler;
+import io.lettuce.core.RedisChannelWriter;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.TestSupport;
 import io.lettuce.core.api.sync.RedisCommands;
@@ -26,9 +29,12 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import reactor.core.Disposable;
 
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.test.LettuceExtension;
+import io.lettuce.test.ReflectionTestUtils;
+import io.lettuce.test.Wait;
 
 /**
  * Integration tests for command encoding error scenarios with GET/SET commands against a Redis test instance.
@@ -52,46 +58,56 @@ class CodecFailureIntegrationTests extends TestSupport {
 
     @BeforeEach
     void setUp() {
-        this.connection.async().flushall();
+        this.connection.sync().flushall();
     }
 
     @Test
     void testCommandsWithCustomCodecRuntimeException() {
 
-        final Integer[] reconnects = { 0 };
-        client.getResources().eventBus().get().subscribe(event -> {
-            if (event instanceof ReconnectAttemptEvent) {
-                reconnects[0]++;
-            }
-        });
-
         try (StatefulRedisConnection<String, String> customConnection = client.connect(failingCodec)) {
             RedisCommands<String, String> customRedis = customConnection.sync();
 
-            // First, test that normal values work fine
-            String normalKey = "normal-key";
-            String normalValue = "normal-value";
+            // Filter reconnect events by this connection's endpoint id to avoid contamination
+            // from other connections sharing the same EventBus (the RedisClient is a JVM-wide singleton).
+            final String epId = unwrapEndpoint(customConnection).getId();
+            final Integer[] reconnects = { 0 };
+            Disposable subscription = client.getResources().eventBus().get().subscribe(event -> {
+                if (event instanceof ReconnectAttemptEvent
+                        && epId.equals(ReflectionTestUtils.<String> getField(event, "epId"))) {
+                    reconnects[0]++;
+                }
+            });
 
-            String result = customRedis.set(normalKey, normalValue);
-            assertThat(result).isEqualTo("OK");
+            try {
+                // First, test that normal values work fine
+                String normalKey = "normal-key";
+                String normalValue = "normal-value";
 
-            String retrieved = customRedis.get(normalKey);
-            assertThat(retrieved).isEqualTo(normalValue);
+                String result = customRedis.set(normalKey, normalValue);
+                assertThat(result).isEqualTo("OK");
 
-            // Now test that the specific failure value throws an exception
-            String failingKey = "failing-key";
-            String failingValue = "encoding_failure";
+                String retrieved = customRedis.get(normalKey);
+                assertThat(retrieved).isEqualTo(normalValue);
 
-            assertThatThrownBy(() -> customRedis.set(failingKey, failingValue)).isInstanceOf(EncoderException.class)
-                    .hasMessageContaining(
-                            "Cannot encode command. Closing the connection as the connection state may be out of sync.");
+                // Now test that the specific failure value throws an exception
+                String failingKey = "failing-key";
+                String failingValue = "encoding_failure";
 
-            // test that commands are executed after reconnecting
-            retrieved = customRedis.get(normalKey);
-            assertThat(retrieved).isEqualTo(normalValue);
+                assertThatThrownBy(() -> customRedis.set(failingKey, failingValue)).isInstanceOf(EncoderException.class)
+                        .hasMessageContaining(
+                                "Cannot encode command. Closing the connection as the connection state may be out of sync.");
 
-            // verify that we have reconnected after the exception
-            assertThat(reconnects[0]).isEqualTo(1);
+                // test that commands are executed after reconnecting
+                retrieved = customRedis.get(normalKey);
+                assertThat(retrieved).isEqualTo(normalValue);
+
+                // verify that we have reconnected after the exception. Poll because EventBus delivery
+                // is asynchronous (publishOn scheduler); allow >= 1 to tolerate transient retry attempts
+                // on the same endpoint while still requiring a reconnect originating from this connection.
+                Wait.untilTrue(() -> reconnects[0] >= 1).waitOrTimeout();
+            } finally {
+                subscription.dispose();
+            }
         }
     }
 
@@ -310,5 +326,17 @@ class CodecFailureIntegrationTests extends TestSupport {
         }
 
     };
+
+    @SuppressWarnings("unchecked")
+    private static Endpoint unwrapEndpoint(StatefulRedisConnection<?, ?> connection) {
+        RedisChannelWriter writer = ((RedisChannelHandler<?, ?>) connection).getChannelWriter();
+        if (writer instanceof Delegating) {
+            writer = ((Delegating<RedisChannelWriter>) writer).unwrap();
+        }
+        if (!(writer instanceof Endpoint)) {
+            throw new IllegalStateException("Cannot unwrap " + writer + " to Endpoint");
+        }
+        return ((Endpoint) writer);
+    }
 
 }

--- a/src/test/java/io/lettuce/core/search/RediSearchAdvancedConceptsIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/search/RediSearchAdvancedConceptsIntegrationTests.java
@@ -11,8 +11,8 @@ import io.lettuce.core.ClientOptions;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.sync.RedisCommands;
-import io.lettuce.core.search.arguments.ScoringFunction;
 import io.lettuce.core.search.arguments.*;
+import io.lettuce.test.Wait;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -718,9 +718,9 @@ public class RediSearchAdvancedConceptsIntegrationTests {
         redis.hset("stem:2", "content_stemmed", "runs fast");
         redis.hset("stem:3", "content_stemmed", "runner speed");
 
-        // Search for "run" should find all variations due to stemming
-        SearchReply<String, String> results = redis.ftSearch("stemming-idx", "@content_stemmed:run");
-        assertThat(results.getCount()).isGreaterThanOrEqualTo(2); // Should find "running" and "runs"
+        // Search for "run" should find all variations due to stemming. Poll to absorb the brief
+        // indexing lag between HSET and the keyspace-notification driven RediSearch indexer.
+        Wait.untilTrue(() -> redis.ftSearch("stemming-idx", "@content_stemmed:run").getCount() >= 2).waitOrTimeout();
 
         redis.ftDropindex("stemming-idx");
 
@@ -738,12 +738,12 @@ public class RediSearchAdvancedConceptsIntegrationTests {
         redis.hset("nostem:3", "content_exact", "runner speed");
         redis.hset("nostem:4", "content_exact", "run now");
 
-        // Search for "run" should only find exact matches
-        results = redis.ftSearch("nostemming-idx", "@content_exact:run");
-        assertThat(results.getCount()).isEqualTo(1); // Only "run now"
+        // Search for "run" should only find exact matches. Poll the first search against the
+        // freshly-populated index to absorb the indexing lag.
+        Wait.untilEquals(1L, () -> redis.ftSearch("nostemming-idx", "@content_exact:run").getCount()).waitOrTimeout();
 
         // Search for "running" should only find exact matches
-        results = redis.ftSearch("nostemming-idx", "@content_exact:running");
+        SearchReply<String, String> results = redis.ftSearch("nostemming-idx", "@content_exact:running");
         assertThat(results.getCount()).isEqualTo(1); // Only "running quickly"
 
         // Search for "runs" should only find exact matches
@@ -767,9 +767,9 @@ public class RediSearchAdvancedConceptsIntegrationTests {
         mixedDoc.put("exact_content", "running marathon");
         redis.hmset("mixed:1", mixedDoc);
 
-        // Search in stemmed field should find with "run"
-        results = redis.ftSearch("mixed-idx", "@stemmed_content:run");
-        assertThat(results.getCount()).isEqualTo(1);
+        // Search in stemmed field should find with "run". Poll the first search against the
+        // freshly-populated index to absorb the indexing lag.
+        Wait.untilEquals(1L, () -> redis.ftSearch("mixed-idx", "@stemmed_content:run").getCount()).waitOrTimeout();
 
         // Search in exact field should not find with "run"
         results = redis.ftSearch("mixed-idx", "@exact_content:run");


### PR DESCRIPTION
Removes flakiness from a set of integration tests that were failing non-deterministically in CI. Test-only changes.

### `PipeliningIntegrationTests`, `ReactiveConnectionIntegrationTests`, `CodecFailureIntegrationTests`

`@BeforeEach` ran `connection.async().flushall()` fire-and-forget, so a test body could start against a keyspace that wasn't yet flushed. Switched to the sync form.

### `CommandListenerIntegrationTests`

Listener callbacks fire on the Netty I/O thread *after* the sync caller has already been unblocked by `command.complete(...)`, so the eager `hasSize(...)` assertions ran before the lists were populated. Replaced with `Wait.untilEquals(...)` polling.

### `AdvancedClusterClientIntegrationTests.randomKey`, `AdvancedClusterReactiveIntegrationTests.randomKey`

`RANDOMKEY` is dispatched to a randomly-picked partition, but the test only seeded two nodes — so a pick on an unseeded node returned `null` and failed the assertion. Now seeds every master partition with a slot-targeted key and asserts the result is in the seeded set.

### `CodecFailureIntegrationTests.testCommandsWithCustomCodecRuntimeException`

`reconnects[0] == 1` was brittle because the `EventBus` is JVM-singleton (cross-connection contamination), `ConnectionWatchdog` publishes one event per retry (retry inflation), and event delivery is async (race with the assertion). Now filters events by the connection's `epId` (resolved via `Delegating.unwrap()` to the underlying `Endpoint`), polls with `Wait.untilTrue(>= 1)`, and disposes the subscription on completion.

### `RediSearchAdvancedConceptsIntegrationTests.testNoStemmingOption`

The first search against a freshly-populated index could race RediSearch's keyspace-notification indexer and observe `count == 0`. Wrapped each first-search-after-fresh-index in a `Wait.untilTrue/untilEquals` poll on the same predicate; subsequent searches keep their direct assertions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that reduce timing-related flakiness by switching to synchronous setup and adding polling around async/eventual-consistency behaviors; low product risk but could mask real regressions if timeouts are too lenient.
> 
> **Overview**
> Improves integration test stability by removing race conditions and eventual-consistency assumptions.
> 
> Several tests now use synchronous `FLUSHALL` in `@BeforeEach` to ensure a clean keyspace before assertions, and `CommandListenerIntegrationTests` replaces immediate event-count assertions with `Wait.untilEquals(...)` polling to account for listener callbacks running asynchronously.
> 
> Cluster `randomkey()` tests now seed *every* master partition with a slot-targeted key and assert the returned key is from the seeded set, avoiding `null` results from randomly chosen empty partitions. Codec failure tests filter `ReconnectAttemptEvent`s by the connection endpoint id, poll for reconnect delivery, and dispose the event subscription to avoid cross-test/event-bus contamination. RediSearch stemming tests poll initial queries to absorb indexer lag after writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b84803d136a308c3d3b787309f25e1970f8a0581. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->