### PR TITLE
Release 7.6.0

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,38 +1,57 @@
-Lettuce 7.5.0 RELEASE NOTES
+Lettuce 7.6.0 RELEASE NOTES
 ==============================
-The Lettuce team is pleased to announce the Lettuce **7.5.0** minor release!
+The Lettuce team is pleased to announce the Lettuce **7.6.0** minor release!
 
-Lettuce 7.5.0 supports Redis 2.6+ up to Redis 8.x. In terms of Java runtime, Lettuce requires at least Java 8 and
-works with Java 24. The driver is tested against Redis 8.6, Redis 8.4, Redis 8.2, Redis 8.0, Redis 7.4 and Redis 7.2.
+✨ Highlights
+---
+Lettuce 7.6.0 introduces support for the new features from [Redis OSS 8.8 release](https://github.com/redis/redis/releases/tag/8.8.0), such as:
+- the new Array data structure
+- INCREX: a window counter rate limiter combining INCR, INCRBY, INCRBYFLOAT, bounds, and expiration
+- XNACK: a new streams command - allow consumers to explicitly release pending messages
+- ZUNION, ZINTER, ZUNIONSTORE, ZINTERSTORE: new COUNT aggregator
+- JSON.SET: new FPHA argument to specify the FP type for homogeneous FP arrays
+---
 
-Thanks to all contributors who made Lettuce 7.5.0.RELEASE possible.
+Lettuce 7.6.0 supports Redis 2.6+ up to Redis 8.x. In terms of Java runtime, Lettuce requires at least Java 8 and
+works with Java 24. The driver is tested against Redis 8.8, Redis 8.6, Redis 8.4, Redis 8.2, Redis 8.0, Redis 7.4 and Redis 7.2.
+
+Thanks to all contributors who made Lettuce 7.6.0.RELEASE possible.
 
 📗 Links
-Reference documentation: https://lettuce.io/core/7.5.0.RELEASE
+Reference documentation: https://lettuce.io/core/7.6.0.RELEASE
 
 ⭐ New Features
-* Hybrid refactor by @a-TODO-rov in https://github.com/redis/lettuce/pull/3667
-* Enable keepalive by default by @a-TODO-rov in https://github.com/redis/lettuce/pull/3669
-* [automatic failover] Add Dynamic Weight Management for Redis Multi-Database Connections by @atakavci in https://github.com/redis/lettuce/pull/3672
+* Add arrays API by @a-TODO-rov in https://github.com/redis/lettuce/pull/3745
+* Introduce INCREX command by @a-TODO-rov in https://github.com/redis/lettuce/pull/3746
+* Redis 8.8: Add XNACK support by @uglide in https://github.com/redis/lettuce/pull/3728
+* Support COUNT aggregator for ZINTER, ZINTERSTORE, ZUNION and ZUNIONSTORE (Redis 8.8) by @atakavci in https://github.com/redis/lettuce/pull/3736
+* Add support for FPHA argument with JSON.SET (Redis 8.8)#4478 by @atakavci in https://github.com/redis/lettuce/pull/3710
+* Add missing Search languages by @viktoriya-kutsarova in https://github.com/redis/lettuce/pull/3690
 
 🐞 Bug Fixes
-* fix memory leak issue on thread local in sharedLock - PR for main branch by @kandogu in https://github.com/redis/lettuce/pull/3640
-* HOTKEYS fixes by @a-TODO-rov in https://github.com/redis/lettuce/pull/3665
-* Fix borrowObject timeout wrapping by @JiHongKim98 in https://github.com/redis/lettuce/pull/3666
-* Fix memory corruption/JVM crash in RediSearch by copying pooled ByteBuffers by @YoHanKi in https://github.com/redis/lettuce/pull/3664
+* ERR unknown subcommand 'MYID' with Azure Managed Redis #3495 by @tishun in https://github.com/redis/lettuce/pull/3693
+* Fix links in README for Streaming API and Native Transports by @a-TODO-rov in https://github.com/redis/lettuce/pull/3707
+* Fix JSON.ARRAPPEND root path encoding by @Dgramada in https://github.com/redis/lettuce/pull/3715
+* Fix benchmark tests by @atakavci in https://github.com/redis/lettuce/pull/3735
+* Fix imports in benchmarks client by @atakavci in https://github.com/redis/lettuce/pull/3737
+* Improve CI pipeline stability in https://github.com/redis/lettuce/pull/3740 , https://github.com/redis/lettuce/pull/3724 by @atakavci , https://github.com/redis/lettuce/pull/3725 by @tishun , https://github.com/redis/lettuce/pull/3720 by @viktoriya-kutsarova
+
+⚙️ Maintenance
+* ci(integration): cap `GITHUB_TOKEN` to `contents: read` by @arpitjain099 in https://github.com/redis/lettuce/pull/3761
+* ci: declare workflow-level `contents: read` on 3 workflows by @arpitjain099 in https://github.com/redis/lettuce/pull/3748
+* Bump Netty 4.2.12.Final by @atakavci in https://github.com/redis/lettuce/pull/3723
+* Bump Netty 4.2.13.Final by @atakavci in https://github.com/redis/lettuce/pull/3751
 
 💡 Other
-* update imports in failover docs by @ggivo in https://github.com/redis/lettuce/pull/3658
-* Bump org.assertj:assertj-core from 3.25.3 to 3.27.7 in the maven group across 1 directory by @dependabot[bot] in https://github.com/redis/lettuce/pull/3629
-* AA scenario tests by @kiryazovi-redis in https://github.com/redis/lettuce/pull/3659
-* Bump org.apache.maven.plugins:maven-gpg-plugin from 3.1.0 to 3.2.8 by @dependabot[bot] in https://github.com/redis/lettuce/pull/3668
-* Improvements to the Lettuce guide (Advanced usage section) by @tishun in https://github.com/redis/lettuce/pull/3674
-* [automatic failover] Docs for dynamic weight management by @atakavci in https://github.com/redis/lettuce/pull/3678
+* Add 8.8 to test matrix by @a-TODO-rov in https://github.com/redis/lettuce/pull/3764
+* Add tests for client auth by @a-TODO-rov in https://github.com/redis/lettuce/pull/3685
+* Introduce reusable workflows by @a-TODO-rov in https://github.com/redis/lettuce/pull/3673
+* Optimize single-node master/replica reads by @Sean-Kenneth-Doherty in https://github.com/redis/lettuce/pull/3758
+* Add subkeyspace notifications integration tests by @a-TODO-rov in https://github.com/redis/lettuce/pull/3734
 
-❤️ New Contributors
-* @kandogu made their first contribution in https://github.com/redis/lettuce/pull/3640
-* @JiHongKim98 made their first contribution in https://github.com/redis/lettuce/pull/3666
-* @YoHanKi made their first contribution in https://github.com/redis/lettuce/pull/3664
-  Welcome to the Lettuce family!
+❤️ New Contributors - Welcome to the Lettuce family!
+* @Dgramada made their first contribution in https://github.com/redis/lettuce/pull/3715
+* @Sean-Kenneth-Doherty made their first contribution in https://github.com/redis/lettuce/pull/3758
+* @arpitjain099 made their first contribution in https://github.com/redis/lettuce/pull/3761
 
-**Full Changelog**: https://github.com/redis/lettuce/compare/7.4.0.RELEASE...7.5.0.RELEASE
+**Full Changelog**: https://github.com/redis/lettuce/compare/7.5.0.RELEASE...7.6.0.RELEASE

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>io.lettuce</groupId>
     <artifactId>lettuce-core</artifactId>
-    <version>7.6.0-SNAPSHOT</version>
+    <version>7.7.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Lettuce</name>


### PR DESCRIPTION
as part of #3766 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version metadata only; no driver or API code changes in this diff.
> 
> **Overview**
> Prepares the **7.6.0** release by replacing the **7.5.0** content in `RELEASE-NOTES.md` with **7.6.0** notes: Redis **8.8** highlights, updated compatibility/testing matrix, doc link, and reorganized feature/fix/maintenance/other sections with a new changelog range **7.5.0.RELEASE…7.6.0.RELEASE**.
> 
> Bumps the Maven project version in `pom.xml` from **7.6.0-SNAPSHOT** to **7.7.0-SNAPSHOT** so development continues on the next minor line after the release cut.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3545cca705a372fa75db4597c9e87e3c9e04e380. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->