### PR TITLE
ci(integration): cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,6 +25,9 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and Test (Redis ${{ matrix.redis_version }})


### PR DESCRIPTION
The `integration` workflow runs the integration test suite. No GitHub API writes from the workflow, so a workflow-level `contents: read` is the right cap for the default `GITHUB_TOKEN`.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI permissions block with no application or runtime behavior changes.
> 
> **Overview**
> The **integration** workflow now declares workflow-level **`permissions`** with **`contents: read`**, capping the default **`GITHUB_TOKEN`** instead of inheriting broader repo defaults.
> 
> This matches the same least-privilege hardening used elsewhere after **`tj-actions/changed-files`**-related supply-chain concerns; the job only needs to read the repo to run tests, not write via the token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f96ee042c515b08e0c0cc80020f0f9f434ce2bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->