### PR TITLE
Wiring new methods to old methods

### DIFF
--- a/src/main/java/io/lettuce/core/AbstractRedisClient.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisClient.java
@@ -37,6 +37,7 @@ import java.util.function.Supplier;
 
 import io.lettuce.core.MaintNotificationsConfig.EndpointTypeSource;
 import io.lettuce.core.api.BaseRedisClient;
+import reactor.core.publisher.Mono;
 import io.lettuce.core.event.command.CommandListener;
 import io.lettuce.core.event.connection.ConnectEvent;
 import io.lettuce.core.event.connection.ConnectionCreatedEvent;
@@ -231,10 +232,33 @@ public abstract class AbstractRedisClient implements BaseRedisClient {
      *
      * @param socketAddressSupplier address supplier for initial connect and re-connect
      * @param connectionBuilder connection builder to configure the connection
+     * @param connectionEvents connection events dispatcher
      * @param redisURI URI of the Redis instance
+     * @since 7.6
      */
     protected void connectionBuilder(Supplier<CompletionStage<SocketAddress>> socketAddressSupplier,
-            ConnectionBuilder connectionBuilder, RedisURI redisURI) {
+            ConnectionBuilder connectionBuilder, ConnectionEvents connectionEvents, RedisURI redisURI) {
+
+        Mono<SocketAddress> monoWrapper = Mono.fromCompletionStage(socketAddressSupplier);
+        connectionBuilder(monoWrapper, connectionBuilder, connectionEvents, redisURI);
+
+        // If the deprecated method (or an override) did not replace the Mono we passed in,
+        // overwrite with the raw Supplier<CompletionStage> to avoid Mono.subscribe() on the hot path.
+        if (connectionBuilder.socketAddress() == monoWrapper) {
+            connectionBuilder.socketAddressSupplier(socketAddressSupplier);
+        }
+    }
+
+    /**
+     * Populate connection builder with necessary resources.
+     *
+     * @param socketAddressSupplier address supplier for initial connect and re-connect
+     * @param connectionBuilder connection builder to configure the connection
+     * @param redisURI URI of the Redis instance
+     */
+    @Deprecated
+    protected void connectionBuilder(Mono<SocketAddress> socketAddressSupplier, ConnectionBuilder connectionBuilder,
+            RedisURI redisURI) {
         connectionBuilder(socketAddressSupplier, connectionBuilder, connectionEvents, redisURI);
     }
 
@@ -247,8 +271,9 @@ public abstract class AbstractRedisClient implements BaseRedisClient {
      * @param redisURI URI of the Redis instance
      * @since 6.2
      */
-    protected void connectionBuilder(Supplier<CompletionStage<SocketAddress>> socketAddressSupplier,
-            ConnectionBuilder connectionBuilder, ConnectionEvents connectionEvents, RedisURI redisURI) {
+    @Deprecated
+    protected void connectionBuilder(Mono<SocketAddress> socketAddressSupplier, ConnectionBuilder connectionBuilder,
+            ConnectionEvents connectionEvents, RedisURI redisURI) {
 
         Bootstrap redisBootstrap = new Bootstrap();
         redisBootstrap.option(ChannelOption.ALLOCATOR, ByteBufAllocator.DEFAULT);
@@ -261,6 +286,7 @@ public abstract class AbstractRedisClient implements BaseRedisClient {
         connectionBuilder.socketAddressSupplier(socketAddressSupplier);
     }
 
+    @Deprecated
     protected void channelType(ConnectionBuilder connectionBuilder, ConnectionPoint connectionPoint) {
 
         LettuceAssert.notNull(connectionPoint, "ConnectionPoint must not be null");
@@ -349,7 +375,7 @@ public abstract class AbstractRedisClient implements BaseRedisClient {
     protected <K, V, T extends RedisChannelHandler<K, V>> ConnectionFuture<T> initializeChannelAsync(
             ConnectionBuilder connectionBuilder) {
 
-        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = connectionBuilder.socketAddress();
+        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = connectionBuilder.socketAddressAsync();
 
         if (clientResources.eventExecutorGroup().isShuttingDown()) {
             throw new IllegalStateException("Cannot connect, Event executor group is terminated.");

--- a/src/main/java/io/lettuce/core/ConnectionBuilder.java
+++ b/src/main/java/io/lettuce/core/ConnectionBuilder.java
@@ -158,8 +158,7 @@ public class ConnectionBuilder {
         if (clientOptions.getMaintNotificationsConfig().maintNotificationsEnabled()) {
             MaintenanceAwareConnectionWatchdog maintenanceAwareWatchdog = new MaintenanceAwareConnectionWatchdog(
                     clientResources.reconnectDelay(), clientOptions, bootstrap, clientResources.timer(),
-                    clientResources.eventExecutorGroup(), supplier, reconnectionListener, clientResources.eventBus(),
-                    endpoint);
+                    clientResources.eventExecutorGroup(), supplier, reconnectionListener, clientResources.eventBus(), endpoint);
             if (connection.getChannelWriter() instanceof MaintenanceAwareComponent) {
                 maintenanceAwareWatchdog.setMaintenanceEventListener((MaintenanceAwareComponent) connection.getChannelWriter());
             }

--- a/src/main/java/io/lettuce/core/ConnectionBuilder.java
+++ b/src/main/java/io/lettuce/core/ConnectionBuilder.java
@@ -29,6 +29,7 @@ import java.util.function.Supplier;
 
 import io.lettuce.core.protocol.MaintenanceAwareComponent;
 import io.lettuce.core.protocol.MaintenanceAwareConnectionWatchdog;
+import reactor.core.publisher.Mono;
 import io.lettuce.core.internal.LettuceAssert;
 import io.lettuce.core.protocol.CommandEncoder;
 import io.lettuce.core.protocol.CommandHandler;
@@ -64,7 +65,9 @@ public class ConnectionBuilder {
 
     public static final AttributeKey<Throwable> INIT_FAILURE = AttributeKey.valueOf("ConnectionBuilder.INIT_FAILURE");
 
-    private Supplier<CompletionStage<SocketAddress>> socketAddressSupplier;
+    private Mono<SocketAddress> socketAddressSupplier;
+
+    private Supplier<CompletionStage<SocketAddress>> socketAddressSupplierAsync;
 
     private ConnectionEvents connectionEvents;
 
@@ -146,21 +149,24 @@ public class ConnectionBuilder {
         }
 
         LettuceAssert.assertState(bootstrap != null, "Bootstrap must be set for autoReconnect=true");
-        LettuceAssert.assertState(socketAddressSupplier != null, "SocketAddressSupplier must be set for autoReconnect=true");
+        LettuceAssert.assertState(socketAddressSupplierAsync != null,
+                "SocketAddressSupplier must be set for autoReconnect=true");
+
+        Supplier<CompletionStage<SocketAddress>> supplier = socketAddressSupplierAsync;
 
         ConnectionWatchdog watchdog;
         if (clientOptions.getMaintNotificationsConfig().maintNotificationsEnabled()) {
             MaintenanceAwareConnectionWatchdog maintenanceAwareWatchdog = new MaintenanceAwareConnectionWatchdog(
                     clientResources.reconnectDelay(), clientOptions, bootstrap, clientResources.timer(),
-                    clientResources.eventExecutorGroup(), socketAddressSupplier, reconnectionListener,
-                    clientResources.eventBus(), endpoint);
+                    clientResources.eventExecutorGroup(), supplier, reconnectionListener, clientResources.eventBus(),
+                    endpoint);
             if (connection.getChannelWriter() instanceof MaintenanceAwareComponent) {
                 maintenanceAwareWatchdog.setMaintenanceEventListener((MaintenanceAwareComponent) connection.getChannelWriter());
             }
             watchdog = maintenanceAwareWatchdog;
         } else {
             watchdog = new ConnectionWatchdog(clientResources.reconnectDelay(), clientOptions, bootstrap,
-                    clientResources.timer(), clientResources.eventExecutorGroup(), socketAddressSupplier, reconnectionListener,
+                    clientResources.timer(), clientResources.eventExecutorGroup(), supplier, reconnectionListener,
                     clientResources.eventBus(), endpoint);
         }
 
@@ -174,14 +180,28 @@ public class ConnectionBuilder {
         return new PlainChannelInitializer(this::buildHandlers, clientResources);
     }
 
-    public ConnectionBuilder socketAddressSupplier(Supplier<CompletionStage<SocketAddress>> socketAddressSupplier) {
+    @Deprecated
+    public ConnectionBuilder socketAddressSupplier(Mono<SocketAddress> socketAddressSupplier) {
         this.socketAddressSupplier = socketAddressSupplier;
+        this.socketAddressSupplierAsync = socketAddressSupplier::toFuture;
         return this;
     }
 
-    public Supplier<CompletionStage<SocketAddress>> socketAddress() {
+    @Deprecated
+    public Mono<SocketAddress> socketAddress() {
         LettuceAssert.assertState(socketAddressSupplier != null, "SocketAddressSupplier must be set");
         return socketAddressSupplier;
+    }
+
+    public ConnectionBuilder socketAddressSupplier(Supplier<CompletionStage<SocketAddress>> socketAddressSupplier) {
+        this.socketAddressSupplierAsync = socketAddressSupplier;
+        this.socketAddressSupplier = Mono.fromCompletionStage(socketAddressSupplier);
+        return this;
+    }
+
+    public Supplier<CompletionStage<SocketAddress>> socketAddressAsync() {
+        LettuceAssert.assertState(socketAddressSupplierAsync != null, "SocketAddressSupplier must be set");
+        return socketAddressSupplierAsync;
     }
 
     public ConnectionBuilder timeout(Duration timeout) {

--- a/src/main/java/io/lettuce/core/RedisClient.java
+++ b/src/main/java/io/lettuce/core/RedisClient.java
@@ -686,6 +686,36 @@ public class RedisClient extends AbstractRedisClient {
     }
 
     /**
+     * Resolve a {@link RedisURI} to a {@link SocketAddress}. Resolution is performed either using Redis Sentinel (if the
+     * {@link RedisURI} is configured with Sentinels) or via DNS resolution.
+     * <p>
+     * Subclasses of {@link RedisClient} may override that method.
+     *
+     * @param redisURI must not be {@code null}.
+     * @return the resolved {@link SocketAddress}.
+     * @see ClientResources#addressResolverGroup()
+     * @see RedisURI#getSentinels()
+     * @see RedisURI#getSentinelMasterId()
+     * @deprecated since 6.6, use {@link #getSocketAddressStage(RedisURI)} instead.
+     */
+    @Deprecated
+    protected Mono<SocketAddress> getSocketAddress(RedisURI redisURI) {
+
+        return Mono.defer(() -> {
+
+            if (redisURI.getSentinelMasterId() != null && !redisURI.getSentinels().isEmpty()) {
+                logger.debug("Connecting to Redis using Sentinels {}, MasterId {}", redisURI.getSentinels(),
+                        redisURI.getSentinelMasterId());
+                return Mono.fromCompletionStage(lookupRedisAsync(redisURI))
+                        .switchIfEmpty(Mono.error(new RedisConnectionException(
+                                "Cannot provide redisAddress using sentinel for masterId " + redisURI.getSentinelMasterId())));
+            } else {
+                return Mono.just(getResources().socketAddressResolver().resolve(redisURI));
+            }
+        });
+    }
+
+    /**
      * Get a {@link Supplier} that produces a {@link CompletionStage} resolving {@link RedisURI} to a {@link SocketAddress}.
      * Resolution is performed either using Redis Sentinel (if the {@link RedisURI} is configured with Sentinels) or via DNS
      * resolution.
@@ -697,23 +727,10 @@ public class RedisClient extends AbstractRedisClient {
      * @see ClientResources#addressResolverGroup()
      * @see RedisURI#getSentinels()
      * @see RedisURI#getSentinelMasterId()
+     * @since 7.6
      */
-    protected Supplier<CompletionStage<SocketAddress>> getSocketAddress(RedisURI redisURI) {
-        return () -> {
-            if (redisURI.getSentinelMasterId() != null && !redisURI.getSentinels().isEmpty()) {
-                logger.debug("Connecting to Redis using Sentinels {}, MasterId {}", redisURI.getSentinels(),
-                        redisURI.getSentinelMasterId());
-                return lookupRedisAsync(redisURI).thenApply(addr -> {
-                    if (addr == null) {
-                        throw new RedisConnectionException(
-                                "Cannot provide redisAddress using sentinel for masterId " + redisURI.getSentinelMasterId());
-                    }
-                    return addr;
-                });
-            } else {
-                return CompletableFuture.completedFuture(getResources().socketAddressResolver().resolve(redisURI));
-            }
-        };
+    protected Supplier<CompletionStage<SocketAddress>> getSocketAddressStage(RedisURI redisURI) {
+        return () -> getSocketAddress(redisURI).toFuture();
     }
 
     /**
@@ -745,7 +762,7 @@ public class RedisClient extends AbstractRedisClient {
     }
 
     private Supplier<CompletionStage<SocketAddress>> getSocketAddressSupplier(RedisURI redisURI) {
-        Supplier<CompletionStage<SocketAddress>> delegate = getSocketAddress(redisURI);
+        Supplier<CompletionStage<SocketAddress>> delegate = getSocketAddressStage(redisURI);
         return () -> delegate.get().thenApply(addr -> {
             logger.debug("Resolved SocketAddress {} using {}", addr, redisURI);
             return addr;

--- a/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
@@ -702,20 +702,25 @@ public class RedisClusterClient extends AbstractRedisClient {
 
         Supplier<CommandHandler> commandHandlerSupplier = () -> new CommandHandler(getClusterClientOptions(), getResources(),
                 endpoint);
-        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = getSocketAddressSupplier(connection::getPartitions,
-                TopologyComparators::sortByClientCount);
-        Mono<StatefulRedisClusterConnectionImpl<K, V>> connectionMono = Mono
-                .defer(() -> connect(socketAddressSupplier, endpoint, connection, commandHandlerSupplier));
+        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = getSocketAddressSupplierStage(
+                connection::getPartitions, TopologyComparators::sortByClientCount);
+
+        CompletableFuture<StatefulRedisClusterConnection<K, V>> result = connectFuture(socketAddressSupplier, endpoint,
+                connection, commandHandlerSupplier);
 
         for (int i = 1; i < getConnectionAttempts(); i++) {
-            connectionMono = connectionMono
-                    .onErrorResume(t -> connect(socketAddressSupplier, endpoint, connection, commandHandlerSupplier));
+            result = result.<CompletableFuture<StatefulRedisClusterConnection<K, V>>> handle((v, t) -> {
+                if (t != null) {
+                    return connectFuture(socketAddressSupplier, endpoint, connection, commandHandlerSupplier);
+                }
+                return CompletableFuture.completedFuture(v);
+            }).thenCompose(f -> f);
         }
 
-        return connectionMono
-                .doOnNext(
-                        c -> connection.registerCloseables(closeableResources, clusterWriter, pooledClusterConnectionProvider))
-                .map(it -> (StatefulRedisClusterConnection<K, V>) it).toFuture();
+        return result.thenApply(c -> {
+            connection.registerCloseables(closeableResources, clusterWriter, pooledClusterConnectionProvider);
+            return c;
+        });
     }
 
     /**
@@ -774,6 +779,36 @@ public class RedisClusterClient extends AbstractRedisClient {
         return Mono.fromCompletionStage(future).doOnError(t -> logger.warn(t.getMessage()));
     }
 
+    @SuppressWarnings("unchecked")
+    private <T, K, V> CompletableFuture<T> connectFuture(Supplier<CompletionStage<SocketAddress>> socketAddressSupplier,
+            DefaultEndpoint endpoint, StatefulRedisClusterConnectionImpl<K, V> connection,
+            Supplier<CommandHandler> commandHandlerSupplier) {
+
+        ConnectionFuture<T> future = connectStatefulAsync(connection, endpoint, getFirstUri(), socketAddressSupplier,
+                commandHandlerSupplier);
+
+        return future.toCompletableFuture().whenComplete((v, t) -> {
+            if (t != null) {
+                logger.warn(t.getMessage());
+            }
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T, K, V> CompletableFuture<T> connectFuture(Supplier<CompletionStage<SocketAddress>> socketAddressSupplier,
+            DefaultEndpoint endpoint, StatefulRedisConnectionImpl<K, V> connection,
+            Supplier<CommandHandler> commandHandlerSupplier) {
+
+        ConnectionFuture<T> future = connectStatefulAsync(connection, endpoint, getFirstUri(), socketAddressSupplier,
+                commandHandlerSupplier);
+
+        return future.toCompletableFuture().whenComplete((v, t) -> {
+            if (t != null) {
+                logger.warn(t.getMessage());
+            }
+        });
+    }
+
     /**
      * Create a clustered connection with command distributor.
      *
@@ -821,20 +856,25 @@ public class RedisClusterClient extends AbstractRedisClient {
 
         Supplier<CommandHandler> commandHandlerSupplier = () -> new PubSubCommandHandler<>(getClusterClientOptions(),
                 getResources(), codec, endpoint);
-        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = getSocketAddressSupplier(connection::getPartitions,
-                TopologyComparators::sortByClientCount);
-        Mono<StatefulRedisClusterPubSubConnectionImpl<K, V>> connectionMono = Mono
-                .defer(() -> connect(socketAddressSupplier, endpoint, connection, commandHandlerSupplier));
+        Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = getSocketAddressSupplierStage(
+                connection::getPartitions, TopologyComparators::sortByClientCount);
+
+        CompletableFuture<StatefulRedisClusterPubSubConnection<K, V>> result = connectFuture(socketAddressSupplier, endpoint,
+                connection, commandHandlerSupplier);
 
         for (int i = 1; i < getConnectionAttempts(); i++) {
-            connectionMono = connectionMono
-                    .onErrorResume(t -> connect(socketAddressSupplier, endpoint, connection, commandHandlerSupplier));
+            result = result.<CompletableFuture<StatefulRedisClusterPubSubConnection<K, V>>> handle((v, t) -> {
+                if (t != null) {
+                    return connectFuture(socketAddressSupplier, endpoint, connection, commandHandlerSupplier);
+                }
+                return CompletableFuture.completedFuture(v);
+            }).thenCompose(f -> f);
         }
 
-        return connectionMono
-                .doOnNext(
-                        c -> connection.registerCloseables(closeableResources, clusterWriter, pooledClusterConnectionProvider))
-                .map(it -> (StatefulRedisClusterPubSubConnection<K, V>) it).toFuture();
+        return result.thenApply(c -> {
+            connection.registerCloseables(closeableResources, clusterWriter, pooledClusterConnectionProvider);
+            return (StatefulRedisClusterPubSubConnection<K, V>) c;
+        });
     }
 
     private int getConnectionAttempts() {
@@ -1177,8 +1217,10 @@ public class RedisClusterClient extends AbstractRedisClient {
      * @param sortFunction Sort function to enforce a specific order. The sort function must not change the order or the input
      *        parameter but create a new collection with the desired order, must not be {@code null}.
      * @return {@link Supplier} for {@link SocketAddress connection points}.
+     * @deprecated since 6.6, use {@link #getSocketAddressSupplierStage(Supplier, Function)} instead.
      */
-    protected Supplier<CompletionStage<SocketAddress>> getSocketAddressSupplier(Supplier<Partitions> partitionsSupplier,
+    @Deprecated
+    protected Mono<SocketAddress> getSocketAddressSupplier(Supplier<Partitions> partitionsSupplier,
             Function<Partitions, Collection<RedisClusterNode>> sortFunction) {
 
         LettuceAssert.notNull(sortFunction, "Sort function must not be null");
@@ -1186,20 +1228,32 @@ public class RedisClusterClient extends AbstractRedisClient {
         RoundRobinSocketAddressSupplier socketAddressSupplier = new RoundRobinSocketAddressSupplier(partitionsSupplier,
                 sortFunction, getResources());
 
-        return () -> {
-            try {
-                if (partitions.isEmpty()) {
-                    RedisURI firstURI = getFirstUri();
-                    SocketAddress socketAddress = getResources().socketAddressResolver().resolve(firstURI);
-                    logger.debug("Resolved SocketAddress {} using {}", socketAddress, firstURI);
-                    return CompletableFuture.completedFuture(socketAddress);
-                }
+        return Mono.defer(() -> {
 
-                return CompletableFuture.completedFuture(socketAddressSupplier.get());
-            } catch (Exception e) {
-                return Futures.failed(e);
+            if (partitions.isEmpty()) {
+                return Mono.fromCallable(() -> {
+                    SocketAddress socketAddress = getResources().socketAddressResolver().resolve(getFirstUri());
+                    logger.debug("Resolved SocketAddress {} using {}", socketAddress, getFirstUri());
+                    return socketAddress;
+                });
             }
-        };
+
+            return Mono.fromCallable(socketAddressSupplier::get);
+        });
+    }
+
+    /**
+     * Returns a {@link Supplier} that produces a {@link CompletionStage} for a {@link SocketAddress}.
+     *
+     * @param partitionsSupplier supplier for the current partitions, must not be {@code null}.
+     * @param sortFunction Sort function to enforce a specific order. The sort function must not change the order or the input
+     *        parameter but create a new collection with the desired order, must not be {@code null}.
+     * @return {@link Supplier} for {@link SocketAddress connection points}.
+     * @since 7.6
+     */
+    protected Supplier<CompletionStage<SocketAddress>> getSocketAddressSupplierStage(Supplier<Partitions> partitionsSupplier,
+            Function<Partitions, Collection<RedisClusterNode>> sortFunction) {
+        return () -> getSocketAddressSupplier(partitionsSupplier, sortFunction).toFuture();
     }
 
     /**

--- a/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
@@ -1253,7 +1253,8 @@ public class RedisClusterClient extends AbstractRedisClient {
      */
     protected Supplier<CompletionStage<SocketAddress>> getSocketAddressSupplierStage(Supplier<Partitions> partitionsSupplier,
             Function<Partitions, Collection<RedisClusterNode>> sortFunction) {
-        return () -> getSocketAddressSupplier(partitionsSupplier, sortFunction).toFuture();
+        Mono<SocketAddress> mono = getSocketAddressSupplier(partitionsSupplier, sortFunction);
+        return mono::toFuture;
     }
 
     /**

--- a/src/main/java/io/lettuce/core/protocol/ConnectionWatchdog.java
+++ b/src/main/java/io/lettuce/core/protocol/ConnectionWatchdog.java
@@ -187,7 +187,7 @@ public class ConnectionWatchdog extends ChannelInboundHandlerAdapter {
                         + ", reusing cached address " + remoteAddress);
             }
 
-            return Mono.just(remoteAddress);
+            return Mono.justOrEmpty(remoteAddress);
         });
     }
 

--- a/src/main/java/io/lettuce/core/protocol/ConnectionWatchdog.java
+++ b/src/main/java/io/lettuce/core/protocol/ConnectionWatchdog.java
@@ -27,10 +27,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
+import io.lettuce.core.Pair;
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.ConnectionBuilder;
 import io.lettuce.core.ConnectionEvents;
-import io.lettuce.core.Pair;
 import io.lettuce.core.event.EventBus;
 import io.lettuce.core.event.connection.ReconnectAttemptEvent;
 import io.lettuce.core.event.connection.ReconnectFailedEvent;
@@ -115,10 +117,36 @@ public class ConnectionWatchdog extends ChannelInboundHandlerAdapter {
      * @param reconnectionListener the reconnection listener, must not be {@code null}
      * @param eventBus Event bus to emit reconnect events.
      * @param endpoint must not be {@code null}
+     * @since 7.6
      */
     public ConnectionWatchdog(Delay reconnectDelay, ClientOptions clientOptions, Bootstrap bootstrap, Timer timer,
             EventExecutorGroup reconnectWorkers, Supplier<CompletionStage<SocketAddress>> socketAddressSupplier,
             ReconnectionListener reconnectionListener, EventBus eventBus, Endpoint endpoint) {
+
+        this(reconnectDelay, clientOptions, bootstrap, timer, reconnectWorkers, Mono.fromCompletionStage(socketAddressSupplier),
+                reconnectionListener, null, eventBus, endpoint);
+    }
+
+    /**
+     * Create a new watchdog that adds to new connections to the supplied {@link ChannelGroup} and establishes a new
+     * {@link Channel} when disconnected, while reconnect is true. The socketAddressSupplier can supply the reconnect address.
+     *
+     * @param reconnectDelay reconnect delay, must not be {@code null}
+     * @param clientOptions client options for the current connection, must not be {@code null}
+     * @param bootstrap Configuration for new channels, must not be {@code null}
+     * @param timer Timer used for delayed reconnect, must not be {@code null}
+     * @param reconnectWorkers executor group for reconnect tasks, must not be {@code null}
+     * @param socketAddressSupplier the socket address supplier to obtain an address for reconnection, may be {@code null}
+     * @param reconnectionListener the reconnection listener, must not be {@code null}
+     * @param connectionFacade the connection facade, must not be {@code null}
+     * @param eventBus Event bus to emit reconnect events.
+     * @param endpoint must not be {@code null}
+     */
+    @Deprecated
+    public ConnectionWatchdog(Delay reconnectDelay, ClientOptions clientOptions, Bootstrap bootstrap, Timer timer,
+            EventExecutorGroup reconnectWorkers, Mono<SocketAddress> socketAddressSupplier,
+            ReconnectionListener reconnectionListener, ConnectionFacade connectionFacade, EventBus eventBus,
+            Endpoint endpoint) {
 
         LettuceAssert.notNull(reconnectDelay, "Delay must not be null");
         LettuceAssert.notNull(clientOptions, "ClientOptions must not be null");
@@ -140,40 +168,33 @@ public class ConnectionWatchdog extends ChannelInboundHandlerAdapter {
         this.redisUri = (String) bootstrap.config().attrs().get(ConnectionBuilder.REDIS_URI);
         this.epid = endpoint.getId();
 
-        Supplier<CompletionStage<SocketAddress>> wrappedSocketAddressSupplier = wrapSocketAddressSupplier(
-                socketAddressSupplier);
+        Supplier<CompletionStage<SocketAddress>> wrappedSocketAddressSupplier = wrapSocketAddressSupplierAsync(
+                socketAddressSupplier::toFuture);
         this.reconnectionHandler = new ReconnectionHandler(clientOptions, bootstrap, wrappedSocketAddressSupplier);
 
         resetReconnectDelay();
     }
 
-    protected Supplier<CompletionStage<SocketAddress>> wrapSocketAddressSupplier(
-            Supplier<CompletionStage<SocketAddress>> source) {
-        return () -> {
-            try {
-                return source.get().handle((addr, t) -> {
-                    if (t != null) {
-                        log(remoteAddress, t);
-                        return remoteAddress;
-                    }
-                    remoteAddress = addr;
-                    return addr;
-                });
-            } catch (Exception e) {
-                log(remoteAddress, e);
-                return CompletableFuture.completedFuture(remoteAddress);
+    @Deprecated
+    protected Mono<SocketAddress> wrapSocketAddressSupplier(Mono<SocketAddress> source) {
+        return source.doOnNext(addr -> remoteAddress = addr).onErrorResume(t -> {
+
+            if (logger.isDebugEnabled()) {
+                logger.warn("Cannot retrieve current address from socketAddressSupplier: " + t.toString()
+                        + ", reusing cached address " + remoteAddress, t);
+            } else {
+                logger.warn("Cannot retrieve current address from socketAddressSupplier: " + t.toString()
+                        + ", reusing cached address " + remoteAddress);
             }
-        };
+
+            return Mono.just(remoteAddress);
+        });
     }
 
-    private void log(SocketAddress cached, Throwable t) {
-        if (logger.isDebugEnabled()) {
-            logger.warn("Cannot retrieve current address from socketAddressSupplier: " + t.toString()
-                    + ", reusing cached address " + cached, t);
-        } else {
-            logger.warn("Cannot retrieve current address from socketAddressSupplier: " + t.toString()
-                    + ", reusing cached address " + cached);
-        }
+    protected Supplier<CompletionStage<SocketAddress>> wrapSocketAddressSupplierAsync(
+            Supplier<CompletionStage<SocketAddress>> source) {
+        Mono<SocketAddress> delegate = wrapSocketAddressSupplier(Mono.fromCompletionStage(source));
+        return delegate::toFuture;
     }
 
     void prepareClose() {

--- a/src/main/java/io/lettuce/core/protocol/MaintenanceAwareConnectionWatchdog.java
+++ b/src/main/java/io/lettuce/core/protocol/MaintenanceAwareConnectionWatchdog.java
@@ -22,6 +22,7 @@ import io.netty.util.Timer;
 import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import reactor.core.publisher.Mono;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -77,12 +78,22 @@ public class MaintenanceAwareConnectionWatchdog extends ConnectionWatchdog imple
 
     private RebindAwareAddressSupplier rebindAwareAddressSupplier;
 
+    @Deprecated
+    public MaintenanceAwareConnectionWatchdog(Delay reconnectDelay, ClientOptions clientOptions, Bootstrap bootstrap,
+            Timer timer, EventExecutorGroup reconnectWorkers, Mono<SocketAddress> socketAddressSupplier,
+            ReconnectionListener reconnectionListener, ConnectionFacade connectionFacade, EventBus eventBus,
+            Endpoint endpoint) {
+
+        super(reconnectDelay, clientOptions, bootstrap, timer, reconnectWorkers, socketAddressSupplier::toFuture,
+                reconnectionListener, eventBus, endpoint);
+    }
+
     public MaintenanceAwareConnectionWatchdog(Delay reconnectDelay, ClientOptions clientOptions, Bootstrap bootstrap,
             Timer timer, EventExecutorGroup reconnectWorkers, Supplier<CompletionStage<SocketAddress>> socketAddressSupplier,
             ReconnectionListener reconnectionListener, EventBus eventBus, Endpoint endpoint) {
 
-        super(reconnectDelay, clientOptions, bootstrap, timer, reconnectWorkers, socketAddressSupplier, reconnectionListener,
-                eventBus, endpoint);
+        this(reconnectDelay, clientOptions, bootstrap, timer, reconnectWorkers, Mono.fromCompletionStage(socketAddressSupplier),
+                reconnectionListener, null, eventBus, endpoint);
     }
 
     @Override
@@ -112,11 +123,19 @@ public class MaintenanceAwareConnectionWatchdog extends ConnectionWatchdog imple
     }
 
     @Override
-    protected Supplier<CompletionStage<SocketAddress>> wrapSocketAddressSupplier(
-            Supplier<CompletionStage<SocketAddress>> socketAddressSupplier) {
-        Supplier<CompletionStage<SocketAddress>> source = super.wrapSocketAddressSupplier(socketAddressSupplier);
+    @Deprecated
+    protected Mono<SocketAddress> wrapSocketAddressSupplier(Mono<SocketAddress> socketAddressSupplier) {
+        Mono<SocketAddress> source = super.wrapSocketAddressSupplier(socketAddressSupplier);
         rebindAwareAddressSupplier = new RebindAwareAddressSupplier();
         return rebindAwareAddressSupplier.wrappedSupplier(source);
+    }
+
+    @Override
+    protected Supplier<CompletionStage<SocketAddress>> wrapSocketAddressSupplierAsync(
+            Supplier<CompletionStage<SocketAddress>> socketAddressSupplier) {
+
+        Mono<SocketAddress> delegate = wrapSocketAddressSupplier(Mono.fromCompletionStage(socketAddressSupplier));
+        return delegate::toFuture;
     }
 
     @Override
@@ -407,23 +426,23 @@ public class MaintenanceAwareConnectionWatchdog extends ConnectionWatchdog imple
          * @param original the original supplier
          * @return a new supplier that is aware of re-bind events
          */
-        public Supplier<CompletionStage<SocketAddress>> wrappedSupplier(Supplier<CompletionStage<SocketAddress>> original) {
-            return () -> {
+        @Deprecated
+        public Mono<SocketAddress> wrappedSupplier(Mono<SocketAddress> original) {
+            return Mono.defer(() -> {
                 State current = state.get();
-                logger.debug("RebindAwareAddressSupplier rebind state: {}", current);
+                logger.debug("RebindAwareAddressSupplier rebind state: {}", state.get());
                 if (current != null && current.rebindAddress != null && clock.instant().isBefore(current.cutoff)) {
-                    logger.debug("RebindAwareAddressSupplier using rebind address: {}", current);
-                    logger.debug("RebindAwareAddressSupplier rebind address: {}", current.rebindAddress);
-                    return CompletableFuture.completedFuture(current.rebindAddress);
+                    logger.debug("RebindAwareAddressSupplier using rebind address: {}", state.get());
+                    return Mono.just(current.rebindAddress)
+                            .doOnSubscribe(s -> logger.debug("RebindAwareAddressSupplier subscribed to rebind address"))
+                            .doOnNext(address -> logger.debug("RebindAwareAddressSupplier rebind address: {}", address));
                 } else {
                     logger.debug("RebindAwareAddressSupplier falling back to original.");
                     state.compareAndSet(current, null);
-                    return original.get().thenApply(address -> {
-                        logger.debug("RebindAwareAddressSupplier original address: {}", address);
-                        return address;
-                    });
+                    return original.doOnSubscribe(s -> logger.debug("RebindAwareAddressSupplier original to rebind address"))
+                            .doOnNext(address -> logger.debug("RebindAwareAddressSupplier original address: {}", address));
                 }
-            };
+            });
         }
 
     }

--- a/src/test/java/io/lettuce/core/protocol/MaintenanceAwareConnectionWatchdogUnitTests.java
+++ b/src/test/java/io/lettuce/core/protocol/MaintenanceAwareConnectionWatchdogUnitTests.java
@@ -50,10 +50,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import reactor.core.publisher.Mono;
 
 /**
  * Unit tests for {@link MaintenanceAwareConnectionWatchdog}.
@@ -514,15 +514,14 @@ class MaintenanceAwareConnectionWatchdogUnitTests {
 
         SocketAddress originalAddress = new InetSocketAddress("localhost", 6379);
         SocketAddress rebindAddress = new InetSocketAddress("127.0.0.1", 6380);
-        Supplier<CompletionStage<SocketAddress>> originalSupplier = () -> CompletableFuture.completedFuture(originalAddress);
 
         // When - rebind with 30 seconds duration
         supplier.rebind(Duration.ofSeconds(30), rebindAddress);
 
         // Then - should return rebind address since we're within the cutoff time
-        Supplier<CompletionStage<SocketAddress>> wrappedSupplier = supplier.wrappedSupplier(originalSupplier);
+        Mono<SocketAddress> wrappedSupplier = supplier.wrappedSupplier(Mono.just(originalAddress));
 
-        assertThat(wrappedSupplier.get().toCompletableFuture().get()).isEqualTo(rebindAddress);
+        assertThat(wrappedSupplier.block()).isEqualTo(rebindAddress);
     }
 
     @Test
@@ -534,21 +533,20 @@ class MaintenanceAwareConnectionWatchdogUnitTests {
         SocketAddress originalAddress = new InetSocketAddress("localhost", 6379);
         // Null rebind address - should return original address
         SocketAddress rebindAddress = null;
-        Supplier<CompletionStage<SocketAddress>> originalSupplier = () -> CompletableFuture.completedFuture(originalAddress);
 
         // When - rebind with 30 seconds duration
         supplier.rebind(Duration.ofSeconds(30), rebindAddress);
 
         // Should return original address since rebind address is null
-        Supplier<CompletionStage<SocketAddress>> wrappedSupplier = supplier.wrappedSupplier(originalSupplier);
+        Mono<SocketAddress> wrappedSupplier = supplier.wrappedSupplier(Mono.just(originalAddress));
 
-        assertThat(wrappedSupplier.get().toCompletableFuture().get()).isEqualTo(originalAddress);
+        assertThat(wrappedSupplier.block()).isEqualTo(originalAddress);
 
         // Step 5: Advance clock past expiration (31 seconds)
         clock.tick(Duration.ofSeconds(31));
 
         // Step 6: New call to same wrappedSupplier should return original address again
-        assertThat(wrappedSupplier.get().toCompletableFuture().get()).isEqualTo(originalAddress);
+        assertThat(wrappedSupplier.block()).isEqualTo(originalAddress);
     }
 
     @Test
@@ -559,25 +557,24 @@ class MaintenanceAwareConnectionWatchdogUnitTests {
         RebindAwareAddressSupplier supplier = new RebindAwareAddressSupplier(clock);
         SocketAddress originalAddress = new InetSocketAddress("localhost", 6379);
         SocketAddress rebindAddress = new InetSocketAddress("127.0.0.1", 6380);
-        Supplier<CompletionStage<SocketAddress>> originalSupplier = () -> CompletableFuture.completedFuture(originalAddress);
 
         // Step 1: Create wrapped supplier once (same instance used throughout)
-        Supplier<CompletionStage<SocketAddress>> wrappedSupplier = supplier.wrappedSupplier(originalSupplier);
+        Mono<SocketAddress> wrappedSupplier = supplier.wrappedSupplier(Mono.just(originalAddress));
 
         // Step 2: First call should return original address (no rebind set yet)
-        assertThat(wrappedSupplier.get().toCompletableFuture().get()).isEqualTo(originalAddress);
+        assertThat(wrappedSupplier.block()).isEqualTo(originalAddress);
 
         // Step 3: Invoke rebind with 30 seconds duration
         supplier.rebind(Duration.ofSeconds(30), rebindAddress);
 
         // Step 4: New call to same wrappedSupplier should return rebind address
-        assertThat(wrappedSupplier.get().toCompletableFuture().get()).isEqualTo(rebindAddress);
+        assertThat(wrappedSupplier.block()).isEqualTo(rebindAddress);
 
         // Step 5: Advance clock past expiration (31 seconds)
         clock.tick(Duration.ofSeconds(31));
 
         // Step 6: New call to same wrappedSupplier should return original address again
-        assertThat(wrappedSupplier.get().toCompletableFuture().get()).isEqualTo(originalAddress);
+        assertThat(wrappedSupplier.block()).isEqualTo(originalAddress);
     }
 
     @Test
@@ -587,13 +584,12 @@ class MaintenanceAwareConnectionWatchdogUnitTests {
         RebindAwareAddressSupplier supplier = new RebindAwareAddressSupplier(fixedClock);
 
         SocketAddress originalAddress = new InetSocketAddress("localhost", 6379);
-        Supplier<CompletionStage<SocketAddress>> originalSupplier = () -> CompletableFuture.completedFuture(originalAddress);
 
         // When - no rebind has been set
-        Supplier<CompletionStage<SocketAddress>> wrappedSupplier = supplier.wrappedSupplier(originalSupplier);
+        Mono<SocketAddress> wrappedSupplier = supplier.wrappedSupplier(Mono.just(originalAddress));
 
         // Then - should return original address
-        assertThat(wrappedSupplier.get().toCompletableFuture().get()).isEqualTo(originalAddress);
+        assertThat(wrappedSupplier.block()).isEqualTo(originalAddress);
 
     }
 


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection establishment and auto-reconnect address resolution paths (including cluster connect retry logic), so regressions could impact connectivity despite mostly being API wiring/deprecation changes.
> 
> **Overview**
> Shifts socket address resolution/connection wiring to prefer `Supplier<CompletionStage<SocketAddress>>` throughout `AbstractRedisClient`, `ConnectionBuilder`, `RedisClient`, and `RedisClusterClient`, while marking the prior `Mono`-based hooks as `@Deprecated` and adding new `*Stage`/`*Async` accessors.
> 
> Updates reconnect watchdogs (`ConnectionWatchdog`, `MaintenanceAwareConnectionWatchdog`) to wrap async suppliers via `Mono` internally and exposes `wrapSocketAddressSupplierAsync`, and rewrites cluster connect retry loops to use `CompletableFuture` chaining instead of Reactor `Mono` retry. Unit tests are adjusted to the new `Mono`-based `RebindAwareAddressSupplier` API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2147c44494f116bbd8e1492366c2229d95aa0b5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->