### PR TITLE
Wire old methods to new methods

### DIFF
--- a/src/main/java/io/lettuce/core/AbstractRedisClient.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisClient.java
@@ -36,7 +36,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import io.lettuce.core.MaintNotificationsConfig.EndpointTypeSource;
-import reactor.core.publisher.Mono;
 import io.lettuce.core.api.BaseRedisClient;
 import io.lettuce.core.event.command.CommandListener;
 import io.lettuce.core.event.connection.ConnectEvent;
@@ -260,38 +259,6 @@ public abstract class AbstractRedisClient implements BaseRedisClient {
         connectionBuilder.channelGroup(channels).connectionEvents(connectionEvents == this.connectionEvents ? connectionEvents
                 : ConnectionEvents.of(this.connectionEvents, connectionEvents));
         connectionBuilder.socketAddressSupplier(socketAddressSupplier);
-    }
-
-    /**
-     * Populate connection builder with necessary resources.
-     *
-     * @param socketAddressSupplier address supplier for initial connect and re-connect
-     * @param connectionBuilder connection builder to configure the connection
-     * @param redisURI URI of the Redis instance
-     * @deprecated since 7.0, use {@link #connectionBuilder(Supplier, ConnectionBuilder, RedisURI)} instead. This method will be
-     *             removed in a future major release as part of the effort to make Reactor an optional dependency.
-     */
-    @Deprecated
-    protected void connectionBuilder(Mono<SocketAddress> socketAddressSupplier, ConnectionBuilder connectionBuilder,
-            RedisURI redisURI) {
-        connectionBuilder(() -> socketAddressSupplier.toFuture(), connectionBuilder, connectionEvents, redisURI);
-    }
-
-    /**
-     * Populate connection builder with necessary resources.
-     *
-     * @param socketAddressSupplier address supplier for initial connect and re-connect
-     * @param connectionBuilder connection builder to configure the connection
-     * @param connectionEvents connection events dispatcher
-     * @param redisURI URI of the Redis instance
-     * @deprecated since 7.0, use {@link #connectionBuilder(Supplier, ConnectionBuilder, ConnectionEvents, RedisURI)} instead.
-     *             This method will be removed in a future major release as part of the effort to make Reactor an optional
-     *             dependency.
-     */
-    @Deprecated
-    protected void connectionBuilder(Mono<SocketAddress> socketAddressSupplier, ConnectionBuilder connectionBuilder,
-            ConnectionEvents connectionEvents, RedisURI redisURI) {
-        connectionBuilder(() -> socketAddressSupplier.toFuture(), connectionBuilder, connectionEvents, redisURI);
     }
 
     protected void channelType(ConnectionBuilder connectionBuilder, ConnectionPoint connectionPoint) {

--- a/src/main/java/io/lettuce/core/AbstractRedisClient.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisClient.java
@@ -250,8 +250,16 @@ public abstract class AbstractRedisClient implements BaseRedisClient {
      */
     protected void connectionBuilder(Supplier<CompletionStage<SocketAddress>> socketAddressSupplier,
             ConnectionBuilder connectionBuilder, ConnectionEvents connectionEvents, RedisURI redisURI) {
-        connectionBuilder(Mono.defer(() -> Mono.fromCompletionStage(socketAddressSupplier.get())), connectionBuilder,
-                connectionEvents, redisURI);
+
+        Bootstrap redisBootstrap = new Bootstrap();
+        redisBootstrap.option(ChannelOption.ALLOCATOR, ByteBufAllocator.DEFAULT);
+
+        connectionBuilder.bootstrap(redisBootstrap);
+        connectionBuilder.apply(redisURI);
+        connectionBuilder.configureBootstrap(!LettuceStrings.isEmpty(redisURI.getSocket()), this::getEventLoopGroup);
+        connectionBuilder.channelGroup(channels).connectionEvents(connectionEvents == this.connectionEvents ? connectionEvents
+                : ConnectionEvents.of(this.connectionEvents, connectionEvents));
+        connectionBuilder.socketAddressSupplier(socketAddressSupplier);
     }
 
     /**
@@ -266,7 +274,7 @@ public abstract class AbstractRedisClient implements BaseRedisClient {
     @Deprecated
     protected void connectionBuilder(Mono<SocketAddress> socketAddressSupplier, ConnectionBuilder connectionBuilder,
             RedisURI redisURI) {
-        connectionBuilder(socketAddressSupplier, connectionBuilder, connectionEvents, redisURI);
+        connectionBuilder(() -> socketAddressSupplier.toFuture(), connectionBuilder, connectionEvents, redisURI);
     }
 
     /**
@@ -283,16 +291,7 @@ public abstract class AbstractRedisClient implements BaseRedisClient {
     @Deprecated
     protected void connectionBuilder(Mono<SocketAddress> socketAddressSupplier, ConnectionBuilder connectionBuilder,
             ConnectionEvents connectionEvents, RedisURI redisURI) {
-
-        Bootstrap redisBootstrap = new Bootstrap();
-        redisBootstrap.option(ChannelOption.ALLOCATOR, ByteBufAllocator.DEFAULT);
-
-        connectionBuilder.bootstrap(redisBootstrap);
-        connectionBuilder.apply(redisURI);
-        connectionBuilder.configureBootstrap(!LettuceStrings.isEmpty(redisURI.getSocket()), this::getEventLoopGroup);
-        connectionBuilder.channelGroup(channels).connectionEvents(connectionEvents == this.connectionEvents ? connectionEvents
-                : ConnectionEvents.of(this.connectionEvents, connectionEvents));
-        connectionBuilder.socketAddressSupplier(() -> socketAddressSupplier.toFuture());
+        connectionBuilder(() -> socketAddressSupplier.toFuture(), connectionBuilder, connectionEvents, redisURI);
     }
 
     protected void channelType(ConnectionBuilder connectionBuilder, ConnectionPoint connectionPoint) {

--- a/src/main/java/io/lettuce/core/AbstractRedisClient.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisClient.java
@@ -268,8 +268,8 @@ public abstract class AbstractRedisClient implements BaseRedisClient {
      * @param socketAddressSupplier address supplier for initial connect and re-connect
      * @param connectionBuilder connection builder to configure the connection
      * @param redisURI URI of the Redis instance
-     * @deprecated since 7.0, use {@link #connectionBuilder(Supplier, ConnectionBuilder, RedisURI)} instead. This method will
-     *             be removed in a future major release as part of the effort to make Reactor an optional dependency.
+     * @deprecated since 7.0, use {@link #connectionBuilder(Supplier, ConnectionBuilder, RedisURI)} instead. This method will be
+     *             removed in a future major release as part of the effort to make Reactor an optional dependency.
      */
     @Deprecated
     protected void connectionBuilder(Mono<SocketAddress> socketAddressSupplier, ConnectionBuilder connectionBuilder,

--- a/src/main/java/io/lettuce/core/AbstractRedisClient.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisClient.java
@@ -36,6 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import io.lettuce.core.MaintNotificationsConfig.EndpointTypeSource;
+import reactor.core.publisher.Mono;
 import io.lettuce.core.api.BaseRedisClient;
 import io.lettuce.core.event.command.CommandListener;
 import io.lettuce.core.event.connection.ConnectEvent;
@@ -259,6 +260,38 @@ public abstract class AbstractRedisClient implements BaseRedisClient {
         connectionBuilder.channelGroup(channels).connectionEvents(connectionEvents == this.connectionEvents ? connectionEvents
                 : ConnectionEvents.of(this.connectionEvents, connectionEvents));
         connectionBuilder.socketAddressSupplier(socketAddressSupplier);
+    }
+
+    /**
+     * Populate connection builder with necessary resources.
+     *
+     * @param socketAddressSupplier address supplier for initial connect and re-connect
+     * @param connectionBuilder connection builder to configure the connection
+     * @param redisURI URI of the Redis instance
+     * @deprecated since 7.0, use {@link #connectionBuilder(Supplier, ConnectionBuilder, RedisURI)} instead. This method will
+     *             be removed in a future major release as part of the effort to make Reactor an optional dependency.
+     */
+    @Deprecated
+    protected void connectionBuilder(Mono<SocketAddress> socketAddressSupplier, ConnectionBuilder connectionBuilder,
+            RedisURI redisURI) {
+        connectionBuilder(() -> socketAddressSupplier.toFuture(), connectionBuilder, connectionEvents, redisURI);
+    }
+
+    /**
+     * Populate connection builder with necessary resources.
+     *
+     * @param socketAddressSupplier address supplier for initial connect and re-connect
+     * @param connectionBuilder connection builder to configure the connection
+     * @param connectionEvents connection events dispatcher
+     * @param redisURI URI of the Redis instance
+     * @deprecated since 7.0, use {@link #connectionBuilder(Supplier, ConnectionBuilder, ConnectionEvents, RedisURI)} instead.
+     *             This method will be removed in a future major release as part of the effort to make Reactor an optional
+     *             dependency.
+     */
+    @Deprecated
+    protected void connectionBuilder(Mono<SocketAddress> socketAddressSupplier, ConnectionBuilder connectionBuilder,
+            ConnectionEvents connectionEvents, RedisURI redisURI) {
+        connectionBuilder(() -> socketAddressSupplier.toFuture(), connectionBuilder, connectionEvents, redisURI);
     }
 
     protected void channelType(ConnectionBuilder connectionBuilder, ConnectionPoint connectionPoint) {

--- a/src/main/java/io/lettuce/core/AbstractRedisClient.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisClient.java
@@ -66,6 +66,7 @@ import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.Future;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import reactor.core.publisher.Mono;
 
 /**
  * Base Redis client. This class holds the netty infrastructure, {@link ClientOptions} and the basic connection procedure. This
@@ -245,10 +246,43 @@ public abstract class AbstractRedisClient implements BaseRedisClient {
      * @param connectionBuilder connection builder to configure the connection
      * @param connectionEvents connection events dispatcher
      * @param redisURI URI of the Redis instance
-     * @since 6.2
+     * @since 7.0
      */
     protected void connectionBuilder(Supplier<CompletionStage<SocketAddress>> socketAddressSupplier,
             ConnectionBuilder connectionBuilder, ConnectionEvents connectionEvents, RedisURI redisURI) {
+        connectionBuilder(Mono.defer(() -> Mono.fromCompletionStage(socketAddressSupplier.get())), connectionBuilder,
+                connectionEvents, redisURI);
+    }
+
+    /**
+     * Populate connection builder with necessary resources.
+     *
+     * @param socketAddressSupplier address supplier for initial connect and re-connect
+     * @param connectionBuilder connection builder to configure the connection
+     * @param redisURI URI of the Redis instance
+     * @deprecated since 7.0, use {@link #connectionBuilder(Supplier, ConnectionBuilder, RedisURI)} instead. This method will be
+     *             removed in a future major release as part of the effort to make Reactor an optional dependency.
+     */
+    @Deprecated
+    protected void connectionBuilder(Mono<SocketAddress> socketAddressSupplier, ConnectionBuilder connectionBuilder,
+            RedisURI redisURI) {
+        connectionBuilder(socketAddressSupplier, connectionBuilder, connectionEvents, redisURI);
+    }
+
+    /**
+     * Populate connection builder with necessary resources.
+     *
+     * @param socketAddressSupplier address supplier for initial connect and re-connect
+     * @param connectionBuilder connection builder to configure the connection
+     * @param connectionEvents connection events dispatcher
+     * @param redisURI URI of the Redis instance
+     * @deprecated since 7.0, use {@link #connectionBuilder(Supplier, ConnectionBuilder, ConnectionEvents, RedisURI)} instead.
+     *             This method will be removed in a future major release as part of the effort to make Reactor an optional
+     *             dependency.
+     */
+    @Deprecated
+    protected void connectionBuilder(Mono<SocketAddress> socketAddressSupplier, ConnectionBuilder connectionBuilder,
+            ConnectionEvents connectionEvents, RedisURI redisURI) {
 
         Bootstrap redisBootstrap = new Bootstrap();
         redisBootstrap.option(ChannelOption.ALLOCATOR, ByteBufAllocator.DEFAULT);
@@ -258,7 +292,7 @@ public abstract class AbstractRedisClient implements BaseRedisClient {
         connectionBuilder.configureBootstrap(!LettuceStrings.isEmpty(redisURI.getSocket()), this::getEventLoopGroup);
         connectionBuilder.channelGroup(channels).connectionEvents(connectionEvents == this.connectionEvents ? connectionEvents
                 : ConnectionEvents.of(this.connectionEvents, connectionEvents));
-        connectionBuilder.socketAddressSupplier(socketAddressSupplier);
+        connectionBuilder.socketAddressSupplier(() -> socketAddressSupplier.toFuture());
     }
 
     protected void channelType(ConnectionBuilder connectionBuilder, ConnectionPoint connectionPoint) {

--- a/src/main/java/io/lettuce/core/RedisClient.java
+++ b/src/main/java/io/lettuce/core/RedisClient.java
@@ -697,8 +697,9 @@ public class RedisClient extends AbstractRedisClient {
      * @see ClientResources#addressResolverGroup()
      * @see RedisURI#getSentinels()
      * @see RedisURI#getSentinelMasterId()
+     * @since 7.0
      */
-    protected Supplier<CompletionStage<SocketAddress>> getSocketAddress(RedisURI redisURI) {
+    protected Supplier<CompletionStage<SocketAddress>> getSocketAddressStage(RedisURI redisURI) {
         return () -> {
             if (redisURI.getSentinelMasterId() != null && !redisURI.getSentinels().isEmpty()) {
                 logger.debug("Connecting to Redis using Sentinels {}, MasterId {}", redisURI.getSentinels(),
@@ -714,6 +715,25 @@ public class RedisClient extends AbstractRedisClient {
                 return CompletableFuture.completedFuture(getResources().socketAddressResolver().resolve(redisURI));
             }
         };
+    }
+
+    /**
+     * Get a {@link Mono} that resolves {@link RedisURI} to a {@link SocketAddress}. Resolution is performed either using Redis
+     * Sentinel (if the {@link RedisURI} is configured with Sentinels) or via DNS resolution.
+     * <p>
+     * Subclasses of {@link RedisClient} may override that method.
+     *
+     * @param redisURI must not be {@code null}.
+     * @return the resolved {@link SocketAddress}.
+     * @see ClientResources#addressResolverGroup()
+     * @see RedisURI#getSentinels()
+     * @see RedisURI#getSentinelMasterId()
+     * @deprecated since 7.0, use {@link #getSocketAddressStage(RedisURI)} instead. This method will be removed in a future
+     *             major release as part of the effort to make Reactor an optional dependency.
+     */
+    @Deprecated
+    protected Mono<SocketAddress> getSocketAddress(RedisURI redisURI) {
+        return Mono.defer(() -> Mono.fromCompletionStage(getSocketAddressStage(redisURI).get()));
     }
 
     /**
@@ -745,7 +765,7 @@ public class RedisClient extends AbstractRedisClient {
     }
 
     private Supplier<CompletionStage<SocketAddress>> getSocketAddressSupplier(RedisURI redisURI) {
-        Supplier<CompletionStage<SocketAddress>> delegate = getSocketAddress(redisURI);
+        Supplier<CompletionStage<SocketAddress>> delegate = getSocketAddressStage(redisURI);
         return () -> delegate.get().thenApply(addr -> {
             logger.debug("Resolved SocketAddress {} using {}", addr, redisURI);
             return addr;

--- a/src/main/java/io/lettuce/core/RedisClient.java
+++ b/src/main/java/io/lettuce/core/RedisClient.java
@@ -765,8 +765,7 @@ public class RedisClient extends AbstractRedisClient {
     }
 
     private Supplier<CompletionStage<SocketAddress>> getSocketAddressSupplier(RedisURI redisURI) {
-        Supplier<CompletionStage<SocketAddress>> delegate = getSocketAddressStage(redisURI);
-        return () -> delegate.get().thenApply(addr -> {
+        return () -> getSocketAddress(redisURI).toFuture().thenApply(addr -> {
             logger.debug("Resolved SocketAddress {} using {}", addr, redisURI);
             return addr;
         });

--- a/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
@@ -702,21 +702,26 @@ public class RedisClusterClient extends AbstractRedisClient {
 
         Supplier<CommandHandler> commandHandlerSupplier = () -> new CommandHandler(getClusterClientOptions(), getResources(),
                 endpoint);
-        Mono<SocketAddress> socketAddressMono = getSocketAddressSupplier(connection::getPartitions,
-                TopologyComparators::sortByClientCount);
-        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = () -> socketAddressMono.toFuture();
-        Mono<StatefulRedisClusterConnectionImpl<K, V>> connectionMono = Mono
-                .defer(() -> connect(socketAddressSupplier, endpoint, connection, commandHandlerSupplier));
+        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = getSocketAddressSupplierStage(
+                connection::getPartitions, TopologyComparators::sortByClientCount);
+
+        CompletableFuture<StatefulRedisClusterConnection<K, V>> result = connectFuture(socketAddressSupplier, endpoint,
+                connection, commandHandlerSupplier);
 
         for (int i = 1; i < getConnectionAttempts(); i++) {
-            connectionMono = connectionMono
-                    .onErrorResume(t -> connect(socketAddressSupplier, endpoint, connection, commandHandlerSupplier));
+            result = result
+                    .<CompletableFuture<StatefulRedisClusterConnection<K, V>>> handle((v, t) -> {
+                        if (t != null) {
+                            return connectFuture(socketAddressSupplier, endpoint, connection, commandHandlerSupplier);
+                        }
+                        return CompletableFuture.completedFuture(v);
+                    }).thenCompose(f -> f);
         }
 
-        return connectionMono
-                .doOnNext(
-                        c -> connection.registerCloseables(closeableResources, clusterWriter, pooledClusterConnectionProvider))
-                .map(it -> (StatefulRedisClusterConnection<K, V>) it).toFuture();
+        return result.thenApply(c -> {
+            connection.registerCloseables(closeableResources, clusterWriter, pooledClusterConnectionProvider);
+            return c;
+        });
     }
 
     /**
@@ -775,6 +780,36 @@ public class RedisClusterClient extends AbstractRedisClient {
         return Mono.fromCompletionStage(future).doOnError(t -> logger.warn(t.getMessage()));
     }
 
+    @SuppressWarnings("unchecked")
+    private <T, K, V> CompletableFuture<T> connectFuture(Supplier<CompletionStage<SocketAddress>> socketAddressSupplier,
+            DefaultEndpoint endpoint, StatefulRedisClusterConnectionImpl<K, V> connection,
+            Supplier<CommandHandler> commandHandlerSupplier) {
+
+        ConnectionFuture<T> future = connectStatefulAsync(connection, endpoint, getFirstUri(), socketAddressSupplier,
+                commandHandlerSupplier);
+
+        return future.toCompletableFuture().whenComplete((v, t) -> {
+            if (t != null) {
+                logger.warn(t.getMessage());
+            }
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T, K, V> CompletableFuture<T> connectFuture(Supplier<CompletionStage<SocketAddress>> socketAddressSupplier,
+            DefaultEndpoint endpoint, StatefulRedisConnectionImpl<K, V> connection,
+            Supplier<CommandHandler> commandHandlerSupplier) {
+
+        ConnectionFuture<T> future = connectStatefulAsync(connection, endpoint, getFirstUri(), socketAddressSupplier,
+                commandHandlerSupplier);
+
+        return future.toCompletableFuture().whenComplete((v, t) -> {
+            if (t != null) {
+                logger.warn(t.getMessage());
+            }
+        });
+    }
+
     /**
      * Create a clustered connection with command distributor.
      *
@@ -822,21 +857,26 @@ public class RedisClusterClient extends AbstractRedisClient {
 
         Supplier<CommandHandler> commandHandlerSupplier = () -> new PubSubCommandHandler<>(getClusterClientOptions(),
                 getResources(), codec, endpoint);
-        Mono<SocketAddress> pubSubSocketAddressMono = getSocketAddressSupplier(connection::getPartitions,
-                TopologyComparators::sortByClientCount);
-        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = () -> pubSubSocketAddressMono.toFuture();
-        Mono<StatefulRedisClusterPubSubConnectionImpl<K, V>> connectionMono = Mono
-                .defer(() -> connect(socketAddressSupplier, endpoint, connection, commandHandlerSupplier));
+        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = getSocketAddressSupplierStage(
+                connection::getPartitions, TopologyComparators::sortByClientCount);
+
+        CompletableFuture<StatefulRedisClusterPubSubConnection<K, V>> result = connectFuture(socketAddressSupplier, endpoint,
+                connection, commandHandlerSupplier);
 
         for (int i = 1; i < getConnectionAttempts(); i++) {
-            connectionMono = connectionMono
-                    .onErrorResume(t -> connect(socketAddressSupplier, endpoint, connection, commandHandlerSupplier));
+            result = result
+                    .<CompletableFuture<StatefulRedisClusterPubSubConnection<K, V>>> handle((v, t) -> {
+                        if (t != null) {
+                            return connectFuture(socketAddressSupplier, endpoint, connection, commandHandlerSupplier);
+                        }
+                        return CompletableFuture.completedFuture(v);
+                    }).thenCompose(f -> f);
         }
 
-        return connectionMono
-                .doOnNext(
-                        c -> connection.registerCloseables(closeableResources, clusterWriter, pooledClusterConnectionProvider))
-                .map(it -> (StatefulRedisClusterPubSubConnection<K, V>) it).toFuture();
+        return result.thenApply(c -> {
+            connection.registerCloseables(closeableResources, clusterWriter, pooledClusterConnectionProvider);
+            return (StatefulRedisClusterPubSubConnection<K, V>) c;
+        });
     }
 
     private int getConnectionAttempts() {

--- a/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
@@ -702,8 +702,8 @@ public class RedisClusterClient extends AbstractRedisClient {
 
         Supplier<CommandHandler> commandHandlerSupplier = () -> new CommandHandler(getClusterClientOptions(), getResources(),
                 endpoint);
-        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = getSocketAddressSupplierStage(
-                connection::getPartitions, TopologyComparators::sortByClientCount);
+        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = () -> getSocketAddressSupplier(
+                connection::getPartitions, TopologyComparators::sortByClientCount).toFuture();
         Mono<StatefulRedisClusterConnectionImpl<K, V>> connectionMono = Mono
                 .defer(() -> connect(socketAddressSupplier, endpoint, connection, commandHandlerSupplier));
 
@@ -821,8 +821,8 @@ public class RedisClusterClient extends AbstractRedisClient {
 
         Supplier<CommandHandler> commandHandlerSupplier = () -> new PubSubCommandHandler<>(getClusterClientOptions(),
                 getResources(), codec, endpoint);
-        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = getSocketAddressSupplierStage(
-                connection::getPartitions, TopologyComparators::sortByClientCount);
+        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = () -> getSocketAddressSupplier(
+                connection::getPartitions, TopologyComparators::sortByClientCount).toFuture();
         Mono<StatefulRedisClusterPubSubConnectionImpl<K, V>> connectionMono = Mono
                 .defer(() -> connect(socketAddressSupplier, endpoint, connection, commandHandlerSupplier));
 

--- a/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
@@ -709,13 +709,12 @@ public class RedisClusterClient extends AbstractRedisClient {
                 connection, commandHandlerSupplier);
 
         for (int i = 1; i < getConnectionAttempts(); i++) {
-            result = result
-                    .<CompletableFuture<StatefulRedisClusterConnection<K, V>>> handle((v, t) -> {
-                        if (t != null) {
-                            return connectFuture(socketAddressSupplier, endpoint, connection, commandHandlerSupplier);
-                        }
-                        return CompletableFuture.completedFuture(v);
-                    }).thenCompose(f -> f);
+            result = result.<CompletableFuture<StatefulRedisClusterConnection<K, V>>> handle((v, t) -> {
+                if (t != null) {
+                    return connectFuture(socketAddressSupplier, endpoint, connection, commandHandlerSupplier);
+                }
+                return CompletableFuture.completedFuture(v);
+            }).thenCompose(f -> f);
         }
 
         return result.thenApply(c -> {
@@ -864,13 +863,12 @@ public class RedisClusterClient extends AbstractRedisClient {
                 connection, commandHandlerSupplier);
 
         for (int i = 1; i < getConnectionAttempts(); i++) {
-            result = result
-                    .<CompletableFuture<StatefulRedisClusterPubSubConnection<K, V>>> handle((v, t) -> {
-                        if (t != null) {
-                            return connectFuture(socketAddressSupplier, endpoint, connection, commandHandlerSupplier);
-                        }
-                        return CompletableFuture.completedFuture(v);
-                    }).thenCompose(f -> f);
+            result = result.<CompletableFuture<StatefulRedisClusterPubSubConnection<K, V>>> handle((v, t) -> {
+                if (t != null) {
+                    return connectFuture(socketAddressSupplier, endpoint, connection, commandHandlerSupplier);
+                }
+                return CompletableFuture.completedFuture(v);
+            }).thenCompose(f -> f);
         }
 
         return result.thenApply(c -> {

--- a/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
@@ -702,8 +702,8 @@ public class RedisClusterClient extends AbstractRedisClient {
 
         Supplier<CommandHandler> commandHandlerSupplier = () -> new CommandHandler(getClusterClientOptions(), getResources(),
                 endpoint);
-        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = getSocketAddressSupplier(connection::getPartitions,
-                TopologyComparators::sortByClientCount);
+        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = getSocketAddressSupplierStage(
+                connection::getPartitions, TopologyComparators::sortByClientCount);
         Mono<StatefulRedisClusterConnectionImpl<K, V>> connectionMono = Mono
                 .defer(() -> connect(socketAddressSupplier, endpoint, connection, commandHandlerSupplier));
 
@@ -821,8 +821,8 @@ public class RedisClusterClient extends AbstractRedisClient {
 
         Supplier<CommandHandler> commandHandlerSupplier = () -> new PubSubCommandHandler<>(getClusterClientOptions(),
                 getResources(), codec, endpoint);
-        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = getSocketAddressSupplier(connection::getPartitions,
-                TopologyComparators::sortByClientCount);
+        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = getSocketAddressSupplierStage(
+                connection::getPartitions, TopologyComparators::sortByClientCount);
         Mono<StatefulRedisClusterPubSubConnectionImpl<K, V>> connectionMono = Mono
                 .defer(() -> connect(socketAddressSupplier, endpoint, connection, commandHandlerSupplier));
 
@@ -1172,13 +1172,15 @@ public class RedisClusterClient extends AbstractRedisClient {
     }
 
     /**
-     * Returns a {@link Supplier} for a {@link SocketAddress}
+     * Returns a {@link Supplier} that produces a {@link CompletionStage} for a {@link SocketAddress}.
      *
+     * @param partitionsSupplier supplier for the current partitions, must not be {@code null}.
      * @param sortFunction Sort function to enforce a specific order. The sort function must not change the order or the input
      *        parameter but create a new collection with the desired order, must not be {@code null}.
      * @return {@link Supplier} for {@link SocketAddress connection points}.
+     * @since 7.0
      */
-    protected Supplier<CompletionStage<SocketAddress>> getSocketAddressSupplier(Supplier<Partitions> partitionsSupplier,
+    protected Supplier<CompletionStage<SocketAddress>> getSocketAddressSupplierStage(Supplier<Partitions> partitionsSupplier,
             Function<Partitions, Collection<RedisClusterNode>> sortFunction) {
 
         LettuceAssert.notNull(sortFunction, "Sort function must not be null");
@@ -1200,6 +1202,23 @@ public class RedisClusterClient extends AbstractRedisClient {
                 return Futures.failed(e);
             }
         };
+    }
+
+    /**
+     * Returns a {@link Supplier} for {@link SocketAddress connection points}.
+     *
+     * @param partitionsSupplier supplier for the current partitions, must not be {@code null}.
+     * @param sortFunction Sort function to enforce a specific order. The sort function must not change the order or the input
+     *        parameter but create a new collection with the desired order, must not be {@code null}.
+     * @return {@link Supplier} for {@link SocketAddress connection points}.
+     * @deprecated since 7.0, use {@link #getSocketAddressSupplierStage(Supplier, Function)} instead. This method will be
+     *             removed in a future major release as part of the effort to make Reactor an optional dependency.
+     */
+    @Deprecated
+    protected Mono<SocketAddress> getSocketAddressSupplier(Supplier<Partitions> partitionsSupplier,
+            Function<Partitions, Collection<RedisClusterNode>> sortFunction) {
+        Supplier<CompletionStage<SocketAddress>> delegate = getSocketAddressSupplierStage(partitionsSupplier, sortFunction);
+        return Mono.defer(() -> Mono.fromCompletionStage(delegate.get()));
     }
 
     /**

--- a/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
@@ -702,8 +702,9 @@ public class RedisClusterClient extends AbstractRedisClient {
 
         Supplier<CommandHandler> commandHandlerSupplier = () -> new CommandHandler(getClusterClientOptions(), getResources(),
                 endpoint);
-        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = () -> getSocketAddressSupplier(
-                connection::getPartitions, TopologyComparators::sortByClientCount).toFuture();
+        Mono<SocketAddress> socketAddressMono = getSocketAddressSupplier(connection::getPartitions,
+                TopologyComparators::sortByClientCount);
+        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = () -> socketAddressMono.toFuture();
         Mono<StatefulRedisClusterConnectionImpl<K, V>> connectionMono = Mono
                 .defer(() -> connect(socketAddressSupplier, endpoint, connection, commandHandlerSupplier));
 
@@ -821,8 +822,9 @@ public class RedisClusterClient extends AbstractRedisClient {
 
         Supplier<CommandHandler> commandHandlerSupplier = () -> new PubSubCommandHandler<>(getClusterClientOptions(),
                 getResources(), codec, endpoint);
-        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = () -> getSocketAddressSupplier(
-                connection::getPartitions, TopologyComparators::sortByClientCount).toFuture();
+        Mono<SocketAddress> pubSubSocketAddressMono = getSocketAddressSupplier(connection::getPartitions,
+                TopologyComparators::sortByClientCount);
+        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = () -> pubSubSocketAddressMono.toFuture();
         Mono<StatefulRedisClusterPubSubConnectionImpl<K, V>> connectionMono = Mono
                 .defer(() -> connect(socketAddressSupplier, endpoint, connection, commandHandlerSupplier));
 

--- a/src/main/java/io/lettuce/core/protocol/ConnectionWatchdog.java
+++ b/src/main/java/io/lettuce/core/protocol/ConnectionWatchdog.java
@@ -141,8 +141,8 @@ public class ConnectionWatchdog extends ChannelInboundHandlerAdapter {
         this.redisUri = (String) bootstrap.config().attrs().get(ConnectionBuilder.REDIS_URI);
         this.epid = endpoint.getId();
 
-        Supplier<CompletionStage<SocketAddress>> wrappedSocketAddressSupplier = wrapSocketAddressSupplierStage(
-                socketAddressSupplier);
+        Supplier<CompletionStage<SocketAddress>> wrappedSocketAddressSupplier = () -> wrapSocketAddressSupplier(
+                Mono.defer(() -> Mono.fromCompletionStage(socketAddressSupplier.get()))).toFuture();
         this.reconnectionHandler = new ReconnectionHandler(clientOptions, bootstrap, wrappedSocketAddressSupplier);
 
         resetReconnectDelay();

--- a/src/main/java/io/lettuce/core/protocol/ConnectionWatchdog.java
+++ b/src/main/java/io/lettuce/core/protocol/ConnectionWatchdog.java
@@ -141,8 +141,9 @@ public class ConnectionWatchdog extends ChannelInboundHandlerAdapter {
         this.redisUri = (String) bootstrap.config().attrs().get(ConnectionBuilder.REDIS_URI);
         this.epid = endpoint.getId();
 
-        Supplier<CompletionStage<SocketAddress>> wrappedSocketAddressSupplier = () -> wrapSocketAddressSupplier(
-                Mono.defer(() -> Mono.fromCompletionStage(socketAddressSupplier.get()))).toFuture();
+        Mono<SocketAddress> wrappedMono = wrapSocketAddressSupplier(
+                Mono.defer(() -> Mono.fromCompletionStage(socketAddressSupplier.get())));
+        Supplier<CompletionStage<SocketAddress>> wrappedSocketAddressSupplier = () -> wrappedMono.toFuture();
         this.reconnectionHandler = new ReconnectionHandler(clientOptions, bootstrap, wrappedSocketAddressSupplier);
 
         resetReconnectDelay();

--- a/src/main/java/io/lettuce/core/protocol/ConnectionWatchdog.java
+++ b/src/main/java/io/lettuce/core/protocol/ConnectionWatchdog.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
+import reactor.core.publisher.Mono;
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.ConnectionBuilder;
 import io.lettuce.core.ConnectionEvents;
@@ -140,14 +141,21 @@ public class ConnectionWatchdog extends ChannelInboundHandlerAdapter {
         this.redisUri = (String) bootstrap.config().attrs().get(ConnectionBuilder.REDIS_URI);
         this.epid = endpoint.getId();
 
-        Supplier<CompletionStage<SocketAddress>> wrappedSocketAddressSupplier = wrapSocketAddressSupplier(
+        Supplier<CompletionStage<SocketAddress>> wrappedSocketAddressSupplier = wrapSocketAddressSupplierStage(
                 socketAddressSupplier);
         this.reconnectionHandler = new ReconnectionHandler(clientOptions, bootstrap, wrappedSocketAddressSupplier);
 
         resetReconnectDelay();
     }
 
-    protected Supplier<CompletionStage<SocketAddress>> wrapSocketAddressSupplier(
+    /**
+     * Wrap the socket address supplier with error handling and caching logic.
+     *
+     * @param source the original supplier
+     * @return the wrapped supplier
+     * @since 7.0
+     */
+    protected Supplier<CompletionStage<SocketAddress>> wrapSocketAddressSupplierStage(
             Supplier<CompletionStage<SocketAddress>> source) {
         return () -> {
             try {
@@ -164,6 +172,20 @@ public class ConnectionWatchdog extends ChannelInboundHandlerAdapter {
                 return CompletableFuture.completedFuture(remoteAddress);
             }
         };
+    }
+
+    /**
+     * Wrap the socket address supplier with error handling and caching logic.
+     *
+     * @param source the original supplier
+     * @return the wrapped supplier
+     * @deprecated since 7.0, use {@link #wrapSocketAddressSupplierStage(Supplier)} instead. This method will be removed in a
+     *             future major release as part of the effort to make Reactor an optional dependency.
+     */
+    @Deprecated
+    protected Mono<SocketAddress> wrapSocketAddressSupplier(Mono<SocketAddress> source) {
+        Supplier<CompletionStage<SocketAddress>> wrapped = wrapSocketAddressSupplierStage(() -> source.toFuture());
+        return Mono.defer(() -> Mono.fromCompletionStage(wrapped.get()));
     }
 
     private void log(SocketAddress cached, Throwable t) {

--- a/src/main/java/io/lettuce/core/protocol/MaintenanceAwareConnectionWatchdog.java
+++ b/src/main/java/io/lettuce/core/protocol/MaintenanceAwareConnectionWatchdog.java
@@ -112,9 +112,9 @@ public class MaintenanceAwareConnectionWatchdog extends ConnectionWatchdog imple
     }
 
     @Override
-    protected Supplier<CompletionStage<SocketAddress>> wrapSocketAddressSupplier(
+    protected Supplier<CompletionStage<SocketAddress>> wrapSocketAddressSupplierStage(
             Supplier<CompletionStage<SocketAddress>> socketAddressSupplier) {
-        Supplier<CompletionStage<SocketAddress>> source = super.wrapSocketAddressSupplier(socketAddressSupplier);
+        Supplier<CompletionStage<SocketAddress>> source = super.wrapSocketAddressSupplierStage(socketAddressSupplier);
         rebindAwareAddressSupplier = new RebindAwareAddressSupplier();
         return rebindAwareAddressSupplier.wrappedSupplier(source);
     }


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection establishment and reconnect address resolution paths (standalone, cluster, and watchdog), so regressions could affect connectivity/retry behavior despite mostly being adapter/rewiring changes.
> 
> **Overview**
> **Refactors socket address resolution and connection wiring to prefer `Supplier<CompletionStage<SocketAddress>>` APIs**, as part of making Reactor optional.
> 
> Introduces new stage-based hooks (`getSocketAddressStage`, `getSocketAddressSupplierStage`, `wrapSocketAddressSupplierStage`) and wires existing `Mono`-returning methods to these as **`@Deprecated` compatibility adapters**.
> 
> Updates cluster connection retry loops to use `CompletableFuture` chaining instead of `Mono` (`connectFuture` helpers), and adjusts `MaintenanceAwareConnectionWatchdog` to override the renamed stage-based wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f17a0f9c07e9538b2ac1f008a81ea842c2f7994b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->