### PR TITLE
Introduce INCREX command

### DIFF
--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -1627,8 +1627,8 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
     }
 
     @Override
-    public RedisFuture<IncrexValue<Double>> increxfloat(K key, double amount, IncrexArgs increxArgs) {
-        return dispatch(commandBuilder.increxfloat(key, amount, increxArgs));
+    public RedisFuture<IncrexValue<Double>> increx(K key, double amount, IncrexFloatArgs increxArgs) {
+        return dispatch(commandBuilder.increx(key, amount, increxArgs));
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands.java
@@ -1617,6 +1617,21 @@ public abstract class AbstractRedisAsyncCommands<K, V> implements RedisAclAsyncC
     }
 
     @Override
+    public RedisFuture<IncrexValue<Long>> increx(K key) {
+        return dispatch(commandBuilder.increx(key));
+    }
+
+    @Override
+    public RedisFuture<IncrexValue<Long>> increx(K key, long amount, IncrexArgs increxArgs) {
+        return dispatch(commandBuilder.increx(key, amount, increxArgs));
+    }
+
+    @Override
+    public RedisFuture<IncrexValue<Double>> increxfloat(K key, double amount, IncrexArgs increxArgs) {
+        return dispatch(commandBuilder.increxfloat(key, amount, increxArgs));
+    }
+
+    @Override
     public RedisFuture<String> info() {
         return dispatch(commandBuilder.info());
     }

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -1659,6 +1659,21 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
+    public Mono<IncrexValue<Long>> increx(K key) {
+        return createMono(() -> commandBuilder.increx(key));
+    }
+
+    @Override
+    public Mono<IncrexValue<Long>> increx(K key, long amount, IncrexArgs increxArgs) {
+        return createMono(() -> commandBuilder.increx(key, amount, increxArgs));
+    }
+
+    @Override
+    public Mono<IncrexValue<Double>> increxfloat(K key, double amount, IncrexArgs increxArgs) {
+        return createMono(() -> commandBuilder.increxfloat(key, amount, increxArgs));
+    }
+
+    @Override
     public Mono<String> info() {
         return createMono(commandBuilder::info);
     }

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -1669,8 +1669,8 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     @Override
-    public Mono<IncrexValue<Double>> increxfloat(K key, double amount, IncrexArgs increxArgs) {
-        return createMono(() -> commandBuilder.increxfloat(key, amount, increxArgs));
+    public Mono<IncrexValue<Double>> increx(K key, double amount, IncrexFloatArgs increxArgs) {
+        return createMono(() -> commandBuilder.increx(key, amount, increxArgs));
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/BaseIncrexArgs.java
+++ b/src/main/java/io/lettuce/core/BaseIncrexArgs.java
@@ -1,0 +1,120 @@
+package io.lettuce.core;
+
+import io.lettuce.core.protocol.CommandArgs;
+import io.lettuce.core.protocol.CommandKeyword;
+import io.lettuce.core.protocol.CommandType;
+
+/**
+ * Abstract base for {@code INCREX} arguments. Owns options common to both the integer-bounded variant ({@link IncrexArgs}) and
+ * the float-bounded variant ({@link IncrexFloatArgs}): {@code SATURATE}, the
+ * {@code EX}/{@code PX}/{@code EXAT}/{@code PXAT}/{@code PERSIST} expiration block, and {@code ENX}.
+ * <p>
+ * Bounds ({@code LBOUND}/{@code UBOUND}) live on the concrete subclasses so the bound type matches the increment type at
+ * compile time &mdash; integer-mode {@code increx} only accepts {@link IncrexArgs}, float-mode {@code increx} only accepts
+ * {@link IncrexFloatArgs}.
+ *
+ * @param <T> the concrete subtype, for fluent method chaining
+ * @since 7.6
+ */
+abstract class BaseIncrexArgs<T extends BaseIncrexArgs<T>> implements CompositeArgument {
+
+    private boolean saturate = false;
+
+    private Long ex;
+
+    private Long px;
+
+    private Long exAt;
+
+    private Long pxAt;
+
+    private boolean persist = false;
+
+    private boolean enx = false;
+
+    @SuppressWarnings("unchecked")
+    private T self() {
+        return (T) this;
+    }
+
+    /**
+     * Saturate the result on out-of-bounds: the value is clamped to the violated bound (or the implicit numeric-type limit when
+     * no explicit bound is set), and the second element of the reply reflects the actual applied increment. Without
+     * {@code SATURATE}, an out-of-bounds operation is silently rejected: the key value and TTL are unchanged and the reply is
+     * {@code [current_value, 0]}.
+     */
+    public T saturate() {
+        this.saturate = true;
+        return self();
+    }
+
+    public T ex(long seconds) {
+        this.ex = seconds;
+        return self();
+    }
+
+    public T px(long milliseconds) {
+        this.px = milliseconds;
+        return self();
+    }
+
+    public T exAt(long timestampSeconds) {
+        this.exAt = timestampSeconds;
+        return self();
+    }
+
+    public T pxAt(long timestampMilliseconds) {
+        this.pxAt = timestampMilliseconds;
+        return self();
+    }
+
+    public T persist() {
+        this.persist = true;
+        return self();
+    }
+
+    /**
+     * Apply the expiry only if the key does not already have one ({@code Expiry only if Not eXists}). If the key already has a
+     * TTL, the existing TTL is preserved.
+     */
+    public T enx() {
+        this.enx = true;
+        return self();
+    }
+
+    @Override
+    public <K, V> void build(CommandArgs<K, V> args) {
+
+        buildBounds(args);
+
+        if (saturate) {
+            args.add(CommandKeyword.SATURATE);
+        }
+
+        if (ex != null) {
+            args.add(CommandKeyword.EX).add(ex);
+        }
+        if (px != null) {
+            args.add(CommandKeyword.PX).add(px);
+        }
+        if (exAt != null) {
+            args.add(CommandKeyword.EXAT).add(exAt);
+        }
+        if (pxAt != null) {
+            args.add(CommandKeyword.PXAT).add(pxAt);
+        }
+        if (persist) {
+            args.add(CommandType.PERSIST);
+        }
+
+        if (enx) {
+            args.add(CommandKeyword.ENX);
+        }
+    }
+
+    /**
+     * Subclasses emit their typed {@code LBOUND}/{@code UBOUND} here.
+     */
+    protected abstract <K, V> void buildBounds(CommandArgs<K, V> args);
+
+}

--- a/src/main/java/io/lettuce/core/IncrexArgs.java
+++ b/src/main/java/io/lettuce/core/IncrexArgs.java
@@ -2,13 +2,13 @@ package io.lettuce.core;
 
 import io.lettuce.core.protocol.CommandArgs;
 import io.lettuce.core.protocol.CommandKeyword;
-import io.lettuce.core.protocol.CommandType;
 
 /**
- * Argument list builder for the Redis {@code INCREX} command. Holds bounds, saturate flag, expiration, and ENX options.
+ * Argument list builder for the integer-bounded form of the Redis {@code INCREX} command. Accepts {@code long} lower/upper
+ * bounds; paired with the {@code increx(K, long, IncrexArgs)} overload on the commands interface (sends {@code BYINT} on the
+ * wire).
  * <p>
- * The increment value and mode (BYINT/BYFLOAT) are determined by which method is called on the commands interface, not by this
- * args class.
+ * For float-bounded INCREX use {@link IncrexFloatArgs}.
  * <p>
  * Usage:
  *
@@ -20,25 +20,11 @@ import io.lettuce.core.protocol.CommandType;
  *
  * @since 7.6
  */
-public class IncrexArgs implements CompositeArgument {
+public class IncrexArgs extends BaseIncrexArgs<IncrexArgs> {
 
-    private Number lbound;
+    private Long lbound;
 
-    private Number ubound;
-
-    private boolean saturate = false;
-
-    private Long ex;
-
-    private Long px;
-
-    private Long exAt;
-
-    private Long pxAt;
-
-    private boolean persist = false;
-
-    private boolean enx = false;
+    private Long ubound;
 
     // ── Static Builder ─────────────────────────────
 
@@ -51,15 +37,7 @@ public class IncrexArgs implements CompositeArgument {
             return new IncrexArgs().lbound(lbound);
         }
 
-        public static IncrexArgs lbound(double lbound) {
-            return new IncrexArgs().lbound(lbound);
-        }
-
         public static IncrexArgs ubound(long ubound) {
-            return new IncrexArgs().ubound(ubound);
-        }
-
-        public static IncrexArgs ubound(double ubound) {
             return new IncrexArgs().ubound(ubound);
         }
 
@@ -100,58 +78,13 @@ public class IncrexArgs implements CompositeArgument {
         return this;
     }
 
-    public IncrexArgs lbound(double lbound) {
-        this.lbound = lbound;
-        return this;
-    }
-
     public IncrexArgs ubound(long ubound) {
         this.ubound = ubound;
         return this;
     }
 
-    public IncrexArgs ubound(double ubound) {
-        this.ubound = ubound;
-        return this;
-    }
-
-    public IncrexArgs saturate() {
-        this.saturate = true;
-        return this;
-    }
-
-    public IncrexArgs ex(long seconds) {
-        this.ex = seconds;
-        return this;
-    }
-
-    public IncrexArgs px(long milliseconds) {
-        this.px = milliseconds;
-        return this;
-    }
-
-    public IncrexArgs exAt(long timestampSeconds) {
-        this.exAt = timestampSeconds;
-        return this;
-    }
-
-    public IncrexArgs pxAt(long timestampMilliseconds) {
-        this.pxAt = timestampMilliseconds;
-        return this;
-    }
-
-    public IncrexArgs persist() {
-        this.persist = true;
-        return this;
-    }
-
-    public IncrexArgs enx() {
-        this.enx = true;
-        return this;
-    }
-
     @Override
-    public <K, V> void build(CommandArgs<K, V> args) {
+    protected <K, V> void buildBounds(CommandArgs<K, V> args) {
 
         if (lbound != null) {
             args.add(CommandKeyword.LBOUND);
@@ -161,30 +94,6 @@ public class IncrexArgs implements CompositeArgument {
         if (ubound != null) {
             args.add(CommandKeyword.UBOUND);
             args.add(ubound);
-        }
-
-        if (saturate) {
-            args.add(CommandKeyword.SATURATE);
-        }
-
-        if (ex != null) {
-            args.add(CommandKeyword.EX).add(ex);
-        }
-        if (px != null) {
-            args.add(CommandKeyword.PX).add(px);
-        }
-        if (exAt != null) {
-            args.add(CommandKeyword.EXAT).add(exAt);
-        }
-        if (pxAt != null) {
-            args.add(CommandKeyword.PXAT).add(pxAt);
-        }
-        if (persist) {
-            args.add(CommandType.PERSIST);
-        }
-
-        if (enx) {
-            args.add(CommandKeyword.ENX);
         }
     }
 

--- a/src/main/java/io/lettuce/core/IncrexArgs.java
+++ b/src/main/java/io/lettuce/core/IncrexArgs.java
@@ -5,7 +5,7 @@ import io.lettuce.core.protocol.CommandKeyword;
 import io.lettuce.core.protocol.CommandType;
 
 /**
- * Argument list builder for the Redis {@code INCREX} command. Holds bounds, overflow, expiration, and ENX options.
+ * Argument list builder for the Redis {@code INCREX} command. Holds bounds, saturate flag, expiration, and ENX options.
  * <p>
  * The increment value and mode (BYINT/BYFLOAT) are determined by which method is called on the commands interface, not by this
  * args class.
@@ -13,8 +13,8 @@ import io.lettuce.core.protocol.CommandType;
  * Usage:
  *
  * <pre>
- * IncrexArgs.Builder.ubound(100).overflow(Overflow.SAT).ex(60)
- * IncrexArgs.Builder.lbound(0).ubound(100).overflow(Overflow.REJECT)
+ * IncrexArgs.Builder.ubound(100).saturate().ex(60)
+ * IncrexArgs.Builder.lbound(0).ubound(100).saturate()
  * new IncrexArgs().ex(30).enx()
  * </pre>
  *
@@ -22,15 +22,11 @@ import io.lettuce.core.protocol.CommandType;
  */
 public class IncrexArgs implements CompositeArgument {
 
-    public enum Overflow {
-        FAIL, SAT, REJECT
-    }
-
     private Number lbound;
 
     private Number ubound;
 
-    private Overflow overflow;
+    private boolean saturate = false;
 
     private Long ex;
 
@@ -67,8 +63,8 @@ public class IncrexArgs implements CompositeArgument {
             return new IncrexArgs().ubound(ubound);
         }
 
-        public static IncrexArgs overflow(Overflow overflow) {
-            return new IncrexArgs().overflow(overflow);
+        public static IncrexArgs saturate() {
+            return new IncrexArgs().saturate();
         }
 
         public static IncrexArgs ex(long seconds) {
@@ -119,8 +115,8 @@ public class IncrexArgs implements CompositeArgument {
         return this;
     }
 
-    public IncrexArgs overflow(Overflow overflow) {
-        this.overflow = overflow;
+    public IncrexArgs saturate() {
+        this.saturate = true;
         return this;
     }
 
@@ -167,19 +163,8 @@ public class IncrexArgs implements CompositeArgument {
             args.add(ubound);
         }
 
-        if (overflow != null) {
-            args.add(CommandKeyword.OVERFLOW);
-            switch (overflow) {
-                case FAIL:
-                    args.add(CommandKeyword.FAIL);
-                    break;
-                case SAT:
-                    args.add(CommandKeyword.SAT);
-                    break;
-                case REJECT:
-                    args.add(CommandKeyword.REJECT);
-                    break;
-            }
+        if (saturate) {
+            args.add(CommandKeyword.SATURATE);
         }
 
         if (ex != null) {

--- a/src/main/java/io/lettuce/core/IncrexArgs.java
+++ b/src/main/java/io/lettuce/core/IncrexArgs.java
@@ -1,0 +1,206 @@
+package io.lettuce.core;
+
+import io.lettuce.core.protocol.CommandArgs;
+import io.lettuce.core.protocol.CommandKeyword;
+import io.lettuce.core.protocol.CommandType;
+
+/**
+ * Argument list builder for the Redis {@code INCREX} command. Holds bounds, overflow, expiration, and ENX options.
+ * <p>
+ * The increment value and mode (BYINT/BYFLOAT) are determined by which method is called on the commands interface, not by this
+ * args class.
+ * <p>
+ * Usage:
+ *
+ * <pre>
+ * IncrexArgs.Builder.ubound(100).overflow(Overflow.SAT).ex(60)
+ * IncrexArgs.Builder.lbound(0).ubound(100).overflow(Overflow.REJECT)
+ * new IncrexArgs().ex(30).enx()
+ * </pre>
+ *
+ * @since 7.6
+ */
+public class IncrexArgs implements CompositeArgument {
+
+    public enum Overflow {
+        FAIL, SAT, REJECT
+    }
+
+    private Number lbound;
+
+    private Number ubound;
+
+    private Overflow overflow;
+
+    private Long ex;
+
+    private Long px;
+
+    private Long exAt;
+
+    private Long pxAt;
+
+    private boolean persist = false;
+
+    private boolean enx = false;
+
+    // ── Static Builder ─────────────────────────────
+
+    public static class Builder {
+
+        private Builder() {
+        }
+
+        public static IncrexArgs lbound(long lbound) {
+            return new IncrexArgs().lbound(lbound);
+        }
+
+        public static IncrexArgs lbound(double lbound) {
+            return new IncrexArgs().lbound(lbound);
+        }
+
+        public static IncrexArgs ubound(long ubound) {
+            return new IncrexArgs().ubound(ubound);
+        }
+
+        public static IncrexArgs ubound(double ubound) {
+            return new IncrexArgs().ubound(ubound);
+        }
+
+        public static IncrexArgs overflow(Overflow overflow) {
+            return new IncrexArgs().overflow(overflow);
+        }
+
+        public static IncrexArgs ex(long seconds) {
+            return new IncrexArgs().ex(seconds);
+        }
+
+        public static IncrexArgs px(long milliseconds) {
+            return new IncrexArgs().px(milliseconds);
+        }
+
+        public static IncrexArgs exAt(long timestampSeconds) {
+            return new IncrexArgs().exAt(timestampSeconds);
+        }
+
+        public static IncrexArgs pxAt(long timestampMilliseconds) {
+            return new IncrexArgs().pxAt(timestampMilliseconds);
+        }
+
+        public static IncrexArgs persist() {
+            return new IncrexArgs().persist();
+        }
+
+        public static IncrexArgs enx() {
+            return new IncrexArgs().enx();
+        }
+
+    }
+
+    // ── Fluent Setters ─────────────────────────────
+
+    public IncrexArgs lbound(long lbound) {
+        this.lbound = lbound;
+        return this;
+    }
+
+    public IncrexArgs lbound(double lbound) {
+        this.lbound = lbound;
+        return this;
+    }
+
+    public IncrexArgs ubound(long ubound) {
+        this.ubound = ubound;
+        return this;
+    }
+
+    public IncrexArgs ubound(double ubound) {
+        this.ubound = ubound;
+        return this;
+    }
+
+    public IncrexArgs overflow(Overflow overflow) {
+        this.overflow = overflow;
+        return this;
+    }
+
+    public IncrexArgs ex(long seconds) {
+        this.ex = seconds;
+        return this;
+    }
+
+    public IncrexArgs px(long milliseconds) {
+        this.px = milliseconds;
+        return this;
+    }
+
+    public IncrexArgs exAt(long timestampSeconds) {
+        this.exAt = timestampSeconds;
+        return this;
+    }
+
+    public IncrexArgs pxAt(long timestampMilliseconds) {
+        this.pxAt = timestampMilliseconds;
+        return this;
+    }
+
+    public IncrexArgs persist() {
+        this.persist = true;
+        return this;
+    }
+
+    public IncrexArgs enx() {
+        this.enx = true;
+        return this;
+    }
+
+    @Override
+    public <K, V> void build(CommandArgs<K, V> args) {
+
+        if (lbound != null) {
+            args.add(CommandKeyword.LBOUND);
+            args.add(lbound);
+        }
+
+        if (ubound != null) {
+            args.add(CommandKeyword.UBOUND);
+            args.add(ubound);
+        }
+
+        if (overflow != null) {
+            args.add(CommandKeyword.OVERFLOW);
+            switch (overflow) {
+                case FAIL:
+                    args.add(CommandKeyword.FAIL);
+                    break;
+                case SAT:
+                    args.add(CommandKeyword.SAT);
+                    break;
+                case REJECT:
+                    args.add(CommandKeyword.REJECT);
+                    break;
+            }
+        }
+
+        if (ex != null) {
+            args.add(CommandKeyword.EX).add(ex);
+        }
+        if (px != null) {
+            args.add(CommandKeyword.PX).add(px);
+        }
+        if (exAt != null) {
+            args.add(CommandKeyword.EXAT).add(exAt);
+        }
+        if (pxAt != null) {
+            args.add(CommandKeyword.PXAT).add(pxAt);
+        }
+        if (persist) {
+            args.add(CommandType.PERSIST);
+        }
+
+        if (enx) {
+            args.add(CommandKeyword.ENX);
+        }
+    }
+
+}

--- a/src/main/java/io/lettuce/core/IncrexFloatArgs.java
+++ b/src/main/java/io/lettuce/core/IncrexFloatArgs.java
@@ -1,0 +1,100 @@
+package io.lettuce.core;
+
+import io.lettuce.core.protocol.CommandArgs;
+import io.lettuce.core.protocol.CommandKeyword;
+
+/**
+ * Argument list builder for the floating-point-bounded form of the Redis {@code INCREX} command. Accepts {@code double}
+ * lower/upper bounds; paired with the {@code increx(K, double, IncrexFloatArgs)} overload on the commands interface (sends
+ * {@code BYFLOAT} on the wire).
+ * <p>
+ * For integer-bounded INCREX use {@link IncrexArgs}.
+ * <p>
+ * Usage:
+ *
+ * <pre>
+ * IncrexFloatArgs.Builder.ubound(100.0).saturate().ex(60)
+ * IncrexFloatArgs.Builder.lbound(0.0).ubound(100.0).saturate()
+ * new IncrexFloatArgs().ex(30).enx()
+ * </pre>
+ *
+ * @since 7.6
+ */
+public class IncrexFloatArgs extends BaseIncrexArgs<IncrexFloatArgs> {
+
+    private Double lbound;
+
+    private Double ubound;
+
+    // ── Static Builder ─────────────────────────────
+
+    public static class Builder {
+
+        private Builder() {
+        }
+
+        public static IncrexFloatArgs lbound(double lbound) {
+            return new IncrexFloatArgs().lbound(lbound);
+        }
+
+        public static IncrexFloatArgs ubound(double ubound) {
+            return new IncrexFloatArgs().ubound(ubound);
+        }
+
+        public static IncrexFloatArgs saturate() {
+            return new IncrexFloatArgs().saturate();
+        }
+
+        public static IncrexFloatArgs ex(long seconds) {
+            return new IncrexFloatArgs().ex(seconds);
+        }
+
+        public static IncrexFloatArgs px(long milliseconds) {
+            return new IncrexFloatArgs().px(milliseconds);
+        }
+
+        public static IncrexFloatArgs exAt(long timestampSeconds) {
+            return new IncrexFloatArgs().exAt(timestampSeconds);
+        }
+
+        public static IncrexFloatArgs pxAt(long timestampMilliseconds) {
+            return new IncrexFloatArgs().pxAt(timestampMilliseconds);
+        }
+
+        public static IncrexFloatArgs persist() {
+            return new IncrexFloatArgs().persist();
+        }
+
+        public static IncrexFloatArgs enx() {
+            return new IncrexFloatArgs().enx();
+        }
+
+    }
+
+    // ── Fluent Setters ─────────────────────────────
+
+    public IncrexFloatArgs lbound(double lbound) {
+        this.lbound = lbound;
+        return this;
+    }
+
+    public IncrexFloatArgs ubound(double ubound) {
+        this.ubound = ubound;
+        return this;
+    }
+
+    @Override
+    protected <K, V> void buildBounds(CommandArgs<K, V> args) {
+
+        if (lbound != null) {
+            args.add(CommandKeyword.LBOUND);
+            args.add(lbound);
+        }
+
+        if (ubound != null) {
+            args.add(CommandKeyword.UBOUND);
+            args.add(ubound);
+        }
+    }
+
+}

--- a/src/main/java/io/lettuce/core/IncrexValue.java
+++ b/src/main/java/io/lettuce/core/IncrexValue.java
@@ -27,7 +27,8 @@ public class IncrexValue<T extends Number> {
     }
 
     /**
-     * The actual increment applied. May differ from the requested increment under {@code OVERFLOW SAT}.
+     * The actual increment applied. May differ from the requested increment when {@code SATURATE} is active and the result is
+     * clamped to a bound.
      */
     public T getIncrement() {
         return increment;

--- a/src/main/java/io/lettuce/core/IncrexValue.java
+++ b/src/main/java/io/lettuce/core/IncrexValue.java
@@ -1,0 +1,56 @@
+package io.lettuce.core;
+
+import java.util.Objects;
+
+/**
+ * Result of the {@code INCREX} command, containing the new value and the actual increment applied.
+ *
+ * @param <T> Number type — {@link Long} for integer mode, {@link Double} for float mode.
+ * @since 7.6
+ */
+public class IncrexValue<T extends Number> {
+
+    private final T value;
+
+    private final T increment;
+
+    public IncrexValue(T value, T increment) {
+        this.value = value;
+        this.increment = increment;
+    }
+
+    /**
+     * The key's value after the increment operation.
+     */
+    public T getValue() {
+        return value;
+    }
+
+    /**
+     * The actual increment applied. May differ from the requested increment under {@code OVERFLOW SAT}.
+     */
+    public T getIncrement() {
+        return increment;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof IncrexValue))
+            return false;
+        IncrexValue<?> that = (IncrexValue<?>) o;
+        return Objects.equals(value, that.value) && Objects.equals(increment, that.increment);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value, increment);
+    }
+
+    @Override
+    public String toString() {
+        return "IncrexValue{value=" + value + ", increment=" + increment + "}";
+    }
+
+}

--- a/src/main/java/io/lettuce/core/RedisCommandBuilder.java
+++ b/src/main/java/io/lettuce/core/RedisCommandBuilder.java
@@ -1977,9 +1977,9 @@ class RedisCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
         return createCommand(INCREX, new IncrexLongOutput<>(codec), args);
     }
 
-    Command<K, V, IncrexValue<Double>> increxfloat(K key, double amount, IncrexArgs increxArgs) {
+    Command<K, V, IncrexValue<Double>> increx(K key, double amount, IncrexFloatArgs increxArgs) {
         notNullKey(key);
-        LettuceAssert.notNull(increxArgs, "IncrexArgs " + MUST_NOT_BE_NULL);
+        LettuceAssert.notNull(increxArgs, "IncrexFloatArgs " + MUST_NOT_BE_NULL);
 
         CommandArgs<K, V> args = new CommandArgs<>(codec).addKey(key).add(BYFLOAT).add(amount);
         increxArgs.build(args);

--- a/src/main/java/io/lettuce/core/RedisCommandBuilder.java
+++ b/src/main/java/io/lettuce/core/RedisCommandBuilder.java
@@ -1961,6 +1961,31 @@ class RedisCommandBuilder<K, V> extends BaseRedisCommandBuilder<K, V> {
         return createCommand(INCRBYFLOAT, new DoubleOutput<>(codec), args);
     }
 
+    Command<K, V, IncrexValue<Long>> increx(K key) {
+        notNullKey(key);
+
+        CommandArgs<K, V> args = new CommandArgs<>(codec).addKey(key);
+        return createCommand(INCREX, new IncrexLongOutput<>(codec), args);
+    }
+
+    Command<K, V, IncrexValue<Long>> increx(K key, long amount, IncrexArgs increxArgs) {
+        notNullKey(key);
+        LettuceAssert.notNull(increxArgs, "IncrexArgs " + MUST_NOT_BE_NULL);
+
+        CommandArgs<K, V> args = new CommandArgs<>(codec).addKey(key).add(BYINT).add(amount);
+        increxArgs.build(args);
+        return createCommand(INCREX, new IncrexLongOutput<>(codec), args);
+    }
+
+    Command<K, V, IncrexValue<Double>> increxfloat(K key, double amount, IncrexArgs increxArgs) {
+        notNullKey(key);
+        LettuceAssert.notNull(increxArgs, "IncrexArgs " + MUST_NOT_BE_NULL);
+
+        CommandArgs<K, V> args = new CommandArgs<>(codec).addKey(key).add(BYFLOAT).add(amount);
+        increxArgs.build(args);
+        return createCommand(INCREX, new IncrexDoubleOutput<>(codec), args);
+    }
+
     Command<K, V, String> info() {
         return createCommand(CommandType.INFO, new StatusOutput<>(codec));
     }

--- a/src/main/java/io/lettuce/core/api/async/RedisStringAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisStringAsyncCommands.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import io.lettuce.core.BitFieldArgs;
 import io.lettuce.core.GetExArgs;
 import io.lettuce.core.IncrexArgs;
+import io.lettuce.core.IncrexFloatArgs;
 import io.lettuce.core.IncrexValue;
 import io.lettuce.core.KeyValue;
 import io.lettuce.core.MSetExArgs;
@@ -354,15 +355,15 @@ public interface RedisStringAsyncCommands<K, V> {
     RedisFuture<IncrexValue<Long>> increx(K key, long amount, IncrexArgs increxArgs);
 
     /**
-     * Increment the float value of a key by the given amount with bounds, overflow, and expiration options.
+     * Increment the float value of a key by the given amount with bounds, saturation, and expiration options.
      *
      * @param key the key.
      * @param amount the increment type: double.
-     * @param increxArgs the {@link IncrexArgs} specifying bounds, overflow, and expiration options.
+     * @param increxArgs the {@link IncrexFloatArgs} specifying bounds, {@code SATURATE} flag, and expiration options.
      * @return IncrexValue containing the new value and actual increment applied.
      * @since 7.6
      */
-    RedisFuture<IncrexValue<Double>> increxfloat(K key, double amount, IncrexArgs increxArgs);
+    RedisFuture<IncrexValue<Double>> increx(K key, double amount, IncrexFloatArgs increxArgs);
 
     /**
      * Get the values of all the given keys.

--- a/src/main/java/io/lettuce/core/api/async/RedisStringAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/api/async/RedisStringAsyncCommands.java
@@ -24,6 +24,8 @@ import java.util.Map;
 
 import io.lettuce.core.BitFieldArgs;
 import io.lettuce.core.GetExArgs;
+import io.lettuce.core.IncrexArgs;
+import io.lettuce.core.IncrexValue;
 import io.lettuce.core.KeyValue;
 import io.lettuce.core.MSetExArgs;
 import io.lettuce.core.RedisFuture;
@@ -332,6 +334,37 @@ public interface RedisStringAsyncCommands<K, V> {
     RedisFuture<Double> incrbyfloat(K key, double amount);
 
     /**
+     * Increment the integer value of a key by 1 using INCREX.
+     *
+     * @param key the key.
+     * @return IncrexValue containing the new value and actual increment applied.
+     * @since 7.6
+     */
+    RedisFuture<IncrexValue<Long>> increx(K key);
+
+    /**
+     * Increment the integer value of a key by the given amount with bounds, overflow, and expiration options.
+     *
+     * @param key the key.
+     * @param amount the increment type: long.
+     * @param increxArgs the {@link IncrexArgs} specifying bounds, overflow, and expiration options.
+     * @return IncrexValue containing the new value and actual increment applied.
+     * @since 7.6
+     */
+    RedisFuture<IncrexValue<Long>> increx(K key, long amount, IncrexArgs increxArgs);
+
+    /**
+     * Increment the float value of a key by the given amount with bounds, overflow, and expiration options.
+     *
+     * @param key the key.
+     * @param amount the increment type: double.
+     * @param increxArgs the {@link IncrexArgs} specifying bounds, overflow, and expiration options.
+     * @return IncrexValue containing the new value and actual increment applied.
+     * @since 7.6
+     */
+    RedisFuture<IncrexValue<Double>> increxfloat(K key, double amount, IncrexArgs increxArgs);
+
+    /**
      * Get the values of all the given keys.
      *
      * @param keys the key.
@@ -351,7 +384,7 @@ public interface RedisStringAsyncCommands<K, V> {
     /**
      * Set multiple keys to multiple values.
      *
-     * @param map the map.
+     * @param map the map containing key-value pairs.
      * @return String simple-string-reply always {@code OK} since {@code MSET} can't fail.
      */
     RedisFuture<String> mset(Map<K, V> map);
@@ -359,7 +392,7 @@ public interface RedisStringAsyncCommands<K, V> {
     /**
      * Set multiple keys to multiple values, only if none of the keys exist.
      *
-     * @param map the map.
+     * @param map the map containing key-value pairs.
      * @return Boolean integer-reply specifically:
      *
      *         {@code 1} if the all the keys were set. {@code 0} if no key was set (at least one key already existed).

--- a/src/main/java/io/lettuce/core/api/reactive/RedisStringReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisStringReactiveCommands.java
@@ -21,6 +21,8 @@ package io.lettuce.core.api.reactive;
 
 import java.util.Map;
 
+import io.lettuce.core.IncrexArgs;
+import io.lettuce.core.IncrexValue;
 import io.lettuce.core.MSetExArgs;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -331,6 +333,37 @@ public interface RedisStringReactiveCommands<K, V> {
      * @return Double bulk-string-reply the value of {@code key} after the increment.
      */
     Mono<Double> incrbyfloat(K key, double amount);
+
+    /**
+     * Increment the integer value of a key by 1 using INCREX.
+     *
+     * @param key the key.
+     * @return IncrexValue containing the new value and actual increment applied.
+     * @since 7.6
+     */
+    Mono<IncrexValue<Long>> increx(K key);
+
+    /**
+     * Increment the integer value of a key by the given amount with bounds, overflow, and expiration options.
+     *
+     * @param key the key.
+     * @param amount the increment type: long.
+     * @param increxArgs the {@link IncrexArgs} specifying bounds, overflow, and expiration options.
+     * @return IncrexValue containing the new value and actual increment applied.
+     * @since 7.6
+     */
+    Mono<IncrexValue<Long>> increx(K key, long amount, IncrexArgs increxArgs);
+
+    /**
+     * Increment the float value of a key by the given amount with bounds, overflow, and expiration options.
+     *
+     * @param key the key.
+     * @param amount the increment type: double.
+     * @param increxArgs the {@link IncrexArgs} specifying bounds, overflow, and expiration options.
+     * @return IncrexValue containing the new value and actual increment applied.
+     * @since 7.6
+     */
+    Mono<IncrexValue<Double>> increxfloat(K key, double amount, IncrexArgs increxArgs);
 
     /**
      * Get the values of all the given keys.

--- a/src/main/java/io/lettuce/core/api/reactive/RedisStringReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisStringReactiveCommands.java
@@ -22,6 +22,7 @@ package io.lettuce.core.api.reactive;
 import java.util.Map;
 
 import io.lettuce.core.IncrexArgs;
+import io.lettuce.core.IncrexFloatArgs;
 import io.lettuce.core.IncrexValue;
 import io.lettuce.core.MSetExArgs;
 import reactor.core.publisher.Flux;
@@ -355,15 +356,15 @@ public interface RedisStringReactiveCommands<K, V> {
     Mono<IncrexValue<Long>> increx(K key, long amount, IncrexArgs increxArgs);
 
     /**
-     * Increment the float value of a key by the given amount with bounds, overflow, and expiration options.
+     * Increment the float value of a key by the given amount with bounds, saturation, and expiration options.
      *
      * @param key the key.
      * @param amount the increment type: double.
-     * @param increxArgs the {@link IncrexArgs} specifying bounds, overflow, and expiration options.
+     * @param increxArgs the {@link IncrexFloatArgs} specifying bounds, {@code SATURATE} flag, and expiration options.
      * @return IncrexValue containing the new value and actual increment applied.
      * @since 7.6
      */
-    Mono<IncrexValue<Double>> increxfloat(K key, double amount, IncrexArgs increxArgs);
+    Mono<IncrexValue<Double>> increx(K key, double amount, IncrexFloatArgs increxArgs);
 
     /**
      * Get the values of all the given keys.

--- a/src/main/java/io/lettuce/core/api/sync/RedisStringCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisStringCommands.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import io.lettuce.core.BitFieldArgs;
 import io.lettuce.core.GetExArgs;
 import io.lettuce.core.IncrexArgs;
+import io.lettuce.core.IncrexFloatArgs;
 import io.lettuce.core.IncrexValue;
 import io.lettuce.core.KeyValue;
 import io.lettuce.core.MSetExArgs;
@@ -353,15 +354,15 @@ public interface RedisStringCommands<K, V> {
     IncrexValue<Long> increx(K key, long amount, IncrexArgs increxArgs);
 
     /**
-     * Increment the float value of a key by the given amount with bounds, overflow, and expiration options.
+     * Increment the float value of a key by the given amount with bounds, saturation, and expiration options.
      *
      * @param key the key.
      * @param amount the increment type: double.
-     * @param increxArgs the {@link IncrexArgs} specifying bounds, overflow, and expiration options.
+     * @param increxArgs the {@link IncrexFloatArgs} specifying bounds, {@code SATURATE} flag, and expiration options.
      * @return IncrexValue containing the new value and actual increment applied.
      * @since 7.6
      */
-    IncrexValue<Double> increxfloat(K key, double amount, IncrexArgs increxArgs);
+    IncrexValue<Double> increx(K key, double amount, IncrexFloatArgs increxArgs);
 
     /**
      * Get the values of all the given keys.

--- a/src/main/java/io/lettuce/core/api/sync/RedisStringCommands.java
+++ b/src/main/java/io/lettuce/core/api/sync/RedisStringCommands.java
@@ -24,6 +24,8 @@ import java.util.Map;
 
 import io.lettuce.core.BitFieldArgs;
 import io.lettuce.core.GetExArgs;
+import io.lettuce.core.IncrexArgs;
+import io.lettuce.core.IncrexValue;
 import io.lettuce.core.KeyValue;
 import io.lettuce.core.MSetExArgs;
 import io.lettuce.core.SetArgs;
@@ -329,6 +331,37 @@ public interface RedisStringCommands<K, V> {
      * @return Double bulk-string-reply the value of {@code key} after the increment.
      */
     Double incrbyfloat(K key, double amount);
+
+    /**
+     * Increment the integer value of a key by 1 using INCREX.
+     *
+     * @param key the key.
+     * @return IncrexValue containing the new value and actual increment applied.
+     * @since 7.6
+     */
+    IncrexValue<Long> increx(K key);
+
+    /**
+     * Increment the integer value of a key by the given amount with bounds, overflow, and expiration options.
+     *
+     * @param key the key.
+     * @param amount the increment type: long.
+     * @param increxArgs the {@link IncrexArgs} specifying bounds, overflow, and expiration options.
+     * @return IncrexValue containing the new value and actual increment applied.
+     * @since 7.6
+     */
+    IncrexValue<Long> increx(K key, long amount, IncrexArgs increxArgs);
+
+    /**
+     * Increment the float value of a key by the given amount with bounds, overflow, and expiration options.
+     *
+     * @param key the key.
+     * @param amount the increment type: double.
+     * @param increxArgs the {@link IncrexArgs} specifying bounds, overflow, and expiration options.
+     * @return IncrexValue containing the new value and actual increment applied.
+     * @since 7.6
+     */
+    IncrexValue<Double> increxfloat(K key, double amount, IncrexArgs increxArgs);
 
     /**
      * Get the values of all the given keys.

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionStringAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionStringAsyncCommands.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import io.lettuce.core.BitFieldArgs;
 import io.lettuce.core.GetExArgs;
 import io.lettuce.core.IncrexArgs;
+import io.lettuce.core.IncrexFloatArgs;
 import io.lettuce.core.IncrexValue;
 import io.lettuce.core.KeyValue;
 import io.lettuce.core.MSetExArgs;
@@ -352,15 +353,15 @@ public interface NodeSelectionStringAsyncCommands<K, V> {
     AsyncExecutions<IncrexValue<Long>> increx(K key, long amount, IncrexArgs increxArgs);
 
     /**
-     * Increment the float value of a key by the given amount with bounds, overflow, and expiration options.
+     * Increment the float value of a key by the given amount with bounds, saturation, and expiration options.
      *
      * @param key the key.
      * @param amount the increment type: double.
-     * @param increxArgs the {@link IncrexArgs} specifying bounds, overflow, and expiration options.
+     * @param increxArgs the {@link IncrexFloatArgs} specifying bounds, {@code SATURATE} flag, and expiration options.
      * @return IncrexValue containing the new value and actual increment applied.
      * @since 7.6
      */
-    AsyncExecutions<IncrexValue<Double>> increxfloat(K key, double amount, IncrexArgs increxArgs);
+    AsyncExecutions<IncrexValue<Double>> increx(K key, double amount, IncrexFloatArgs increxArgs);
 
     /**
      * Get the values of all the given keys.

--- a/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionStringAsyncCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/async/NodeSelectionStringAsyncCommands.java
@@ -24,6 +24,8 @@ import java.util.Map;
 
 import io.lettuce.core.BitFieldArgs;
 import io.lettuce.core.GetExArgs;
+import io.lettuce.core.IncrexArgs;
+import io.lettuce.core.IncrexValue;
 import io.lettuce.core.KeyValue;
 import io.lettuce.core.MSetExArgs;
 import io.lettuce.core.SetArgs;
@@ -328,6 +330,37 @@ public interface NodeSelectionStringAsyncCommands<K, V> {
      * @return Double bulk-string-reply the value of {@code key} after the increment.
      */
     AsyncExecutions<Double> incrbyfloat(K key, double amount);
+
+    /**
+     * Increment the integer value of a key by 1 using INCREX.
+     *
+     * @param key the key.
+     * @return IncrexValue containing the new value and actual increment applied.
+     * @since 7.6
+     */
+    AsyncExecutions<IncrexValue<Long>> increx(K key);
+
+    /**
+     * Increment the integer value of a key by the given amount with bounds, overflow, and expiration options.
+     *
+     * @param key the key.
+     * @param amount the increment type: long.
+     * @param increxArgs the {@link IncrexArgs} specifying bounds, overflow, and expiration options.
+     * @return IncrexValue containing the new value and actual increment applied.
+     * @since 7.6
+     */
+    AsyncExecutions<IncrexValue<Long>> increx(K key, long amount, IncrexArgs increxArgs);
+
+    /**
+     * Increment the float value of a key by the given amount with bounds, overflow, and expiration options.
+     *
+     * @param key the key.
+     * @param amount the increment type: double.
+     * @param increxArgs the {@link IncrexArgs} specifying bounds, overflow, and expiration options.
+     * @return IncrexValue containing the new value and actual increment applied.
+     * @since 7.6
+     */
+    AsyncExecutions<IncrexValue<Double>> increxfloat(K key, double amount, IncrexArgs increxArgs);
 
     /**
      * Get the values of all the given keys.

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionStringCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionStringCommands.java
@@ -24,6 +24,8 @@ import java.util.Map;
 
 import io.lettuce.core.BitFieldArgs;
 import io.lettuce.core.GetExArgs;
+import io.lettuce.core.IncrexArgs;
+import io.lettuce.core.IncrexValue;
 import io.lettuce.core.KeyValue;
 import io.lettuce.core.MSetExArgs;
 import io.lettuce.core.SetArgs;
@@ -328,6 +330,37 @@ public interface NodeSelectionStringCommands<K, V> {
      * @return Double bulk-string-reply the value of {@code key} after the increment.
      */
     Executions<Double> incrbyfloat(K key, double amount);
+
+    /**
+     * Increment the integer value of a key by 1 using INCREX.
+     *
+     * @param key the key.
+     * @return IncrexValue containing the new value and actual increment applied.
+     * @since 7.6
+     */
+    Executions<IncrexValue<Long>> increx(K key);
+
+    /**
+     * Increment the integer value of a key by the given amount with bounds, overflow, and expiration options.
+     *
+     * @param key the key.
+     * @param amount the increment type: long.
+     * @param increxArgs the {@link IncrexArgs} specifying bounds, overflow, and expiration options.
+     * @return IncrexValue containing the new value and actual increment applied.
+     * @since 7.6
+     */
+    Executions<IncrexValue<Long>> increx(K key, long amount, IncrexArgs increxArgs);
+
+    /**
+     * Increment the float value of a key by the given amount with bounds, overflow, and expiration options.
+     *
+     * @param key the key.
+     * @param amount the increment type: double.
+     * @param increxArgs the {@link IncrexArgs} specifying bounds, overflow, and expiration options.
+     * @return IncrexValue containing the new value and actual increment applied.
+     * @since 7.6
+     */
+    Executions<IncrexValue<Double>> increxfloat(K key, double amount, IncrexArgs increxArgs);
 
     /**
      * Get the values of all the given keys.

--- a/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionStringCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/sync/NodeSelectionStringCommands.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import io.lettuce.core.BitFieldArgs;
 import io.lettuce.core.GetExArgs;
 import io.lettuce.core.IncrexArgs;
+import io.lettuce.core.IncrexFloatArgs;
 import io.lettuce.core.IncrexValue;
 import io.lettuce.core.KeyValue;
 import io.lettuce.core.MSetExArgs;
@@ -352,15 +353,15 @@ public interface NodeSelectionStringCommands<K, V> {
     Executions<IncrexValue<Long>> increx(K key, long amount, IncrexArgs increxArgs);
 
     /**
-     * Increment the float value of a key by the given amount with bounds, overflow, and expiration options.
+     * Increment the float value of a key by the given amount with bounds, saturation, and expiration options.
      *
      * @param key the key.
      * @param amount the increment type: double.
-     * @param increxArgs the {@link IncrexArgs} specifying bounds, overflow, and expiration options.
+     * @param increxArgs the {@link IncrexFloatArgs} specifying bounds, {@code SATURATE} flag, and expiration options.
      * @return IncrexValue containing the new value and actual increment applied.
      * @since 7.6
      */
-    Executions<IncrexValue<Double>> increxfloat(K key, double amount, IncrexArgs increxArgs);
+    Executions<IncrexValue<Double>> increx(K key, double amount, IncrexFloatArgs increxArgs);
 
     /**
      * Get the values of all the given keys.

--- a/src/main/java/io/lettuce/core/output/IncrexDoubleOutput.java
+++ b/src/main/java/io/lettuce/core/output/IncrexDoubleOutput.java
@@ -1,0 +1,43 @@
+package io.lettuce.core.output;
+
+import io.lettuce.core.IncrexValue;
+import io.lettuce.core.codec.RedisCodec;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Parses the {@code INCREX} array response {@code [value, increment]} into {@link IncrexValue}{@code <Double>}.
+ *
+ * @since 7.6
+ */
+public class IncrexDoubleOutput<K, V> extends CommandOutput<K, V, IncrexValue<Double>> {
+
+    private Double first;
+
+    private int index = 0;
+
+    public IncrexDoubleOutput(RedisCodec<K, V> codec) {
+        super(codec, null);
+    }
+
+    @Override
+    public void set(ByteBuffer bytes) {
+        double parsed = (bytes == null) ? 0d : Double.parseDouble(decodeString(bytes));
+        capture(parsed);
+    }
+
+    @Override
+    public void set(double number) {
+        capture(number);
+    }
+
+    private void capture(double value) {
+        if (index == 0) {
+            first = value;
+        } else {
+            output = new IncrexValue<>(first, value);
+        }
+        index++;
+    }
+
+}

--- a/src/main/java/io/lettuce/core/output/IncrexLongOutput.java
+++ b/src/main/java/io/lettuce/core/output/IncrexLongOutput.java
@@ -1,0 +1,43 @@
+package io.lettuce.core.output;
+
+import io.lettuce.core.IncrexValue;
+import io.lettuce.core.codec.RedisCodec;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Parses the {@code INCREX} array response {@code [value, increment]} into {@link IncrexValue}{@code <Long>}.
+ *
+ * @since 7.6
+ */
+public class IncrexLongOutput<K, V> extends CommandOutput<K, V, IncrexValue<Long>> {
+
+    private Long first;
+
+    private int index = 0;
+
+    public IncrexLongOutput(RedisCodec<K, V> codec) {
+        super(codec, null);
+    }
+
+    @Override
+    public void set(ByteBuffer bytes) {
+        long parsed = Long.parseLong(decodeString(bytes));
+        capture(parsed);
+    }
+
+    @Override
+    public void set(long integer) {
+        capture(integer);
+    }
+
+    private void capture(long value) {
+        if (index == 0) {
+            first = value;
+        } else {
+            output = new IncrexValue<>(first, value);
+        }
+        index++;
+    }
+
+}

--- a/src/main/java/io/lettuce/core/protocol/CommandKeyword.java
+++ b/src/main/java/io/lettuce/core/protocol/CommandKeyword.java
@@ -65,7 +65,10 @@ public enum CommandKeyword implements ProtocolKeyword {
 
     METRICS, DURATION, SAMPLE, CPU, NET, START, STOP,
 
-    FP16, BF16, FP32, FP64, FPHA;
+    FP16, BF16, FP32, FP64, FPHA,
+
+    // INCREX keywords
+    BYFLOAT, BYINT, ENX, FAIL, LBOUND, OVERFLOW, REJECT, SAT, UBOUND;
 
     public final byte[] bytes;
 

--- a/src/main/java/io/lettuce/core/protocol/CommandKeyword.java
+++ b/src/main/java/io/lettuce/core/protocol/CommandKeyword.java
@@ -68,7 +68,7 @@ public enum CommandKeyword implements ProtocolKeyword {
     FP16, BF16, FP32, FP64, FPHA,
 
     // INCREX keywords
-    BYFLOAT, BYINT, ENX, FAIL, LBOUND, OVERFLOW, REJECT, SAT, UBOUND;
+    BYFLOAT, BYINT, ENX, LBOUND, SATURATE, UBOUND;
 
     public final byte[] bytes;
 

--- a/src/main/java/io/lettuce/core/protocol/CommandType.java
+++ b/src/main/java/io/lettuce/core/protocol/CommandType.java
@@ -54,7 +54,7 @@ public enum CommandType implements ProtocolKeyword {
 
     // Numeric
 
-    DECR, DECRBY, INCR, INCRBY, INCRBYFLOAT,
+    DECR, DECRBY, INCR, INCRBY, INCRBYFLOAT, INCREX,
 
     // List
 

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisStringCoroutinesCommands.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisStringCoroutinesCommands.kt
@@ -275,6 +275,37 @@ interface RedisStringCoroutinesCommands<K : Any, V : Any> {
     suspend fun incrbyfloat(key: K, amount: Double): Double?
 
     /**
+     * Increment the integer value of a key by 1 using INCREX.
+     *
+     * @param key the key.
+     * @return IncrexValue containing the new value and actual increment applied.
+     * @since 7.6
+     */
+    suspend fun increx(key: K): IncrexValue<Long>?
+
+    /**
+     * Increment the integer value of a key by the given amount with bounds, overflow, and expiration options.
+     *
+     * @param key the key.
+     * @param amount the increment type: long.
+     * @param increxArgs the [IncrexArgs] specifying bounds, overflow, and expiration options.
+     * @return IncrexValue containing the new value and actual increment applied.
+     * @since 7.6
+     */
+    suspend fun increx(key: K, amount: Long, increxArgs: IncrexArgs): IncrexValue<Long>?
+
+    /**
+     * Increment the float value of a key by the given amount with bounds, overflow, and expiration options.
+     *
+     * @param key the key.
+     * @param amount the increment type: Double.
+     * @param increxArgs the [IncrexArgs] specifying bounds, overflow, and expiration options.
+     * @return IncrexValue containing the new value and actual increment applied.
+     * @since 7.6
+     */
+    suspend fun increxfloat(key: K, amount: Double, increxArgs: IncrexArgs): IncrexValue<Double>?
+
+    /**
      * Get the values of all the given keys.
      *
      * @param keys the key.

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisStringCoroutinesCommands.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisStringCoroutinesCommands.kt
@@ -295,15 +295,15 @@ interface RedisStringCoroutinesCommands<K : Any, V : Any> {
     suspend fun increx(key: K, amount: Long, increxArgs: IncrexArgs): IncrexValue<Long>?
 
     /**
-     * Increment the float value of a key by the given amount with bounds, overflow, and expiration options.
+     * Increment the float value of a key by the given amount with bounds, saturation, and expiration options.
      *
      * @param key the key.
      * @param amount the increment type: Double.
-     * @param increxArgs the [IncrexArgs] specifying bounds, overflow, and expiration options.
+     * @param increxArgs the [IncrexFloatArgs] specifying bounds, [SATURATE] flag, and expiration options.
      * @return IncrexValue containing the new value and actual increment applied.
      * @since 7.6
      */
-    suspend fun increxfloat(key: K, amount: Double, increxArgs: IncrexArgs): IncrexValue<Double>?
+    suspend fun increx(key: K, amount: Double, increxArgs: IncrexFloatArgs): IncrexValue<Double>?
 
     /**
      * Get the values of all the given keys.

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisStringCoroutinesCommandsImpl.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisStringCoroutinesCommandsImpl.kt
@@ -98,8 +98,8 @@ internal class RedisStringCoroutinesCommandsImpl<K : Any, V : Any>(internal val 
     override suspend fun increx(key: K, amount: Long, increxArgs: IncrexArgs): IncrexValue<Long>? =
         ops.increx(key, amount, increxArgs).awaitFirstOrNull()
 
-    override suspend fun increxfloat(key: K, amount: Double, increxArgs: IncrexArgs): IncrexValue<Double>? =
-        ops.increxfloat(key, amount, increxArgs).awaitFirstOrNull()
+    override suspend fun increx(key: K, amount: Double, increxArgs: IncrexFloatArgs): IncrexValue<Double>? =
+        ops.increx(key, amount, increxArgs).awaitFirstOrNull()
 
     override fun mget(vararg keys: K): Flow<KeyValue<K, V>> = ops.mget(*keys).asFlow()
 

--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisStringCoroutinesCommandsImpl.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisStringCoroutinesCommandsImpl.kt
@@ -92,6 +92,15 @@ internal class RedisStringCoroutinesCommandsImpl<K : Any, V : Any>(internal val 
     override suspend fun incrbyfloat(key: K, amount: Double): Double? =
         ops.incrbyfloat(key, amount).awaitFirstOrNull()
 
+    override suspend fun increx(key: K): IncrexValue<Long>? =
+        ops.increx(key).awaitFirstOrNull()
+
+    override suspend fun increx(key: K, amount: Long, increxArgs: IncrexArgs): IncrexValue<Long>? =
+        ops.increx(key, amount, increxArgs).awaitFirstOrNull()
+
+    override suspend fun increxfloat(key: K, amount: Double, increxArgs: IncrexArgs): IncrexValue<Double>? =
+        ops.increxfloat(key, amount, increxArgs).awaitFirstOrNull()
+
     override fun mget(vararg keys: K): Flow<KeyValue<K, V>> = ops.mget(*keys).asFlow()
 
     override suspend fun mset(map: Map<K, V>): String? = ops.mset(map).awaitFirstOrNull()

--- a/src/main/templates/io/lettuce/core/api/RedisStringCommands.java
+++ b/src/main/templates/io/lettuce/core/api/RedisStringCommands.java
@@ -322,6 +322,37 @@ public interface RedisStringCommands<K, V> {
     Double incrbyfloat(K key, double amount);
 
     /**
+     * Increment the integer value of a key by 1 using INCREX.
+     *
+     * @param key the key.
+     * @return IncrexValue containing the new value and actual increment applied.
+     * @since 7.6
+     */
+    IncrexValue<Long> increx(K key);
+
+    /**
+     * Increment the integer value of a key by the given amount with bounds, overflow, and expiration options.
+     *
+     * @param key the key.
+     * @param amount the increment type: long.
+     * @param increxArgs the {@link IncrexArgs} specifying bounds, overflow, and expiration options.
+     * @return IncrexValue containing the new value and actual increment applied.
+     * @since 7.6
+     */
+    IncrexValue<Long> increx(K key, long amount, IncrexArgs increxArgs);
+
+    /**
+     * Increment the float value of a key by the given amount with bounds, overflow, and expiration options.
+     *
+     * @param key the key.
+     * @param amount the increment type: double.
+     * @param increxArgs the {@link IncrexArgs} specifying bounds, overflow, and expiration options.
+     * @return IncrexValue containing the new value and actual increment applied.
+     * @since 7.6
+     */
+    IncrexValue<Double> increxfloat(K key, double amount, IncrexArgs increxArgs);
+
+    /**
      * Get the values of all the given keys.
      *
      * @param keys the key.

--- a/src/main/templates/io/lettuce/core/api/RedisStringCommands.java
+++ b/src/main/templates/io/lettuce/core/api/RedisStringCommands.java
@@ -342,15 +342,15 @@ public interface RedisStringCommands<K, V> {
     IncrexValue<Long> increx(K key, long amount, IncrexArgs increxArgs);
 
     /**
-     * Increment the float value of a key by the given amount with bounds, overflow, and expiration options.
+     * Increment the float value of a key by the given amount with bounds, saturation, and expiration options.
      *
      * @param key the key.
      * @param amount the increment type: double.
-     * @param increxArgs the {@link IncrexArgs} specifying bounds, overflow, and expiration options.
+     * @param increxArgs the {@link IncrexFloatArgs} specifying bounds, {@code SATURATE} flag, and expiration options.
      * @return IncrexValue containing the new value and actual increment applied.
      * @since 7.6
      */
-    IncrexValue<Double> increxfloat(K key, double amount, IncrexArgs increxArgs);
+    IncrexValue<Double> increx(K key, double amount, IncrexFloatArgs increxArgs);
 
     /**
      * Get the values of all the given keys.

--- a/src/test/java/io/lettuce/core/IncrexArgsUnitTests.java
+++ b/src/test/java/io/lettuce/core/IncrexArgsUnitTests.java
@@ -19,24 +19,10 @@ class IncrexArgsUnitTests {
     }
 
     @Test
-    void shouldRenderOverflowSat() {
+    void shouldRenderSaturate() {
         CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
-        IncrexArgs.Builder.overflow(IncrexArgs.Overflow.SAT).build(args);
-        assertThat(args.toCommandString()).isEqualTo("OVERFLOW SAT");
-    }
-
-    @Test
-    void shouldRenderOverflowReject() {
-        CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
-        IncrexArgs.Builder.overflow(IncrexArgs.Overflow.REJECT).build(args);
-        assertThat(args.toCommandString()).isEqualTo("OVERFLOW REJECT");
-    }
-
-    @Test
-    void shouldRenderOverflowFail() {
-        CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
-        IncrexArgs.Builder.overflow(IncrexArgs.Overflow.FAIL).build(args);
-        assertThat(args.toCommandString()).isEqualTo("OVERFLOW FAIL");
+        IncrexArgs.Builder.saturate().build(args);
+        assertThat(args.toCommandString()).isEqualTo("SATURATE");
     }
 
     @Test
@@ -84,8 +70,8 @@ class IncrexArgsUnitTests {
     @Test
     void shouldRenderFullArgs() {
         CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
-        IncrexArgs.Builder.lbound(0).ubound(100).overflow(IncrexArgs.Overflow.SAT).ex(60).enx().build(args);
-        assertThat(args.toCommandString()).isEqualTo("LBOUND 0 UBOUND 100 OVERFLOW SAT EX 60 ENX");
+        IncrexArgs.Builder.lbound(0).ubound(100).saturate().ex(60).enx().build(args);
+        assertThat(args.toCommandString()).isEqualTo("LBOUND 0 UBOUND 100 SATURATE EX 60 ENX");
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/IncrexArgsUnitTests.java
+++ b/src/test/java/io/lettuce/core/IncrexArgsUnitTests.java
@@ -1,0 +1,105 @@
+package io.lettuce.core;
+
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.protocol.CommandArgs;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static io.lettuce.TestTags.UNIT_TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag(UNIT_TEST)
+class IncrexArgsUnitTests {
+
+    @Test
+    void shouldRenderLboundUbound() {
+        CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
+        IncrexArgs.Builder.lbound(0).ubound(100).build(args);
+        assertThat(args.toCommandString()).isEqualTo("LBOUND 0 UBOUND 100");
+    }
+
+    @Test
+    void shouldRenderOverflowSat() {
+        CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
+        IncrexArgs.Builder.overflow(IncrexArgs.Overflow.SAT).build(args);
+        assertThat(args.toCommandString()).isEqualTo("OVERFLOW SAT");
+    }
+
+    @Test
+    void shouldRenderOverflowReject() {
+        CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
+        IncrexArgs.Builder.overflow(IncrexArgs.Overflow.REJECT).build(args);
+        assertThat(args.toCommandString()).isEqualTo("OVERFLOW REJECT");
+    }
+
+    @Test
+    void shouldRenderOverflowFail() {
+        CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
+        IncrexArgs.Builder.overflow(IncrexArgs.Overflow.FAIL).build(args);
+        assertThat(args.toCommandString()).isEqualTo("OVERFLOW FAIL");
+    }
+
+    @Test
+    void shouldRenderEx() {
+        CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
+        IncrexArgs.Builder.ex(60).build(args);
+        assertThat(args.toCommandString()).isEqualTo("EX 60");
+    }
+
+    @Test
+    void shouldRenderPx() {
+        CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
+        IncrexArgs.Builder.px(5000).build(args);
+        assertThat(args.toCommandString()).isEqualTo("PX 5000");
+    }
+
+    @Test
+    void shouldRenderExAt() {
+        CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
+        IncrexArgs.Builder.exAt(1700000000).build(args);
+        assertThat(args.toCommandString()).isEqualTo("EXAT 1700000000");
+    }
+
+    @Test
+    void shouldRenderPxAt() {
+        CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
+        IncrexArgs.Builder.pxAt(1700000000000L).build(args);
+        assertThat(args.toCommandString()).isEqualTo("PXAT 1700000000000");
+    }
+
+    @Test
+    void shouldRenderPersist() {
+        CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
+        IncrexArgs.Builder.persist().build(args);
+        assertThat(args.toCommandString()).isEqualTo("PERSIST");
+    }
+
+    @Test
+    void shouldRenderEnx() {
+        CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
+        IncrexArgs.Builder.ex(60).enx().build(args);
+        assertThat(args.toCommandString()).isEqualTo("EX 60 ENX");
+    }
+
+    @Test
+    void shouldRenderFullArgs() {
+        CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
+        IncrexArgs.Builder.lbound(0).ubound(100).overflow(IncrexArgs.Overflow.SAT).ex(60).enx().build(args);
+        assertThat(args.toCommandString()).isEqualTo("LBOUND 0 UBOUND 100 OVERFLOW SAT EX 60 ENX");
+    }
+
+    @Test
+    void shouldRenderNoArgs() {
+        CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
+        new IncrexArgs().build(args);
+        assertThat(args.toCommandString()).isEmpty();
+    }
+
+    @Test
+    void shouldRenderDoubleBounds() {
+        CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
+        IncrexArgs.Builder.lbound(-1.5).ubound(9.5).build(args);
+        assertThat(args.toCommandString()).isEqualTo("LBOUND -1.5 UBOUND 9.5");
+    }
+
+}

--- a/src/test/java/io/lettuce/core/IncrexFloatArgsUnitTests.java
+++ b/src/test/java/io/lettuce/core/IncrexFloatArgsUnitTests.java
@@ -9,75 +9,82 @@ import static io.lettuce.TestTags.UNIT_TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Tag(UNIT_TEST)
-class IncrexArgsUnitTests {
+class IncrexFloatArgsUnitTests {
 
     @Test
     void shouldRenderLboundUbound() {
         CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
-        IncrexArgs.Builder.lbound(0).ubound(100).build(args);
-        assertThat(args.toCommandString()).isEqualTo("LBOUND 0 UBOUND 100");
+        IncrexFloatArgs.Builder.lbound(0.0).ubound(100.0).build(args);
+        assertThat(args.toCommandString()).isEqualTo("LBOUND 0.0 UBOUND 100.0");
+    }
+
+    @Test
+    void shouldRenderDoubleBounds() {
+        CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
+        IncrexFloatArgs.Builder.lbound(-1.5).ubound(9.5).build(args);
+        assertThat(args.toCommandString()).isEqualTo("LBOUND -1.5 UBOUND 9.5");
     }
 
     @Test
     void shouldRenderSaturate() {
         CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
-        IncrexArgs.Builder.saturate().build(args);
+        IncrexFloatArgs.Builder.saturate().build(args);
         assertThat(args.toCommandString()).isEqualTo("SATURATE");
     }
 
     @Test
     void shouldRenderEx() {
         CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
-        IncrexArgs.Builder.ex(60).build(args);
+        IncrexFloatArgs.Builder.ex(60).build(args);
         assertThat(args.toCommandString()).isEqualTo("EX 60");
     }
 
     @Test
     void shouldRenderPx() {
         CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
-        IncrexArgs.Builder.px(5000).build(args);
+        IncrexFloatArgs.Builder.px(5000).build(args);
         assertThat(args.toCommandString()).isEqualTo("PX 5000");
     }
 
     @Test
     void shouldRenderExAt() {
         CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
-        IncrexArgs.Builder.exAt(1700000000).build(args);
+        IncrexFloatArgs.Builder.exAt(1700000000).build(args);
         assertThat(args.toCommandString()).isEqualTo("EXAT 1700000000");
     }
 
     @Test
     void shouldRenderPxAt() {
         CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
-        IncrexArgs.Builder.pxAt(1700000000000L).build(args);
+        IncrexFloatArgs.Builder.pxAt(1700000000000L).build(args);
         assertThat(args.toCommandString()).isEqualTo("PXAT 1700000000000");
     }
 
     @Test
     void shouldRenderPersist() {
         CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
-        IncrexArgs.Builder.persist().build(args);
+        IncrexFloatArgs.Builder.persist().build(args);
         assertThat(args.toCommandString()).isEqualTo("PERSIST");
     }
 
     @Test
     void shouldRenderEnx() {
         CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
-        IncrexArgs.Builder.ex(60).enx().build(args);
+        IncrexFloatArgs.Builder.ex(60).enx().build(args);
         assertThat(args.toCommandString()).isEqualTo("EX 60 ENX");
     }
 
     @Test
     void shouldRenderFullArgs() {
         CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
-        IncrexArgs.Builder.lbound(0).ubound(100).saturate().ex(60).enx().build(args);
-        assertThat(args.toCommandString()).isEqualTo("LBOUND 0 UBOUND 100 SATURATE EX 60 ENX");
+        IncrexFloatArgs.Builder.lbound(0.0).ubound(100.0).saturate().ex(60).enx().build(args);
+        assertThat(args.toCommandString()).isEqualTo("LBOUND 0.0 UBOUND 100.0 SATURATE EX 60 ENX");
     }
 
     @Test
     void shouldRenderNoArgs() {
         CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
-        new IncrexArgs().build(args);
+        new IncrexFloatArgs().build(args);
         assertThat(args.toCommandString()).isEmpty();
     }
 

--- a/src/test/java/io/lettuce/core/commands/StringCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/StringCommandIntegrationTests.java
@@ -573,9 +573,9 @@ public class StringCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("INCREX")
-    void increxRejectOverflow() {
+    void increxDefaultRejectSilent() {
         redis.set(key, "0");
-        IncrexArgs args = IncrexArgs.Builder.ubound(5).overflow(IncrexArgs.Overflow.REJECT);
+        IncrexArgs args = IncrexArgs.Builder.ubound(5);
         IncrexValue<Long> res = redis.increx(key, 10, args);
         assertThat(res.getValue()).isEqualTo(0L);
         assertThat(res.getIncrement()).isEqualTo(0L);
@@ -583,9 +583,9 @@ public class StringCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("INCREX")
-    void increxSatOverflowUbound() {
+    void increxSaturateUbound() {
         redis.set(key, "0");
-        IncrexArgs args = IncrexArgs.Builder.ubound(5).overflow(IncrexArgs.Overflow.SAT);
+        IncrexArgs args = IncrexArgs.Builder.ubound(5).saturate();
         IncrexValue<Long> res = redis.increx(key, 10, args);
         assertThat(res.getValue()).isEqualTo(5L);
         assertThat(res.getIncrement()).isEqualTo(5L);
@@ -593,9 +593,9 @@ public class StringCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("INCREX")
-    void increxSatOverflowLbound() {
+    void increxSaturateLbound() {
         redis.set(key, "5");
-        IncrexArgs args = IncrexArgs.Builder.lbound(0).overflow(IncrexArgs.Overflow.SAT);
+        IncrexArgs args = IncrexArgs.Builder.lbound(0).saturate();
         IncrexValue<Long> res = redis.increx(key, -100, args);
         assertThat(res.getValue()).isEqualTo(0L);
         assertThat(res.getIncrement()).isEqualTo(-5L);
@@ -603,17 +603,9 @@ public class StringCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("INCREX")
-    void increxFailOverflow() {
-        redis.set(key, "0");
-        IncrexArgs args = IncrexArgs.Builder.ubound(5).overflow(IncrexArgs.Overflow.FAIL);
-        assertThatThrownBy(() -> redis.increx(key, 10, args)).isInstanceOf(RedisCommandExecutionException.class);
-    }
-
-    @Test
-    @EnabledOnCommand("INCREX")
-    void increxSatStillAppliesExpiry() {
+    void increxSaturateStillAppliesExpiry() {
         redis.set(key, "5");
-        IncrexArgs args = IncrexArgs.Builder.ubound(5).overflow(IncrexArgs.Overflow.SAT).ex(60);
+        IncrexArgs args = IncrexArgs.Builder.ubound(5).saturate().ex(60);
         IncrexValue<Long> res = redis.increx(key, 1, args);
         assertThat(res.getValue()).isEqualTo(5L);
         assertThat(res.getIncrement()).isEqualTo(0L);
@@ -673,9 +665,9 @@ public class StringCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("INCREX")
-    void increxFloatSatOverflow() {
+    void increxSaturateFloat() {
         redis.set(key, "0.0");
-        IncrexArgs args = IncrexArgs.Builder.ubound(5.0).overflow(IncrexArgs.Overflow.SAT);
+        IncrexArgs args = IncrexArgs.Builder.ubound(5.0).saturate();
         IncrexValue<Double> res = redis.increxfloat(key, 10.0, args);
         assertThat(res.getValue()).isEqualTo(5.0);
         assertThat(res.getIncrement()).isEqualTo(5.0);

--- a/src/test/java/io/lettuce/core/commands/StringCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/StringCommandIntegrationTests.java
@@ -555,8 +555,8 @@ public class StringCommandIntegrationTests extends TestSupport {
     @EnabledOnCommand("INCREX")
     void increxByFloatWithBoundsAndExpiry() {
         redis.set(key, "3.25");
-        IncrexArgs args = IncrexArgs.Builder.lbound(-1.5).ubound(9.5).ex(60);
-        IncrexValue<Double> res = redis.increxfloat(key, 1.25, args);
+        IncrexFloatArgs args = IncrexFloatArgs.Builder.lbound(-1.5).ubound(9.5).ex(60);
+        IncrexValue<Double> res = redis.increx(key, 1.25, args);
         assertThat(res.getValue()).isEqualTo(4.5);
         assertThat(res.getIncrement()).isEqualTo(1.25);
     }
@@ -667,8 +667,8 @@ public class StringCommandIntegrationTests extends TestSupport {
     @EnabledOnCommand("INCREX")
     void increxSaturateFloat() {
         redis.set(key, "0.0");
-        IncrexArgs args = IncrexArgs.Builder.ubound(5.0).saturate();
-        IncrexValue<Double> res = redis.increxfloat(key, 10.0, args);
+        IncrexFloatArgs args = IncrexFloatArgs.Builder.ubound(5.0).saturate();
+        IncrexValue<Double> res = redis.increx(key, 10.0, args);
         assertThat(res.getValue()).isEqualTo(5.0);
         assertThat(res.getIncrement()).isEqualTo(5.0);
     }

--- a/src/test/java/io/lettuce/core/commands/StringCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/StringCommandIntegrationTests.java
@@ -530,4 +530,155 @@ public class StringCommandIntegrationTests extends TestSupport {
         assertThat(matchResult.getMatchString()).isNullOrEmpty();
     }
 
+    // ── INCREX ──────────────────────────────────────────
+
+    @Test
+    @EnabledOnCommand("INCREX")
+    void increxBasic() {
+        IncrexValue<Long> res = redis.increx(key);
+        assertThat(res.getValue()).isEqualTo(1L);
+        assertThat(res.getIncrement()).isEqualTo(1L);
+    }
+
+    @Test
+    @EnabledOnCommand("INCREX")
+    void increxByIntWithBoundsAndExpiry() {
+        redis.set(key, "10");
+        IncrexArgs args = IncrexArgs.Builder.lbound(0).ubound(20).ex(60);
+        IncrexValue<Long> res = redis.increx(key, 2, args);
+        assertThat(res.getValue()).isEqualTo(12L);
+        assertThat(res.getIncrement()).isEqualTo(2L);
+        assertThat(redis.ttl(key)).isGreaterThan(0);
+    }
+
+    @Test
+    @EnabledOnCommand("INCREX")
+    void increxByFloatWithBoundsAndExpiry() {
+        redis.set(key, "3.25");
+        IncrexArgs args = IncrexArgs.Builder.lbound(-1.5).ubound(9.5).ex(60);
+        IncrexValue<Double> res = redis.increxfloat(key, 1.25, args);
+        assertThat(res.getValue()).isEqualTo(4.5);
+        assertThat(res.getIncrement()).isEqualTo(1.25);
+    }
+
+    @Test
+    @EnabledOnCommand("INCREX")
+    void increxNegativeIncrement() {
+        redis.set(key, "10");
+        IncrexArgs args = new IncrexArgs();
+        IncrexValue<Long> res = redis.increx(key, -3, args);
+        assertThat(res.getValue()).isEqualTo(7L);
+        assertThat(res.getIncrement()).isEqualTo(-3L);
+    }
+
+    @Test
+    @EnabledOnCommand("INCREX")
+    void increxRejectOverflow() {
+        redis.set(key, "0");
+        IncrexArgs args = IncrexArgs.Builder.ubound(5).overflow(IncrexArgs.Overflow.REJECT);
+        IncrexValue<Long> res = redis.increx(key, 10, args);
+        assertThat(res.getValue()).isEqualTo(0L);
+        assertThat(res.getIncrement()).isEqualTo(0L);
+    }
+
+    @Test
+    @EnabledOnCommand("INCREX")
+    void increxSatOverflowUbound() {
+        redis.set(key, "0");
+        IncrexArgs args = IncrexArgs.Builder.ubound(5).overflow(IncrexArgs.Overflow.SAT);
+        IncrexValue<Long> res = redis.increx(key, 10, args);
+        assertThat(res.getValue()).isEqualTo(5L);
+        assertThat(res.getIncrement()).isEqualTo(5L);
+    }
+
+    @Test
+    @EnabledOnCommand("INCREX")
+    void increxSatOverflowLbound() {
+        redis.set(key, "5");
+        IncrexArgs args = IncrexArgs.Builder.lbound(0).overflow(IncrexArgs.Overflow.SAT);
+        IncrexValue<Long> res = redis.increx(key, -100, args);
+        assertThat(res.getValue()).isEqualTo(0L);
+        assertThat(res.getIncrement()).isEqualTo(-5L);
+    }
+
+    @Test
+    @EnabledOnCommand("INCREX")
+    void increxFailOverflow() {
+        redis.set(key, "0");
+        IncrexArgs args = IncrexArgs.Builder.ubound(5).overflow(IncrexArgs.Overflow.FAIL);
+        assertThatThrownBy(() -> redis.increx(key, 10, args)).isInstanceOf(RedisCommandExecutionException.class);
+    }
+
+    @Test
+    @EnabledOnCommand("INCREX")
+    void increxSatStillAppliesExpiry() {
+        redis.set(key, "5");
+        IncrexArgs args = IncrexArgs.Builder.ubound(5).overflow(IncrexArgs.Overflow.SAT).ex(60);
+        IncrexValue<Long> res = redis.increx(key, 1, args);
+        assertThat(res.getValue()).isEqualTo(5L);
+        assertThat(res.getIncrement()).isEqualTo(0L);
+        assertThat(redis.ttl(key)).isGreaterThan(0);
+    }
+
+    @Test
+    @EnabledOnCommand("INCREX")
+    void increxPersist() {
+        redis.set(key, "5");
+        redis.expire(key, 300);
+        IncrexArgs args = IncrexArgs.Builder.persist();
+        IncrexValue<Long> res = redis.increx(key, 2, args);
+        assertThat(res.getValue()).isEqualTo(7L);
+        assertThat(res.getIncrement()).isEqualTo(2L);
+        assertThat(redis.ttl(key)).isEqualTo(-1);
+    }
+
+    @Test
+    @EnabledOnCommand("INCREX")
+    void increxEnxNoExistingTtl() {
+        redis.set(key, "5");
+        IncrexArgs args = IncrexArgs.Builder.ex(60).enx();
+        IncrexValue<Long> res = redis.increx(key, 1, args);
+        assertThat(res.getValue()).isEqualTo(6L);
+        assertThat(redis.ttl(key)).isGreaterThan(0);
+    }
+
+    @Test
+    @EnabledOnCommand("INCREX")
+    void increxEnxWithExistingTtl() {
+        redis.set(key, "5");
+        redis.expire(key, 300);
+        long ttlBefore = redis.ttl(key);
+        IncrexArgs args = IncrexArgs.Builder.ex(60).enx();
+        redis.increx(key, 1, args);
+        long ttlAfter = redis.ttl(key);
+        assertThat(ttlAfter).isGreaterThan(60);
+    }
+
+    @Test
+    @EnabledOnCommand("INCREX")
+    void increxNonExistentKey() {
+        IncrexArgs args = new IncrexArgs();
+        IncrexValue<Long> res = redis.increx(key, 5, args);
+        assertThat(res.getValue()).isEqualTo(5L);
+        assertThat(res.getIncrement()).isEqualTo(5L);
+    }
+
+    @Test
+    @EnabledOnCommand("INCREX")
+    void increxNonNumericKey() {
+        redis.set(key, "hello");
+        IncrexArgs args = new IncrexArgs();
+        assertThatThrownBy(() -> redis.increx(key, 1, args)).isInstanceOf(RedisCommandExecutionException.class);
+    }
+
+    @Test
+    @EnabledOnCommand("INCREX")
+    void increxFloatSatOverflow() {
+        redis.set(key, "0.0");
+        IncrexArgs args = IncrexArgs.Builder.ubound(5.0).overflow(IncrexArgs.Overflow.SAT);
+        IncrexValue<Double> res = redis.increxfloat(key, 10.0, args);
+        assertThat(res.getValue()).isEqualTo(5.0);
+        assertThat(res.getIncrement()).isEqualTo(5.0);
+    }
+
 }

--- a/src/test/java/io/lettuce/core/commands/StringCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/StringCommandIntegrationTests.java
@@ -681,4 +681,12 @@ public class StringCommandIntegrationTests extends TestSupport {
         assertThat(res.getIncrement()).isEqualTo(5.0);
     }
 
+    @Test
+    @EnabledOnCommand("INCREX")
+    void increxFloatThenIntFails() {
+        redis.set(key, "1.5");
+        IncrexArgs args = new IncrexArgs();
+        assertThatThrownBy(() -> redis.increx(key, 1, args)).isInstanceOf(RedisCommandExecutionException.class);
+    }
+
 }

--- a/src/test/java/io/lettuce/core/commands/StringCommandResp2IntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/StringCommandResp2IntegrationTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2011-Present, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ */
+package io.lettuce.core.commands;
+
+import static io.lettuce.TestTags.INTEGRATION_TEST;
+
+import javax.inject.Inject;
+
+import io.lettuce.core.api.sync.RedisCommands;
+import org.junit.jupiter.api.Tag;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.protocol.ProtocolVersion;
+
+/**
+ * Integration tests for {@link io.lettuce.core.api.sync.RedisStringCommands} using RESP2 protocol.
+ * <p>
+ * Extends {@link StringCommandIntegrationTests} and runs all the same tests using the RESP2 protocol to ensure backward
+ * compatibility and protocol-agnostic behavior.
+ */
+@Tag(INTEGRATION_TEST)
+class StringCommandResp2IntegrationTests extends StringCommandIntegrationTests {
+
+    @Inject
+    public StringCommandResp2IntegrationTests(RedisClient client) {
+        super(connectWithResp2(client));
+    }
+
+    private static RedisCommands<String, String> connectWithResp2(RedisClient client) {
+        client.setOptions(ClientOptions.builder().protocolVersion(ProtocolVersion.RESP2).build());
+        return client.connect().sync();
+    }
+
+}

--- a/src/test/java/io/lettuce/core/output/IncrexOutputUnitTests.java
+++ b/src/test/java/io/lettuce/core/output/IncrexOutputUnitTests.java
@@ -1,0 +1,87 @@
+package io.lettuce.core.output;
+
+import io.lettuce.core.IncrexValue;
+import io.lettuce.core.codec.StringCodec;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import static io.lettuce.TestTags.UNIT_TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag(UNIT_TEST)
+class IncrexOutputUnitTests {
+
+    @Test
+    void longOutputFromBulkStrings() {
+        IncrexLongOutput<String, String> output = new IncrexLongOutput<>(StringCodec.UTF8);
+        output.set(wrap("12"));
+        output.set(wrap("2"));
+
+        IncrexValue<Long> result = output.get();
+        assertThat(result.getValue()).isEqualTo(12L);
+        assertThat(result.getIncrement()).isEqualTo(2L);
+    }
+
+    @Test
+    void longOutputFromIntegers() {
+        IncrexLongOutput<String, String> output = new IncrexLongOutput<>(StringCodec.UTF8);
+        output.set(12L);
+        output.set(2L);
+
+        IncrexValue<Long> result = output.get();
+        assertThat(result.getValue()).isEqualTo(12L);
+        assertThat(result.getIncrement()).isEqualTo(2L);
+    }
+
+    @Test
+    void doubleOutputFromBulkStrings() {
+        IncrexDoubleOutput<String, String> output = new IncrexDoubleOutput<>(StringCodec.UTF8);
+        output.set(wrap("4.5"));
+        output.set(wrap("1.25"));
+
+        IncrexValue<Double> result = output.get();
+        assertThat(result.getValue()).isEqualTo(4.5);
+        assertThat(result.getIncrement()).isEqualTo(1.25);
+    }
+
+    @Test
+    void doubleOutputFromDoubles() {
+        IncrexDoubleOutput<String, String> output = new IncrexDoubleOutput<>(StringCodec.UTF8);
+        output.set(4.5);
+        output.set(1.25);
+
+        IncrexValue<Double> result = output.get();
+        assertThat(result.getValue()).isEqualTo(4.5);
+        assertThat(result.getIncrement()).isEqualTo(1.25);
+    }
+
+    @Test
+    void longOutputNegativeIncrement() {
+        IncrexLongOutput<String, String> output = new IncrexLongOutput<>(StringCodec.UTF8);
+        output.set(wrap("7"));
+        output.set(wrap("-3"));
+
+        IncrexValue<Long> result = output.get();
+        assertThat(result.getValue()).isEqualTo(7L);
+        assertThat(result.getIncrement()).isEqualTo(-3L);
+    }
+
+    @Test
+    void doubleOutputZeroIncrement() {
+        IncrexDoubleOutput<String, String> output = new IncrexDoubleOutput<>(StringCodec.UTF8);
+        output.set(wrap("5.0"));
+        output.set(wrap("0"));
+
+        IncrexValue<Double> result = output.get();
+        assertThat(result.getValue()).isEqualTo(5.0);
+        assertThat(result.getIncrement()).isEqualTo(0.0);
+    }
+
+    private static ByteBuffer wrap(String s) {
+        return ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8));
+    }
+
+}


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Redis command (`INCREX`) across sync/async/reactive/coroutines APIs with new argument builders and custom response parsing, which could affect command encoding/decoding and compatibility with older servers.
> 
> **Overview**
> Adds first-class support for the Redis `INCREX` command across the Lettuce string command APIs (sync/async/reactive, cluster node selection, and Kotlin coroutines), including overloads for default increment and typed `BYINT`/`BYFLOAT` variants.
> 
> Introduces `IncrexArgs`/`IncrexFloatArgs` (with shared `BaseIncrexArgs`) to encode bounds (`LBOUND`/`UBOUND`), `SATURATE`, and expiration options (`EX`/`PX`/`EXAT`/`PXAT`/`PERSIST`/`ENX`), plus a new `IncrexValue<T>` result type parsed via `IncrexLongOutput`/`IncrexDoubleOutput`. Updates protocol enums (`CommandType.INCREX`, new `CommandKeyword`s) and adds unit/integration coverage, including RESP2 integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1eca2c893511771ba4dfdf20da152535ca85b86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->