### PR TITLE
Add option to skip unit tests in reusable workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -55,5 +55,5 @@ jobs:
     uses: ./.github/workflows/run-tests.yml
     with:
       client_libs_test_image_tag: ${{ github.event.inputs.client_libs_test_image_tag }}
-    secrets:
-      codecov_token: ${{ secrets.CODECOV_TOKEN }}
+      skip_unit_tests: true
+      upload_coverage: false

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,6 +51,11 @@ on:
         required: false
         type: boolean
         default: true
+      skip_unit_tests:
+        description: 'Skip unit tests and run only integration tests'
+        required: false
+        type: boolean
+        default: false
     secrets:
       codecov_token:
         description: 'Codecov token for uploading coverage'
@@ -128,7 +133,12 @@ jobs:
       - name: Run tests
         run: |
           export TEST_WORK_FOLDER=$REDIS_ENV_WORK_DIR
-          make test-coverage
+          if [ "${{ inputs.skip_unit_tests }}" = "true" ]; then
+            echo "Skipping unit tests, running integration tests only"
+            make test MVN_EXTRA_ARGS="-DskipUnitTests=true"
+          else
+            make test-coverage
+          fi
         env:
           REDIS_ENV_WORK_DIR: ${{ steps.args.outputs.redis_env_work_dir }}
           JVM_OPTS: -Xmx3200m

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ SUPPORTED_TEST_ENV_VERSIONS := 8.8 8.6 8.4 8.2 8.0 7.4 7.2
 DEFAULT_TEST_ENV_VERSION := 8.8
 export REDIS_ENV_WORK_DIR := $(or ${REDIS_ENV_WORK_DIR},$(ROOT_DIR)/work)
 MVN_SOCKET_ARGS := -Ddomainsocket="$(REDIS_ENV_WORK_DIR)/socket-6482" -Dsentineldomainsocket="$(REDIS_ENV_WORK_DIR)/socket-26379"
+MVN_EXTRA_ARGS ?=
 
 define COMPOSE_ENV
 	if [ -z "$(version)" ]; then \
@@ -43,10 +44,10 @@ start:
 	echo "Started test environment with Redis $$display_version.";
 
 test:
-	TEST_WORK_FOLDER=$(REDIS_ENV_WORK_DIR) mvn -DskipITs=false $(MVN_SOCKET_ARGS) clean compile verify -P$(PROFILE)
+	TEST_WORK_FOLDER=$(REDIS_ENV_WORK_DIR) mvn -DskipITs=false $(MVN_SOCKET_ARGS) $(MVN_EXTRA_ARGS) clean compile verify -P$(PROFILE)
 
 test-coverage:
-	TEST_WORK_FOLDER=$(REDIS_ENV_WORK_DIR) mvn -DskipITs=false $(MVN_SOCKET_ARGS) clean compile verify jacoco:report -P$(PROFILE)
+	TEST_WORK_FOLDER=$(REDIS_ENV_WORK_DIR) mvn -DskipITs=false $(MVN_SOCKET_ARGS) $(MVN_EXTRA_ARGS) clean compile verify jacoco:report -P$(PROFILE)
 
 stop:
 	@$(COMPOSE_ENV) \

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- You need a running redis+sentinel for all tests, therefore disabled by default -->
         <skipITs>true</skipITs>
+        <!-- Inherits from skipTests for backward compatibility, can be overridden with -DskipUnitTests=true -->
+        <skipUnitTests>${skipTests}</skipUnitTests>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
 
     </properties>
@@ -906,6 +908,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <skipTests>${skipUnitTests}</skipTests>
                     <systemPropertyVariables>
                         <io.netty.eventLoopThreads>4</io.netty.eventLoopThreads>
                     </systemPropertyVariables>

--- a/src/test/java/io/lettuce/core/TestSupport.java
+++ b/src/test/java/io/lettuce/core/TestSupport.java
@@ -19,12 +19,16 @@
  */
 package io.lettuce.core;
 
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
 import io.lettuce.core.internal.LettuceSets;
 import io.lettuce.test.settings.TestSettings;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 
 /**
  * @author Mark Paluch
@@ -44,7 +48,7 @@ public abstract class TestSupport {
 
     public static final CharSequence aclPasswd = TestSettings.aclPassword();
 
-    public static final String key = "key";
+    public String key = "key";
 
     public static final String value = "value";
 
@@ -74,6 +78,11 @@ public abstract class TestSupport {
 
     protected static Set<String> set(String... args) {
         return LettuceSets.newHashSet(args);
+    }
+
+    @BeforeEach
+    void changeKey(TestInfo testInfo) {
+        this.key = "key-" + testInfo.getTestMethod().map(Method::getName).orElse("unknown");
     }
 
 }

--- a/src/test/java/io/lettuce/core/cluster/AdvancedClusterReactiveIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/AdvancedClusterReactiveIntegrationTests.java
@@ -400,23 +400,25 @@ class AdvancedClusterReactiveIntegrationTests extends TestSupport {
 
     @Test
     void readFromReplicas() {
+        // Use KEY_A which is known to hash to a slot owned by port4's master
+        String testKey = ClusterTestSettings.KEY_A;
 
         RedisClusterReactiveCommands<String, String> connection = commands.getConnection(ClusterTestSettings.host,
                 ClusterTestSettings.port4);
         connection.readOnly().subscribe();
-        commands.set(key, value).subscribe();
+        commands.set(testKey, value).subscribe();
 
-        NodeSelectionAsyncIntegrationTests.waitForReplication(commands.getStatefulConnection().async(), ClusterTestSettings.key,
+        NodeSelectionAsyncIntegrationTests.waitForReplication(commands.getStatefulConnection().async(), testKey,
                 ClusterTestSettings.port4);
 
         AtomicBoolean error = new AtomicBoolean();
-        connection.get(key).doOnError(throwable -> error.set(true)).block();
+        connection.get(testKey).doOnError(throwable -> error.set(true)).block();
 
         assertThat(error.get()).isFalse();
 
         connection.readWrite().subscribe();
 
-        StepVerifier.create(connection.get(key)).expectError(RedisCommandExecutionException.class).verify();
+        StepVerifier.create(connection.get(testKey)).expectError(RedisCommandExecutionException.class).verify();
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/cluster/NodeSelectionAsyncIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/NodeSelectionAsyncIntegrationTests.java
@@ -231,18 +231,20 @@ class NodeSelectionAsyncIntegrationTests extends TestSupport {
 
     @Test
     void testReplicaReadWrite() {
+        // Use KEY_A which is known to hash to a slot owned by port4's master
+        String testKey = ClusterTestSettings.KEY_A;
 
         AsyncNodeSelection<String, String> nodes = commands
                 .nodes(redisClusterNode -> redisClusterNode.getFlags().contains(RedisClusterNode.NodeFlag.REPLICA));
 
         assertThat(nodes.size()).isEqualTo(2);
 
-        TestFutures.awaitOrTimeout(commands.set(key, value));
+        TestFutures.awaitOrTimeout(commands.set(testKey, value));
 
-        waitForReplication(key, ClusterTestSettings.port4);
+        waitForReplication(testKey, ClusterTestSettings.port4);
 
         List<Throwable> t = new ArrayList<>();
-        AsyncExecutions<String> keys = nodes.commands().get(key);
+        AsyncExecutions<String> keys = nodes.commands().get(testKey);
         keys.stream().forEach(lcs -> {
             lcs.toCompletableFuture().exceptionally(throwable -> {
                 t.add(throwable);
@@ -257,18 +259,20 @@ class NodeSelectionAsyncIntegrationTests extends TestSupport {
 
     @Test
     void testReplicasWithReadOnly() {
+        // Use KEY_A which is known to hash to a slot owned by port4's master
+        String testKey = ClusterTestSettings.KEY_A;
 
         AsyncNodeSelection<String, String> nodes = commands
                 .replicas(redisClusterNode -> redisClusterNode.is(RedisClusterNode.NodeFlag.REPLICA));
 
         assertThat(nodes.size()).isEqualTo(2);
 
-        TestFutures.awaitOrTimeout(commands.set(key, value));
-        waitForReplication(key, ClusterTestSettings.port4);
+        TestFutures.awaitOrTimeout(commands.set(testKey, value));
+        waitForReplication(testKey, ClusterTestSettings.port4);
 
         List<Throwable> t = new ArrayList<>();
         List<String> strings = new ArrayList<>();
-        AsyncExecutions<String> keys = nodes.commands().get(key);
+        AsyncExecutions<String> keys = nodes.commands().get(testKey);
         keys.stream().forEach(lcs -> {
             lcs.toCompletableFuture().exceptionally(throwable -> {
                 t.add(throwable);

--- a/src/test/java/io/lettuce/core/cluster/NodeSelectionSyncIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/NodeSelectionSyncIntegrationTests.java
@@ -182,8 +182,10 @@ class NodeSelectionSyncIntegrationTests extends TestSupport {
 
     @Test
     void testReplicasWithReadOnly() {
+        // Use KEY_A which is known to hash to a slot owned by port4's master
+        String testKey = ClusterTestSettings.KEY_A;
 
-        int slot = SlotHash.getSlot(key);
+        int slot = SlotHash.getSlot(testKey);
         Optional<RedisClusterNode> master = clusterClient.getPartitions().getPartitions().stream()
                 .filter(redisClusterNode -> redisClusterNode.hasSlot(slot)).findFirst();
 
@@ -193,10 +195,10 @@ class NodeSelectionSyncIntegrationTests extends TestSupport {
 
         assertThat(nodes.size()).isEqualTo(1);
 
-        commands.set(key, value);
-        waitForReplication(key, ClusterTestSettings.port4);
+        commands.set(testKey, value);
+        waitForReplication(testKey, ClusterTestSettings.port4);
 
-        Executions<String> keys = nodes.commands().get(key);
+        Executions<String> keys = nodes.commands().get(testKey);
         assertThat(keys).hasSize(1).contains(value);
     }
 

--- a/src/test/java/io/lettuce/core/commands/GeoCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/GeoCommandIntegrationTests.java
@@ -337,7 +337,7 @@ public class GeoCommandIntegrationTests extends TestSupport {
 
         prepareGeo();
 
-        String resultKey = "38o54"; // yields in same slot as "key"
+        String resultKey = "{" + key + "}:result"; // same hash slot as key due to hash tag
         Long result = redis.georadius(key, 8.665351, 49.553302, 5, GeoArgs.Unit.km,
                 new GeoRadiusStoreArgs<>().withStore(resultKey));
         assertThat(result).isEqualTo(2);
@@ -351,7 +351,7 @@ public class GeoCommandIntegrationTests extends TestSupport {
 
         prepareGeo();
 
-        String resultKey = "38o54"; // yields in same slot as "key"
+        String resultKey = "{" + key + "}:result"; // same hash slot as key due to hash tag
         Long result = redis.georadius(key, 8.665351, 49.553302, 5, GeoArgs.Unit.km,
                 new GeoRadiusStoreArgs<>().withCount(1).desc().withStore(resultKey));
         assertThat(result).isEqualTo(1);
@@ -366,9 +366,9 @@ public class GeoCommandIntegrationTests extends TestSupport {
 
         prepareGeo();
 
-        String resultKey = "38o54"; // yields in same slot as "key"
+        String resultKey = "{" + key + "}:result"; // same hash slot as key due to hash tag
         Long result = redis.georadius(key, 8.665351, 49.553302, 5, GeoArgs.Unit.km,
-                new GeoRadiusStoreArgs<>().withStoreDist("38o54"));
+                new GeoRadiusStoreArgs<>().withStoreDist(resultKey));
         assertThat(result).isEqualTo(2);
 
         List<ScoredValue<String>> dist = redis.zrangeWithScores(resultKey, 0, -1);
@@ -380,9 +380,9 @@ public class GeoCommandIntegrationTests extends TestSupport {
 
         prepareGeo();
 
-        String resultKey = "38o54"; // yields in same slot as "key"
+        String resultKey = "{" + key + "}:result"; // same hash slot as key due to hash tag
         Long result = redis.georadius(key, 8.665351, 49.553302, 5, GeoArgs.Unit.km,
-                new GeoRadiusStoreArgs<>().withCount(1).desc().withStoreDist("38o54"));
+                new GeoRadiusStoreArgs<>().withCount(1).desc().withStoreDist(resultKey));
         assertThat(result).isEqualTo(1);
 
         List<ScoredValue<String>> dist = redis.zrangeWithScores(resultKey, 0, -1);
@@ -421,9 +421,9 @@ public class GeoCommandIntegrationTests extends TestSupport {
 
         prepareGeo();
 
-        String resultKey = "38o54"; // yields in same slot as "key"
+        String resultKey = "{" + key + "}:result"; // same hash slot as key due to hash tag
         Long result = redis.georadiusbymember(key, "Bahn", 5, GeoArgs.Unit.km,
-                new GeoRadiusStoreArgs<>().withCount(1).desc().withStoreDist("38o54"));
+                new GeoRadiusStoreArgs<>().withCount(1).desc().withStoreDist(resultKey));
         assertThat(result).isEqualTo(1);
 
         List<ScoredValue<String>> dist = redis.zrangeWithScores(resultKey, 0, -1);
@@ -572,7 +572,7 @@ public class GeoCommandIntegrationTests extends TestSupport {
 
         prepareGeo();
 
-        String resultKey = "38o54"; // yields in same slot as "key"
+        String resultKey = "{" + key + "}:result"; // same hash slot as key due to hash tag
         Long result = redis.geosearchstore(resultKey, key, GeoSearch.fromMember("Bahn"), GeoSearch.byRadius(5, GeoArgs.Unit.km),
                 new GeoArgs(), true);
         assertThat(result).isEqualTo(2);

--- a/src/test/java/io/lettuce/core/commands/HashCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/HashCommandIntegrationTests.java
@@ -665,7 +665,7 @@ public class HashCommandIntegrationTests extends TestSupport {
         Map<String, String> expect = new LinkedHashMap<>();
         setup100KeyValues(expect);
 
-        MapScanCursor<String, String> cursor = redis.hscan(key, ScanArgs.Builder.limit(100).match("key1*"));
+        MapScanCursor<String, String> cursor = redis.hscan(key, ScanArgs.Builder.limit(100).match(key + "1*"));
 
         assertThat(cursor.getCursor()).isEqualTo("0");
         assertThat(cursor.isFinished()).isTrue();
@@ -681,7 +681,7 @@ public class HashCommandIntegrationTests extends TestSupport {
         Map<String, String> expect = new LinkedHashMap<>();
         setup100KeyValues(expect);
 
-        KeyScanCursor<String> cursor = redis.hscanNovalues(key, ScanArgs.Builder.limit(100).match("key1*"));
+        KeyScanCursor<String> cursor = redis.hscanNovalues(key, ScanArgs.Builder.limit(100).match(key + "1*"));
 
         assertThat(cursor.getCursor()).isEqualTo("0");
         assertThat(cursor.isFinished()).isTrue();

--- a/src/test/java/io/lettuce/core/commands/KeyCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/KeyCommandIntegrationTests.java
@@ -603,7 +603,7 @@ public class KeyCommandIntegrationTests extends TestSupport {
         Set<String> expect = new HashSet<>();
         setup100KeyValues(expect);
 
-        KeyScanCursor<String> cursor = redis.scan(KeyScanArgs.Builder.limit(200).match("key1*"));
+        KeyScanCursor<String> cursor = redis.scan(KeyScanArgs.Builder.limit(200).match(key + "1*"));
 
         assertThat(cursor.getCursor()).isEqualTo("0");
         assertThat(cursor.isFinished()).isTrue();

--- a/src/test/java/io/lettuce/core/commands/ListCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/ListCommandIntegrationTests.java
@@ -349,8 +349,8 @@ public class ListCommandIntegrationTests extends TestSupport {
     @Test
     @EnabledOnCommand("LMOVE") // Redis 6.2
     void lmove() {
-        String list1 = key;
-        String list2 = "38o54"; // yields in same slot as "key"
+        String list1 = "{" + key + "}:1";
+        String list2 = "{" + key + "}:2"; // same hash slot as list1 due to hash tag
 
         redis.rpush(list1, "one", "two", "three");
         redis.lmove(list1, list2, LMoveArgs.Builder.rightLeft());
@@ -362,8 +362,8 @@ public class ListCommandIntegrationTests extends TestSupport {
     @Test
     @EnabledOnCommand("BLMOVE") // Redis 6.2
     void blmove() {
-        String list1 = key;
-        String list2 = "38o54"; // yields in same slot as "key"
+        String list1 = "{" + key + "}:1";
+        String list2 = "{" + key + "}:2"; // same hash slot as list1 due to hash tag
 
         redis.rpush(list1, "one", "two", "three");
         redis.blmove(list1, list2, LMoveArgs.Builder.leftRight(), 1000);
@@ -375,8 +375,8 @@ public class ListCommandIntegrationTests extends TestSupport {
     @Test
     @EnabledOnCommand("BLMOVE") // Redis 6.2
     void blmoveDoubleTimeout() {
-        String list1 = key;
-        String list2 = "38o54"; // yields in same slot as "key"
+        String list1 = "{" + key + "}:1";
+        String list2 = "{" + key + "}:2"; // same hash slot as list1 due to hash tag
 
         redis.rpush(list1, "one", "two", "three");
         redis.blmove(list1, list2, LMoveArgs.Builder.leftRight(), 1.5);

--- a/src/test/java/io/lettuce/core/commands/StreamCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/StreamCommandIntegrationTests.java
@@ -427,7 +427,7 @@ public class StreamCommandIntegrationTests extends TestSupport {
 
         redis.xgroupCreate(StreamOffset.latest(key), "group", XGroupCreateArgs.Builder.entriesRead(5).mkstream(true));
 
-        List<List<Object>> group = (List) redis.xinfoGroups("key");
+        List<List<Object>> group = (List) redis.xinfoGroups(key);
 
         assertThat(group.get(0)).containsSequence("entries-read", 5L, "lag");
     }
@@ -442,7 +442,7 @@ public class StreamCommandIntegrationTests extends TestSupport {
         redis.xadd(key, Collections.singletonMap("key", "value"));
         redis.xgroupCreate(StreamOffset.latest(key), "group", XGroupCreateArgs.Builder.entriesRead(5).mkstream(true));
 
-        List<List<Object>> group = (List) redis.xinfoGroups("key");
+        List<List<Object>> group = (List) redis.xinfoGroups(key);
 
         assertThat(group.get(0)).containsSequence("entries-read", 2L, "lag");
     }
@@ -698,7 +698,7 @@ public class StreamCommandIntegrationTests extends TestSupport {
 
         StreamMessage<String, String> message = claimedMessages.getMessages().get(0);
         assertThat(message.getBody()).isNull();
-        assertThat(message.getStream()).isEqualTo("key");
+        assertThat(message.getStream()).isEqualTo(key);
         assertThat(message.getId()).isEqualTo(id1);
     }
 
@@ -760,7 +760,7 @@ public class StreamCommandIntegrationTests extends TestSupport {
         StreamMessage<String, String> message = claimedMessages.get(0);
 
         assertThat(message.getBody()).isNull();
-        assertThat(message.getStream()).isEqualTo("key");
+        assertThat(message.getStream()).isEqualTo(key);
         assertThat(message.getId()).isEqualTo(id2);
     }
 

--- a/src/test/java/io/lettuce/core/commands/StringCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/StringCommandIntegrationTests.java
@@ -140,7 +140,7 @@ public class StringCommandIntegrationTests extends TestSupport {
     }
 
     protected void setupMget() {
-        assertThat(redis.mget(key)).isEqualTo(list(KeyValue.empty("key")));
+        assertThat(redis.mget(key)).isEqualTo(list(KeyValue.empty(key)));
         redis.set("one", "1");
         redis.set("two", "2");
     }

--- a/src/test/java/io/lettuce/core/dynamic/RedisCommandsClusterIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/dynamic/RedisCommandsClusterIntegrationTests.java
@@ -45,8 +45,8 @@ class RedisCommandsClusterIntegrationTests extends TestSupport {
 
         api.setSync(key, value, Timeout.create(Duration.ofSeconds(10)));
 
-        assertThat(api.get("key").get()).isEqualTo("value");
-        assertThat(api.getAsBytes("key")).isEqualTo("value".getBytes());
+        assertThat(api.get(key).get()).isEqualTo(value);
+        assertThat(api.getAsBytes(key)).isEqualTo(value.getBytes());
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/dynamic/RedisCommandsSyncIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/dynamic/RedisCommandsSyncIntegrationTests.java
@@ -51,8 +51,8 @@ class RedisCommandsSyncIntegrationTests extends TestSupport {
         MultipleExecutionModels api = factory.getCommands(MultipleExecutionModels.class);
 
         api.setSync(key, value, Timeout.create(10, TimeUnit.SECONDS));
-        assertThat(api.get("key")).isEqualTo("value");
-        assertThat(api.getAsBytes("key")).isEqualTo("value".getBytes());
+        assertThat(api.get(key)).isEqualTo(value);
+        assertThat(api.getAsBytes(key)).isEqualTo(value.getBytes());
 
         connection.close();
     }
@@ -65,9 +65,10 @@ class RedisCommandsSyncIntegrationTests extends TestSupport {
 
         MultipleExecutionModels api = factory.getCommands(MultipleExecutionModels.class);
 
-        api.setSync(key, value, Timeout.create(10, TimeUnit.SECONDS));
+        // Use a fixed key for this test since getAsBytes() default method hardcodes "key"
+        api.setSync("key", value, Timeout.create(10, TimeUnit.SECONDS));
 
-        assertThat(api.getAsBytes()).isEqualTo("value".getBytes());
+        assertThat(api.getAsBytes()).isEqualTo(value.getBytes());
 
         connection.close();
     }


### PR DESCRIPTION
Adjust the integration infra to support ENV_VAR for skipping unit tests on demand.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI wiring and test isolation; no production client or security behavior is modified.
> 
> **Overview**
> Adds a **`skip_unit_tests`** path through reusable CI (`run-tests.yml`, `integration.yml`) so custom client-libs image runs can execute **integration tests only** via `make test MVN_EXTRA_ARGS="-DskipUnitTests=true"` with coverage upload disabled. Maven gains **`skipUnitTests`** (defaults from `skipTests`) and Surefire **`skipTests`** binding; the Makefile forwards **`MVN_EXTRA_ARGS`** on `test` / `test-coverage`.
> 
> Integration tests are adjusted for **per-method Redis keys**: `TestSupport.key` is no longer a shared static `"key"` but is set in **`@BeforeEach`** to `key-<methodName>`, with follow-on fixes (hash-tagged secondary keys, **`ClusterTestSettings.KEY_A`** for replica scenarios, scan/match prefixes, stream assertions using `key`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2079b6a858b28e21750c74f295b85a93f84131e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->