### PR TITLE
Recreate inactive write connections in PooledClusterConnectionProvider #2930

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/PooledClusterConnectionProvider.java
+++ b/src/main/java/io/lettuce/core/cluster/PooledClusterConnectionProvider.java
@@ -66,6 +66,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
  * @param <V> Value type.
  * @author Mark Paluch
  * @author Tihomir Mateev
+ * @author PreAgile
  * @since 3.0
  */
 @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -183,7 +184,23 @@ class PooledClusterConnectionProvider<K, V>
 
         CompletableFuture<StatefulRedisConnection<K, V>> writer = writers[slot];
         if (writer != null) {
-            return writer;
+
+            // In-flight future: trust the in-progress connection attempt instead of preempting it.
+            if (!writer.isDone()) {
+                return writer;
+            }
+
+            // writers[slot] is only populated with CompletableFuture.completedFuture(connection) below,
+            // so a completed slot always carries a non-failed future. Skip getNow if it ever failed
+            // exceptionally to keep this defensive.
+            if (!writer.isCompletedExceptionally()) {
+                StatefulRedisConnection<K, V> cached = writer.getNow(null);
+                if (cached != null && cached.isOpen()) {
+                    return writer;
+                }
+
+                evictInactiveWriter(slot, writer, cached);
+            }
         }
 
         RedisClusterNode master = partitions.getMasterBySlot(slot);
@@ -213,6 +230,54 @@ class PooledClusterConnectionProvider<K, V>
 
             return connection;
         }).toCompletableFuture();
+    }
+
+    /**
+     * Evict an inactive cached writer from both the {@code writers[slot]} fast cache and the underlying
+     * {@link AsyncConnectionProvider} cache so the next call materializes a fresh physical connection.
+     * <p>
+     * The {@code writers[slot] == expected} reference check serializes concurrent stale detections: only the thread that
+     * observed the same future evicts the slot. The provider cache entry holding the inactive connection is located by identity
+     * match against the {@link AsyncConnectionProvider} iteration, so a topology change (failover) that has already replaced
+     * the {@link ConnectionKey} mapping cannot lead to closing the wrong connection.
+     *
+     * @param slot the slot whose cached writer turned out to be inactive.
+     * @param expected the writer future captured before the inactivity check.
+     * @param staleConnection the inactive connection retrieved from the writer, may be {@code null}.
+     */
+    private void evictInactiveWriter(int slot, CompletableFuture<StatefulRedisConnection<K, V>> expected,
+            StatefulRedisConnection<K, V> staleConnection) {
+
+        boolean evicted;
+        stateLock.lock();
+        try {
+            evicted = writers[slot] == expected;
+            if (evicted) {
+                writers[slot] = null;
+            }
+        } finally {
+            stateLock.unlock();
+        }
+
+        if (!evicted || staleConnection == null) {
+            return;
+        }
+
+        // Locate the provider cache entry by identity match. The forEach lambda runs synchronously for completed Sync
+        // entries (Sync.doWithConnection inlines the consumer when PHASE_COMPLETE), and an inactive connection is always
+        // already-completed - so the holder is populated by the time forEach returns. In-progress entries cannot match
+        // by identity because no connection instance is bound to them yet.
+        final ConnectionKey[] staleKeyHolder = new ConnectionKey[1];
+        connectionProvider.forEach((cacheKey, connection) -> {
+            if (connection == staleConnection && staleKeyHolder[0] == null) {
+                staleKeyHolder[0] = cacheKey;
+            }
+        });
+
+        ConnectionKey staleKey = staleKeyHolder[0];
+        if (staleKey != null) {
+            connectionProvider.close(staleKey);
+        }
     }
 
     private CompletableFuture<StatefulRedisConnection<K, V>> getReadConnection(int slot) {

--- a/src/test/java/io/lettuce/core/cluster/PooledClusterConnectionProviderUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/PooledClusterConnectionProviderUnitTests.java
@@ -66,6 +66,7 @@ import io.lettuce.core.resource.ClientResources;
  * Unit tests for {@link PooledClusterConnectionProvider}.
  *
  * @author Mark Paluch
+ * @author PreAgile
  */
 @Tag(UNIT_TEST)
 @ExtendWith(MockitoExtension.class)
@@ -459,6 +460,46 @@ class PooledClusterConnectionProviderUnitTests {
 
         assertThat(future).isCompletedExceptionally();
         verify(clusterEventListener).onUncoveredSlot(anyInt());
+    }
+
+    @Test
+    void shouldRecreateInactiveWriteConnection() {
+
+        StatefulRedisConnection<String, String> staleConnection = mock(StatefulRedisConnection.class);
+        StatefulRedisConnection<String, String> freshConnection = mock(StatefulRedisConnection.class);
+
+        when(staleConnection.isOpen()).thenReturn(false);
+        when(staleConnection.closeAsync()).thenReturn(CompletableFuture.completedFuture(null));
+        when(freshConnection.isOpen()).thenReturn(true);
+
+        when(clientMock.connectToNodeAsync(eq(StringCodec.UTF8), eq("localhost:1"), any(), any())).thenReturn(
+                ConnectionFuture.from(socketAddressMock, CompletableFuture.completedFuture(staleConnection)),
+                ConnectionFuture.from(socketAddressMock, CompletableFuture.completedFuture(freshConnection)));
+
+        StatefulRedisConnection<String, String> first = sut.getConnection(ConnectionIntent.WRITE, 1);
+        assertThat(first).isSameAs(staleConnection);
+
+        StatefulRedisConnection<String, String> second = sut.getConnection(ConnectionIntent.WRITE, 1);
+
+        assertThat(second).isSameAs(freshConnection);
+        verify(staleConnection).closeAsync();
+        verify(clientMock, times(2)).connectToNodeAsync(eq(StringCodec.UTF8), eq("localhost:1"), any(), any());
+    }
+
+    @Test
+    void shouldReuseOpenWriteConnection() {
+
+        when(channelHandlerMock.isOpen()).thenReturn(true);
+
+        when(clientMock.connectToNodeAsync(eq(StringCodec.UTF8), eq("localhost:1"), any(), any()))
+                .thenReturn(ConnectionFuture.from(socketAddressMock, CompletableFuture.completedFuture(nodeConnectionMock)));
+
+        StatefulRedisConnection<String, String> first = sut.getConnection(ConnectionIntent.WRITE, 1);
+        StatefulRedisConnection<String, String> second = sut.getConnection(ConnectionIntent.WRITE, 1);
+
+        assertThat(first).isSameAs(nodeConnectionMock);
+        assertThat(second).isSameAs(nodeConnectionMock);
+        verify(clientMock).connectToNodeAsync(eq(StringCodec.UTF8), eq("localhost:1"), any(), any());
     }
 
 }


### PR DESCRIPTION
`PooledClusterConnectionProvider.getWriteConnection` returns the cached writer for a slot without checking whether the underlying channel is still open. After a master connection turns inactive - failover, network blip, server restart - the `CompletableFuture` cached in `writers[slot]` still points at a closed `StatefulRedisConnection`, and every subsequent write throws `RedisException("Currently not connected. Commands are rejected")` until the next topology refresh wipes the slot. The reporter saw this in production with `rejectCommandsWhenInactive = true` and confirmed it survives until the slot is reset by a topology change.

Just clearing `writers[slot]` is not enough: `AsyncConnectionProvider.connections` still holds the same `Sync` for the `ConnectionKey`, so the next call resurrects the same stale connection. The fix has to evict both caches together.

This mirrors the read-path recovery introduced by #503 for `getReadConnection`: a non-blocking `isOpen` check on the cached writer, plus an eviction step when the channel is closed. All checks use `isDone` / `getNow(null)` / `isOpen` so there is no `.join()` / `.block()` anywhere on the dispatch path.

## How

In `getWriteConnection`:

- If the cached writer is still in-flight (`isDone() == false`), return it as-is so concurrent callers do not preempt an ongoing connection attempt.
- If it is completed and the connection reports `isOpen()`, return it (hot path, unchanged behaviour).
- Otherwise call the new `evictInactiveWriter` helper before falling through to materialize a new connection.

`evictInactiveWriter`:

1. Under `stateLock`, reset `writers[slot]` only when it still references the future we observed (`writers[slot] == expected`). The thread that wins this check is the one responsible for closing the stale connection; other threads see a fresh writer slotted in by the winner and back off.
2. Locate the corresponding `ConnectionKey` by identity match through `AsyncConnectionProvider.forEach((key, conn) -> ...)`. The closed connection is by definition already in `PHASE_COMPLETE`, so `Sync.doWithConnection` runs the consumer inline during the iteration and the holder is populated before `forEach` returns. Identity match (`conn == staleConnection`) means a topology change that has already remapped the slot to a different master cannot lead to closing the fresh connection.
3. Call the existing `AsyncConnectionProvider.close(K)` which removes the entry from the map and triggers `closeAsync` on the connection - no blocking close.

## Tests

Two unit tests in `PooledClusterConnectionProviderUnitTests`:

- `shouldRecreateInactiveWriteConnection` - first `getConnection(WRITE, slot)` caches a connection whose `isOpen()` later returns `false`; the second call must obtain a fresh connection from `clientMock.connectToNodeAsync` (verified `times(2)`) and `closeAsync` must be called on the stale one.
- `shouldReuseOpenWriteConnection` - regression guard that a healthy cached writer still serves repeated calls from the fast cache with only one `connectToNodeAsync` invocation.

`mvn -Dtest='io.lettuce.core.cluster.*UnitTests' test` is green (181 tests, 0 failures) including the existing read-path coverage from #503.

Closes #2930

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster connection pooling on the write hot path; logic is defensive and mirrors read-path recovery, but incorrect eviction could affect live connections under concurrency or failover.
> 
> **Overview**
> **Cluster write connections** no longer stay pinned to a closed channel after failover or a network blip. `getWriteConnection` now treats an in-flight cached future as authoritative, returns a completed cache only when `isOpen()` is true, and otherwise evicts the stale entry before opening a new one.
> 
> The new **`evictInactiveWriter`** path clears both the per-slot `writers[slot]` fast cache (only if the future still matches what the caller saw) and the matching entry in **`AsyncConnectionProvider`**, located by connection identity so a topology remap cannot close the wrong socket. Checks use non-blocking `isDone` / `getNow` / `isOpen` on the dispatch path, aligned with the existing read-side inactive handling.
> 
> Unit tests cover **recreating** an inactive write connection (second connect + `closeAsync` on stale) and **reusing** a healthy cached writer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 696fe14dcbdae435ffce02fb98f6e873ad2b749a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->