### PR TITLE
Fix batch command timeout handling

### DIFF
--- a/src/main/java/io/lettuce/core/dynamic/BatchExecutableCommand.java
+++ b/src/main/java/io/lettuce/core/dynamic/BatchExecutableCommand.java
@@ -75,40 +75,20 @@ class BatchExecutableCommand implements ExecutableCommand {
             return null;
         }
 
-        Duration timeout = connection.getTimeout();
-        long timeoutNs = timeout.toNanos();
-        long started = System.nanoTime();
-        boolean timeoutReached = false;
+        BatchTimeout batchTimeout = new BatchTimeout(connection.getTimeout());
 
         BatchException exception = null;
         List<RedisCommand<?, ?, ?>> failures = null;
         for (RedisCommand<?, ?, ?> batchTask : batchTasks) {
 
             RedisFuture<?> future = (RedisFuture<?>) batchTask;
-            boolean commandTimedOut = false;
 
             try {
-                if (timeoutReached && !future.isDone()) {
+                if (batchTimeout.isReached() && !future.isDone()) {
                     continue;
                 }
 
-                long waitNs = 0;
-
-                if (!timeoutReached && timeoutNs > 0) {
-                    waitNs = timeoutNs - (System.nanoTime() - started);
-
-                    if (waitNs <= 0 && !future.isDone()) {
-                        commandTimedOut = true;
-                        throw ExceptionFactory.createTimeoutException(timeout);
-                    }
-
-                    waitNs = Math.max(waitNs, 0);
-                }
-
-                if (!Futures.await(waitNs, TimeUnit.NANOSECONDS, future)) {
-                    commandTimedOut = true;
-                    throw ExceptionFactory.createTimeoutException(timeout);
-                }
+                batchTimeout.await(future);
             } catch (Exception e) {
                 if (exception == null) {
                     failures = new ArrayList<>();
@@ -117,10 +97,6 @@ class BatchExecutableCommand implements ExecutableCommand {
 
                 failures.add(batchTask);
                 exception.addSuppressed(e);
-
-                if (commandTimedOut) {
-                    timeoutReached = true;
-                }
             }
         }
 
@@ -134,6 +110,60 @@ class BatchExecutableCommand implements ExecutableCommand {
     @Override
     public CommandMethod getCommandMethod() {
         return commandMethod;
+    }
+
+    private static final class BatchTimeout {
+
+        private final Duration timeout;
+
+        private final long timeoutNs;
+
+        private final long startedNs = System.nanoTime();
+
+        private boolean reached;
+
+        BatchTimeout(Duration timeout) {
+
+            this.timeout = timeout;
+            this.timeoutNs = timeout.toNanos();
+        }
+
+        boolean isReached() {
+            return reached;
+        }
+
+        void await(RedisFuture<?> future) {
+
+            if (future.isDone() || !isEnabled()) {
+                Futures.await(0, TimeUnit.NANOSECONDS, future);
+                return;
+            }
+
+            long remainingNs = remainingNs();
+
+            if (remainingNs <= 0) {
+                throwTimeoutException();
+            }
+
+            if (!Futures.await(remainingNs, TimeUnit.NANOSECONDS, future)) {
+                throwTimeoutException();
+            }
+        }
+
+        private boolean isEnabled() {
+            return timeoutNs > 0;
+        }
+
+        private long remainingNs() {
+            return timeoutNs - (System.nanoTime() - startedNs);
+        }
+
+        private void throwTimeoutException() {
+
+            reached = true;
+            throw ExceptionFactory.createTimeoutException(timeout);
+        }
+
     }
 
 }

--- a/src/main/java/io/lettuce/core/dynamic/BatchExecutableCommand.java
+++ b/src/main/java/io/lettuce/core/dynamic/BatchExecutableCommand.java
@@ -4,12 +4,14 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import io.lettuce.core.RedisFuture;
 import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.dynamic.batch.BatchException;
 import io.lettuce.core.dynamic.batch.CommandBatching;
 import io.lettuce.core.dynamic.parameter.ExecutionSpecificParameters;
+import io.lettuce.core.internal.ExceptionFactory;
 import io.lettuce.core.internal.Futures;
 import io.lettuce.core.protocol.AsyncCommand;
 import io.lettuce.core.protocol.RedisCommand;
@@ -74,13 +76,39 @@ class BatchExecutableCommand implements ExecutableCommand {
         }
 
         Duration timeout = connection.getTimeout();
+        long timeoutNs = timeout.toNanos();
+        long started = System.nanoTime();
+        boolean timeoutReached = false;
 
         BatchException exception = null;
         List<RedisCommand<?, ?, ?>> failures = null;
         for (RedisCommand<?, ?, ?> batchTask : batchTasks) {
 
+            RedisFuture<?> future = (RedisFuture<?>) batchTask;
+            boolean commandTimedOut = false;
+
             try {
-                Futures.await(timeout, (RedisFuture) batchTask);
+                if (timeoutReached && !future.isDone()) {
+                    continue;
+                }
+
+                long waitNs = 0;
+
+                if (!timeoutReached && timeoutNs > 0) {
+                    waitNs = timeoutNs - (System.nanoTime() - started);
+
+                    if (waitNs <= 0 && !future.isDone()) {
+                        commandTimedOut = true;
+                        throw ExceptionFactory.createTimeoutException(timeout);
+                    }
+
+                    waitNs = Math.max(waitNs, 0);
+                }
+
+                if (!Futures.await(waitNs, TimeUnit.NANOSECONDS, future)) {
+                    commandTimedOut = true;
+                    throw ExceptionFactory.createTimeoutException(timeout);
+                }
             } catch (Exception e) {
                 if (exception == null) {
                     failures = new ArrayList<>();
@@ -89,6 +117,10 @@ class BatchExecutableCommand implements ExecutableCommand {
 
                 failures.add(batchTask);
                 exception.addSuppressed(e);
+
+                if (commandTimedOut) {
+                    timeoutReached = true;
+                }
             }
         }
 

--- a/src/main/java/io/lettuce/core/dynamic/BatchExecutableCommand.java
+++ b/src/main/java/io/lettuce/core/dynamic/BatchExecutableCommand.java
@@ -75,7 +75,7 @@ class BatchExecutableCommand implements ExecutableCommand {
             return null;
         }
 
-        BatchTimeout batchTimeout = new BatchTimeout(connection.getTimeout());
+        BatchDeadline deadline = new BatchDeadline(connection.getTimeout());
 
         BatchException exception = null;
         List<RedisCommand<?, ?, ?>> failures = null;
@@ -84,11 +84,11 @@ class BatchExecutableCommand implements ExecutableCommand {
             RedisFuture<?> future = (RedisFuture<?>) batchTask;
 
             try {
-                if (batchTimeout.isReached() && !future.isDone()) {
+                if (deadline.isExpiredAndPending(future)) {
                     continue;
                 }
 
-                batchTimeout.await(future);
+                deadline.await(future);
             } catch (Exception e) {
                 if (exception == null) {
                     failures = new ArrayList<>();
@@ -112,7 +112,7 @@ class BatchExecutableCommand implements ExecutableCommand {
         return commandMethod;
     }
 
-    private static final class BatchTimeout {
+    private static final class BatchDeadline {
 
         private final Duration timeout;
 
@@ -120,16 +120,16 @@ class BatchExecutableCommand implements ExecutableCommand {
 
         private final long startedNs = System.nanoTime();
 
-        private boolean reached;
+        private boolean expired;
 
-        BatchTimeout(Duration timeout) {
+        BatchDeadline(Duration timeout) {
 
             this.timeout = timeout;
             this.timeoutNs = timeout.toNanos();
         }
 
-        boolean isReached() {
-            return reached;
+        boolean isExpiredAndPending(RedisFuture<?> future) {
+            return expired && !future.isDone();
         }
 
         void await(RedisFuture<?> future) {
@@ -160,7 +160,7 @@ class BatchExecutableCommand implements ExecutableCommand {
 
         private void throwTimeoutException() {
 
-            reached = true;
+            expired = true;
             throw ExceptionFactory.createTimeoutException(timeout);
         }
 

--- a/src/main/java/io/lettuce/core/dynamic/BatchExecutableCommand.java
+++ b/src/main/java/io/lettuce/core/dynamic/BatchExecutableCommand.java
@@ -20,6 +20,7 @@ import io.lettuce.core.protocol.RedisCommand;
  * Executable command that uses a {@link Batcher} for command execution.
  *
  * @author Mark Paluch
+ * @author Yunseop Eom
  * @since 5.0
  */
 class BatchExecutableCommand implements ExecutableCommand {

--- a/src/main/java/io/lettuce/core/dynamic/BatchExecutableCommand.java
+++ b/src/main/java/io/lettuce/core/dynamic/BatchExecutableCommand.java
@@ -143,12 +143,23 @@ class BatchExecutableCommand implements ExecutableCommand {
             long remainingNs = remainingNs();
 
             if (remainingNs <= 0) {
-                throwTimeoutException();
+                awaitCompletedOrThrowTimeout(future);
+                return;
             }
 
             if (!Futures.await(remainingNs, TimeUnit.NANOSECONDS, future)) {
-                throwTimeoutException();
+                awaitCompletedOrThrowTimeout(future);
             }
+        }
+
+        private void awaitCompletedOrThrowTimeout(RedisFuture<?> future) {
+
+            if (future.isDone()) {
+                Futures.await(0, TimeUnit.NANOSECONDS, future);
+                return;
+            }
+
+            throwTimeoutException();
         }
 
         private boolean isEnabled() {

--- a/src/test/java/io/lettuce/core/dynamic/BatchExecutableCommandUnitTests.java
+++ b/src/test/java/io/lettuce/core/dynamic/BatchExecutableCommandUnitTests.java
@@ -1,0 +1,311 @@
+package io.lettuce.core.dynamic;
+
+import static io.lettuce.TestTags.UNIT_TEST;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.lettuce.core.RedisCommandExecutionException;
+import io.lettuce.core.RedisCommandTimeoutException;
+import io.lettuce.core.api.StatefulConnection;
+import io.lettuce.core.dynamic.batch.BatchException;
+import io.lettuce.core.protocol.AsyncCommand;
+import io.lettuce.core.protocol.Command;
+import io.lettuce.core.protocol.CommandType;
+import io.lettuce.core.protocol.RedisCommand;
+
+/**
+ * Unit tests for {@link BatchExecutableCommand}.
+ */
+@Tag(UNIT_TEST)
+@ExtendWith(MockitoExtension.class)
+class BatchExecutableCommandUnitTests {
+
+    @Mock
+    private StatefulConnection<Object, Object> connection;
+
+    @Test
+    void synchronizeShouldIgnoreEmptyBatchWithoutReadingTimeout() {
+
+        assertThat(BatchExecutableCommand.synchronize(BatchTasks.EMPTY, connection)).isNull();
+
+        verifyNoInteractions(connection);
+    }
+
+    @Test
+    void synchronizeShouldReturnWhenAllBatchCommandsCompleted() {
+
+        when(connection.getTimeout()).thenReturn(Duration.ofMillis(10));
+
+        AsyncCommand<Object, Object, Object> first = completedCommand();
+        AsyncCommand<Object, Object, Object> second = completedCommand();
+
+        assertThat(BatchExecutableCommand.synchronize(batchTasks(first, second), connection)).isNull();
+    }
+
+    @Test
+    void synchronizeShouldAggregateAllCompletedCommandFailures() {
+
+        when(connection.getTimeout()).thenReturn(Duration.ofMillis(10));
+
+        AsyncCommand<Object, Object, Object> first = failedCommand(new RedisCommandExecutionException("first"));
+        AsyncCommand<Object, Object, Object> second = completedCommand();
+        AsyncCommand<Object, Object, Object> third = failedCommand(new RedisCommandExecutionException("third"));
+
+        BatchException exception = catchThrowableOfType(
+                () -> BatchExecutableCommand.synchronize(batchTasks(first, second, third), connection), BatchException.class);
+
+        assertThat(exception.getFailedCommands()).containsExactly(first, third);
+        assertThat(exception.getSuppressed()).hasSize(2);
+        assertThat(exception.getSuppressed()[0]).isInstanceOf(RedisCommandExecutionException.class)
+                .hasMessageContaining("first");
+        assertThat(exception.getSuppressed()[1]).isInstanceOf(RedisCommandExecutionException.class)
+                .hasMessageContaining("third");
+    }
+
+    @Test
+    void synchronizeShouldConvertAwaitTimeoutIntoBatchException() {
+
+        when(connection.getTimeout()).thenReturn(Duration.ofNanos(1));
+
+        AsyncCommand<Object, Object, Object> pending = pendingCommand();
+
+        BatchException exception = catchThrowableOfType(
+                () -> BatchExecutableCommand.synchronize(batchTasks(pending), connection), BatchException.class);
+
+        assertThat(exception.getFailedCommands()).containsExactly(pending);
+        assertThat(exception.getSuppressed()).hasSize(1);
+        assertThat(exception.getSuppressed()[0]).isInstanceOf(RedisCommandTimeoutException.class)
+                .hasMessageContaining("Command timed out");
+    }
+
+    @Test
+    void synchronizeShouldApplyTimeoutAcrossWholeBatch() {
+
+        Duration timeout = Duration.ofMillis(500);
+        when(connection.getTimeout()).thenReturn(timeout);
+
+        DelayingCommand first = new DelayingCommand(Duration.ofMillis(25));
+        TimingOutCommand second = new TimingOutCommand();
+
+        BatchException exception = catchThrowableOfType(
+                () -> BatchExecutableCommand.synchronize(batchTasks(first, second), connection), BatchException.class);
+
+        assertThat(exception.getFailedCommands()).containsExactly(second);
+        assertThat(second.timedGetCalls()).isEqualTo(1);
+        assertThat(second.timeoutNs()).isPositive().isLessThan(timeout.toNanos());
+    }
+
+    @Test
+    void synchronizeShouldNotBlockOnUnfinishedCommandsAfterBatchTimeout() {
+
+        when(connection.getTimeout()).thenReturn(Duration.ofNanos(1));
+
+        TimingOutCommand timedOut = new TimingOutCommand();
+        AsyncCommand<Object, Object, Object> failedAfterTimeout = failedCommand(
+                new RedisCommandExecutionException("already failed"));
+        FailIfAwaitedCommand unfinishedAfterTimeout = new FailIfAwaitedCommand();
+
+        BatchException exception = catchThrowableOfType(() -> BatchExecutableCommand
+                .synchronize(batchTasks(timedOut, failedAfterTimeout, unfinishedAfterTimeout), connection),
+                BatchException.class);
+
+        assertThat(exception.getFailedCommands()).containsExactly(timedOut, failedAfterTimeout);
+        assertThat(exception.getSuppressed()).hasSize(2);
+        assertThat(exception.getSuppressed()[0]).isInstanceOf(RedisCommandTimeoutException.class);
+        assertThat(exception.getSuppressed()[1]).isInstanceOf(RedisCommandExecutionException.class)
+                .hasMessageContaining("already failed");
+        assertThat(unfinishedAfterTimeout.wasAwaited()).isFalse();
+    }
+
+    @Test
+    void synchronizeShouldCollectAlreadyCompletedFailuresAfterBatchTimeout() {
+
+        when(connection.getTimeout()).thenReturn(Duration.ofNanos(1));
+
+        TimingOutCommand timedOut = new TimingOutCommand();
+        AsyncCommand<Object, Object, Object> completedAfterTimeout = completedCommand();
+        AsyncCommand<Object, Object, Object> failedAfterTimeout = failedCommand(
+                new RedisCommandExecutionException("done before scan"));
+
+        BatchException exception = catchThrowableOfType(() -> BatchExecutableCommand
+                .synchronize(batchTasks(timedOut, completedAfterTimeout, failedAfterTimeout), connection),
+                BatchException.class);
+
+        assertThat(exception.getFailedCommands()).containsExactly(timedOut, failedAfterTimeout);
+        assertThat(exception.getSuppressed()).hasSize(2);
+        assertThat(exception.getSuppressed()[0]).isInstanceOf(RedisCommandTimeoutException.class);
+        assertThat(exception.getSuppressed()[1]).isInstanceOf(RedisCommandExecutionException.class)
+                .hasMessageContaining("done before scan");
+    }
+
+    @Test
+    void synchronizeShouldUseUnboundedWaitForZeroTimeout() {
+
+        when(connection.getTimeout()).thenReturn(Duration.ZERO);
+
+        CompletesOnUnboundedGetCommand command = new CompletesOnUnboundedGetCommand();
+
+        assertThat(BatchExecutableCommand.synchronize(batchTasks(command), connection)).isNull();
+
+        assertThat(command.unboundedGetCalls()).isEqualTo(1);
+        assertThat(command.timedGetCalls()).isZero();
+    }
+
+    private static BatchTasks batchTasks(RedisCommand<?, ?, ?>... commands) {
+        return new BatchTasks(Arrays.asList(commands));
+    }
+
+    private static AsyncCommand<Object, Object, Object> pendingCommand() {
+        return new AsyncCommand<>(new Command<>(CommandType.COMMAND, null, null));
+    }
+
+    private static AsyncCommand<Object, Object, Object> completedCommand() {
+
+        AsyncCommand<Object, Object, Object> command = pendingCommand();
+        command.complete();
+        return command;
+    }
+
+    private static AsyncCommand<Object, Object, Object> failedCommand(Throwable throwable) {
+
+        AsyncCommand<Object, Object, Object> command = pendingCommand();
+        command.completeExceptionally(throwable);
+        return command;
+    }
+
+    private static class DelayingCommand extends AsyncCommand<Object, Object, Object> {
+
+        private final long delayNs;
+
+        DelayingCommand(Duration delay) {
+            super(new Command<>(CommandType.COMMAND, null, null));
+            this.delayNs = delay.toNanos();
+        }
+
+        @Override
+        public Object get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+
+            parkAtLeast(delayNs);
+            complete();
+            return null;
+        }
+
+    }
+
+    private static class TimingOutCommand extends AsyncCommand<Object, Object, Object> {
+
+        private final AtomicInteger timedGetCalls = new AtomicInteger();
+
+        private volatile long timeoutNs;
+
+        TimingOutCommand() {
+            super(new Command<>(CommandType.COMMAND, null, null));
+        }
+
+        @Override
+        public Object get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+
+            timedGetCalls.incrementAndGet();
+            timeoutNs = unit.toNanos(timeout);
+            throw new TimeoutException();
+        }
+
+        int timedGetCalls() {
+            return timedGetCalls.get();
+        }
+
+        long timeoutNs() {
+            return timeoutNs;
+        }
+
+    }
+
+    private static class FailIfAwaitedCommand extends AsyncCommand<Object, Object, Object> {
+
+        private final AtomicBoolean awaited = new AtomicBoolean();
+
+        FailIfAwaitedCommand() {
+            super(new Command<>(CommandType.COMMAND, null, null));
+        }
+
+        @Override
+        public Object get() throws InterruptedException, ExecutionException {
+
+            awaited.set(true);
+            throw new AssertionError("Unfinished command must not be awaited after the batch timeout is reached");
+        }
+
+        @Override
+        public Object get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+
+            awaited.set(true);
+            throw new AssertionError("Unfinished command must not be awaited after the batch timeout is reached");
+        }
+
+        boolean wasAwaited() {
+            return awaited.get();
+        }
+
+    }
+
+    private static class CompletesOnUnboundedGetCommand extends AsyncCommand<Object, Object, Object> {
+
+        private final AtomicInteger unboundedGetCalls = new AtomicInteger();
+
+        private final AtomicInteger timedGetCalls = new AtomicInteger();
+
+        CompletesOnUnboundedGetCommand() {
+            super(new Command<>(CommandType.COMMAND, null, null));
+        }
+
+        @Override
+        public Object get() throws InterruptedException, ExecutionException {
+
+            unboundedGetCalls.incrementAndGet();
+            complete();
+            return null;
+        }
+
+        @Override
+        public Object get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+
+            timedGetCalls.incrementAndGet();
+            throw new AssertionError("Zero timeout must use Future.get() without a timeout");
+        }
+
+        int unboundedGetCalls() {
+            return unboundedGetCalls.get();
+        }
+
+        int timedGetCalls() {
+            return timedGetCalls.get();
+        }
+
+    }
+
+    private static void parkAtLeast(long nanos) {
+
+        long deadline = System.nanoTime() + nanos;
+
+        while (System.nanoTime() < deadline) {
+            long remaining = deadline - System.nanoTime();
+            LockSupport.parkNanos(Math.min(TimeUnit.MILLISECONDS.toNanos(1), remaining));
+        }
+    }
+
+}

--- a/src/test/java/io/lettuce/core/dynamic/BatchExecutableCommandUnitTests.java
+++ b/src/test/java/io/lettuce/core/dynamic/BatchExecutableCommandUnitTests.java
@@ -20,6 +20,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.lettuce.core.RedisCommandExecutionException;
+import io.lettuce.core.RedisCommandInterruptedException;
 import io.lettuce.core.RedisCommandTimeoutException;
 import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.dynamic.batch.BatchException;
@@ -166,6 +167,118 @@ class BatchExecutableCommandUnitTests {
         assertThat(command.timedGetCalls()).isZero();
     }
 
+    @Test
+    void synchronizeShouldUseUnboundedWaitForNegativeTimeout() {
+
+        when(connection.getTimeout()).thenReturn(Duration.ofNanos(-1));
+
+        CompletesOnUnboundedGetCommand command = new CompletesOnUnboundedGetCommand();
+
+        assertThat(BatchExecutableCommand.synchronize(batchTasks(command), connection)).isNull();
+
+        assertThat(command.unboundedGetCalls()).isEqualTo(1);
+        assertThat(command.timedGetCalls()).isZero();
+    }
+
+    @Test
+    void synchronizeShouldUseUnboundedWaitForCompletedCommandWithPositiveTimeout() {
+
+        when(connection.getTimeout()).thenReturn(Duration.ofSeconds(1));
+
+        CompletedGetTrackingCommand command = new CompletedGetTrackingCommand();
+
+        assertThat(BatchExecutableCommand.synchronize(batchTasks(command), connection)).isNull();
+
+        assertThat(command.unboundedGetCalls()).isEqualTo(1);
+        assertThat(command.timedGetCalls()).isZero();
+    }
+
+    @Test
+    void synchronizeShouldUseUnboundedWaitForCompletedFailureWithPositiveTimeout() {
+
+        when(connection.getTimeout()).thenReturn(Duration.ofSeconds(1));
+
+        RedisCommandExecutionException failure = new RedisCommandExecutionException("completed failure");
+        FailedCompletedGetTrackingCommand command = new FailedCompletedGetTrackingCommand(failure);
+
+        BatchException exception = catchThrowableOfType(
+                () -> BatchExecutableCommand.synchronize(batchTasks(command), connection), BatchException.class);
+
+        assertThat(exception.getFailedCommands()).containsExactly(command);
+        assertThat(exception.getSuppressed()).hasSize(1);
+        assertThat(exception.getSuppressed()[0]).isInstanceOf(RedisCommandExecutionException.class)
+                .hasMessageContaining("completed failure");
+        assertThat(command.unboundedGetCalls()).isEqualTo(1);
+        assertThat(command.timedGetCalls()).isZero();
+    }
+
+    @Test
+    void synchronizeShouldExpireDeadlineBeforeAwaitingPendingCommand() {
+
+        when(connection.getTimeout()).thenReturn(Duration.ofMillis(50));
+
+        DelayingCommand completedAfterDeadline = new DelayingCommand(Duration.ofMillis(75));
+        FailIfAwaitedCommand timedOutAfterDeadline = new FailIfAwaitedCommand();
+        FailIfAwaitedCommand skippedAfterDeadline = new FailIfAwaitedCommand();
+
+        BatchException exception = catchThrowableOfType(
+                () -> BatchExecutableCommand.synchronize(
+                        batchTasks(completedAfterDeadline, timedOutAfterDeadline, skippedAfterDeadline), connection),
+                BatchException.class);
+
+        assertThat(exception.getFailedCommands()).containsExactly(timedOutAfterDeadline);
+        assertThat(exception.getSuppressed()).hasSize(1);
+        assertThat(exception.getSuppressed()[0]).isInstanceOf(RedisCommandTimeoutException.class);
+        assertThat(timedOutAfterDeadline.wasAwaited()).isFalse();
+        assertThat(skippedAfterDeadline.wasAwaited()).isFalse();
+    }
+
+    @Test
+    void synchronizeShouldCollectCompletedFailuresAfterDeadlineExpiredBeforeAwait() {
+
+        when(connection.getTimeout()).thenReturn(Duration.ofMillis(50));
+
+        DelayingCommand completedAfterDeadline = new DelayingCommand(Duration.ofMillis(75));
+        FailIfAwaitedCommand timedOutAfterDeadline = new FailIfAwaitedCommand();
+        AsyncCommand<Object, Object, Object> failedAfterDeadline = failedCommand(
+                new RedisCommandExecutionException("completed after deadline"));
+        FailIfAwaitedCommand skippedAfterDeadline = new FailIfAwaitedCommand();
+
+        BatchException exception = catchThrowableOfType(() -> BatchExecutableCommand.synchronize(
+                batchTasks(completedAfterDeadline, timedOutAfterDeadline, failedAfterDeadline, skippedAfterDeadline),
+                connection), BatchException.class);
+
+        assertThat(exception.getFailedCommands()).containsExactly(timedOutAfterDeadline, failedAfterDeadline);
+        assertThat(exception.getSuppressed()).hasSize(2);
+        assertThat(exception.getSuppressed()[0]).isInstanceOf(RedisCommandTimeoutException.class);
+        assertThat(exception.getSuppressed()[1]).isInstanceOf(RedisCommandExecutionException.class)
+                .hasMessageContaining("completed after deadline");
+        assertThat(timedOutAfterDeadline.wasAwaited()).isFalse();
+        assertThat(skippedAfterDeadline.wasAwaited()).isFalse();
+    }
+
+    @Test
+    void synchronizeShouldAggregateInterruptedAwaitAsBatchFailure() {
+
+        when(connection.getTimeout()).thenReturn(Duration.ofSeconds(1));
+
+        InterruptingCommand command = new InterruptingCommand();
+
+        try {
+            BatchException exception = catchThrowableOfType(
+                    () -> BatchExecutableCommand.synchronize(batchTasks(command), connection), BatchException.class);
+
+            assertThat(exception.getFailedCommands()).containsExactly(command);
+            assertThat(exception.getSuppressed()).hasSize(1);
+            assertThat(exception.getSuppressed()[0]).isInstanceOf(RedisCommandInterruptedException.class);
+            assertThat(command.timedGetCalls()).isEqualTo(1);
+            assertThat(command.unboundedGetCalls()).isZero();
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
     private static BatchTasks batchTasks(RedisCommand<?, ?, ?>... commands) {
         return new BatchTasks(Arrays.asList(commands));
     }
@@ -286,6 +399,92 @@ class BatchExecutableCommandUnitTests {
 
             timedGetCalls.incrementAndGet();
             throw new AssertionError("Zero timeout must use Future.get() without a timeout");
+        }
+
+        int unboundedGetCalls() {
+            return unboundedGetCalls.get();
+        }
+
+        int timedGetCalls() {
+            return timedGetCalls.get();
+        }
+
+    }
+
+    private static class CompletedGetTrackingCommand extends AsyncCommand<Object, Object, Object> {
+
+        private final AtomicInteger unboundedGetCalls = new AtomicInteger();
+
+        private final AtomicInteger timedGetCalls = new AtomicInteger();
+
+        CompletedGetTrackingCommand() {
+            this(null);
+        }
+
+        CompletedGetTrackingCommand(Throwable throwable) {
+            super(new Command<>(CommandType.COMMAND, null, null));
+
+            if (throwable == null) {
+                complete();
+            } else {
+                completeExceptionally(throwable);
+            }
+        }
+
+        @Override
+        public Object get() throws InterruptedException, ExecutionException {
+
+            unboundedGetCalls.incrementAndGet();
+            return super.get();
+        }
+
+        @Override
+        public Object get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+
+            timedGetCalls.incrementAndGet();
+            throw new AssertionError("Completed command must use Future.get() without a timeout");
+        }
+
+        int unboundedGetCalls() {
+            return unboundedGetCalls.get();
+        }
+
+        int timedGetCalls() {
+            return timedGetCalls.get();
+        }
+
+    }
+
+    private static class FailedCompletedGetTrackingCommand extends CompletedGetTrackingCommand {
+
+        FailedCompletedGetTrackingCommand(Throwable throwable) {
+            super(throwable);
+        }
+
+    }
+
+    private static class InterruptingCommand extends AsyncCommand<Object, Object, Object> {
+
+        private final AtomicInteger unboundedGetCalls = new AtomicInteger();
+
+        private final AtomicInteger timedGetCalls = new AtomicInteger();
+
+        InterruptingCommand() {
+            super(new Command<>(CommandType.COMMAND, null, null));
+        }
+
+        @Override
+        public Object get() throws InterruptedException, ExecutionException {
+
+            unboundedGetCalls.incrementAndGet();
+            throw new InterruptedException("interrupted");
+        }
+
+        @Override
+        public Object get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+
+            timedGetCalls.incrementAndGet();
+            throw new InterruptedException("interrupted");
         }
 
         int unboundedGetCalls() {

--- a/src/test/java/io/lettuce/core/dynamic/BatchExecutableCommandUnitTests.java
+++ b/src/test/java/io/lettuce/core/dynamic/BatchExecutableCommandUnitTests.java
@@ -31,6 +31,8 @@ import io.lettuce.core.protocol.RedisCommand;
 
 /**
  * Unit tests for {@link BatchExecutableCommand}.
+ *
+ * @author Yunseop Eom
  */
 @Tag(UNIT_TEST)
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/io/lettuce/core/dynamic/BatchExecutableCommandUnitTests.java
+++ b/src/test/java/io/lettuce/core/dynamic/BatchExecutableCommandUnitTests.java
@@ -97,6 +97,70 @@ class BatchExecutableCommandUnitTests {
     }
 
     @Test
+    void synchronizeShouldObserveSuccessCompletedAsTimedWaitExpires() {
+
+        when(connection.getTimeout()).thenReturn(Duration.ofSeconds(1));
+
+        CompletesAsTimedWaitExpiresCommand command = new CompletesAsTimedWaitExpiresCommand();
+
+        assertThat(BatchExecutableCommand.synchronize(batchTasks(command), connection)).isNull();
+
+        assertThat(command.timedGetCalls()).isEqualTo(1);
+        assertThat(command.unboundedGetCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void synchronizeShouldCollectFailureCompletedAsTimedWaitExpires() {
+
+        when(connection.getTimeout()).thenReturn(Duration.ofSeconds(1));
+
+        RedisCommandExecutionException failure = new RedisCommandExecutionException("failed at timeout boundary");
+        CompletesAsTimedWaitExpiresCommand command = new CompletesAsTimedWaitExpiresCommand(failure);
+
+        BatchException exception = catchThrowableOfType(
+                () -> BatchExecutableCommand.synchronize(batchTasks(command), connection), BatchException.class);
+
+        assertThat(exception.getFailedCommands()).containsExactly(command);
+        assertThat(exception.getSuppressed()).hasSize(1);
+        assertThat(exception.getSuppressed()[0]).isInstanceOf(RedisCommandExecutionException.class)
+                .hasMessageContaining("failed at timeout boundary");
+        assertThat(command.timedGetCalls()).isEqualTo(1);
+        assertThat(command.unboundedGetCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void synchronizeShouldObserveSuccessCompletedAsDeadlineExpiresBeforeWait() {
+
+        when(connection.getTimeout()).thenReturn(Duration.ofMillis(1));
+
+        CompletesAsDeadlineExpiresCommand command = new CompletesAsDeadlineExpiresCommand(Duration.ofMillis(5));
+
+        assertThat(BatchExecutableCommand.synchronize(batchTasks(command), connection)).isNull();
+
+        assertThat(command.timedGetCalls()).isZero();
+        assertThat(command.unboundedGetCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void synchronizeShouldCollectFailureCompletedAsDeadlineExpiresBeforeWait() {
+
+        when(connection.getTimeout()).thenReturn(Duration.ofMillis(1));
+
+        RedisCommandExecutionException failure = new RedisCommandExecutionException("failed as deadline expired");
+        CompletesAsDeadlineExpiresCommand command = new CompletesAsDeadlineExpiresCommand(Duration.ofMillis(5), failure);
+
+        BatchException exception = catchThrowableOfType(
+                () -> BatchExecutableCommand.synchronize(batchTasks(command), connection), BatchException.class);
+
+        assertThat(exception.getFailedCommands()).containsExactly(command);
+        assertThat(exception.getSuppressed()).hasSize(1);
+        assertThat(exception.getSuppressed()[0]).isInstanceOf(RedisCommandExecutionException.class)
+                .hasMessageContaining("failed as deadline expired");
+        assertThat(command.timedGetCalls()).isZero();
+        assertThat(command.unboundedGetCalls()).isEqualTo(1);
+    }
+
+    @Test
     void synchronizeShouldApplyTimeoutAcrossWholeBatch() {
 
         Duration timeout = Duration.ofMillis(500);
@@ -346,6 +410,104 @@ class BatchExecutableCommandUnitTests {
 
         long timeoutNs() {
             return timeoutNs;
+        }
+
+    }
+
+    private abstract static class CompletingAtTimeoutBoundaryCommand extends AsyncCommand<Object, Object, Object> {
+
+        private final Throwable failure;
+
+        private final AtomicInteger unboundedGetCalls = new AtomicInteger();
+
+        private final AtomicInteger timedGetCalls = new AtomicInteger();
+
+        CompletingAtTimeoutBoundaryCommand(Throwable failure) {
+            super(new Command<>(CommandType.COMMAND, null, null));
+            this.failure = failure;
+        }
+
+        @Override
+        public Object get() throws InterruptedException, ExecutionException {
+
+            unboundedGetCalls.incrementAndGet();
+            return super.get();
+        }
+
+        void recordTimedGet() {
+            timedGetCalls.incrementAndGet();
+        }
+
+        void completeAtTimeoutBoundary() {
+
+            if (failure == null) {
+                complete();
+            } else {
+                completeExceptionally(failure);
+            }
+        }
+
+        int unboundedGetCalls() {
+            return unboundedGetCalls.get();
+        }
+
+        int timedGetCalls() {
+            return timedGetCalls.get();
+        }
+
+    }
+
+    private static class CompletesAsTimedWaitExpiresCommand extends CompletingAtTimeoutBoundaryCommand {
+
+        CompletesAsTimedWaitExpiresCommand() {
+            this(null);
+        }
+
+        CompletesAsTimedWaitExpiresCommand(Throwable failure) {
+            super(failure);
+        }
+
+        @Override
+        public Object get(long timeout, TimeUnit unit) throws TimeoutException {
+
+            recordTimedGet();
+            completeAtTimeoutBoundary();
+            throw new TimeoutException();
+        }
+
+    }
+
+    private static class CompletesAsDeadlineExpiresCommand extends CompletingAtTimeoutBoundaryCommand {
+
+        private final long completionDelayNs;
+
+        private final AtomicInteger doneChecks = new AtomicInteger();
+
+        CompletesAsDeadlineExpiresCommand(Duration completionDelay) {
+            this(completionDelay, null);
+        }
+
+        CompletesAsDeadlineExpiresCommand(Duration completionDelay, Throwable failure) {
+            super(failure);
+            this.completionDelayNs = completionDelay.toNanos();
+        }
+
+        @Override
+        public boolean isDone() {
+
+            if (doneChecks.incrementAndGet() == 1) {
+                parkAtLeast(completionDelayNs);
+                completeAtTimeoutBoundary();
+                return false;
+            }
+
+            return super.isDone();
+        }
+
+        @Override
+        public Object get(long timeout, TimeUnit unit) {
+
+            throw new AssertionError("Expired deadline must not use Future.get(long, TimeUnit)");
         }
 
     }


### PR DESCRIPTION
Fixes #2261.

## Summary
- apply the configured timeout as a single budget across the whole batch synchronization step
- stop waiting on unfinished commands once the batch timeout has already been reached
- recheck command completion at the timeout boundary before recording a timeout failure
- keep collecting failures from commands that are already completed exceptionally
- add focused unit coverage for whole-batch budgeting, post-timeout behavior, timeout-boundary completion races, and unbounded waits

## Verification
- `mvn -q formatter:validate` (Java 17)
- `mvn -Dmaven.gitcommitid.skip=true clean test` (Java 17; 4,700 tests, 0 failures, 0 errors, 11 skipped)
- full Redis 8.6 integration suite attempted locally; the batch integration tests passed, but the suite finished with unrelated Docker fixture errors (missing TLS certificate mount and Redis RDB persistence `MISCONF`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes synchronous dynamic batch wait semantics and timeout timing, which can affect latency and failure reporting for batched Redis commands, though behavior is narrowly scoped and heavily unit-tested.
> 
> **Overview**
> **Batch synchronization** no longer gives each command the full connection timeout. A new **`BatchDeadline`** tracks one elapsed budget for the whole `synchronize` loop and waits only for the **remaining** time on pending futures.
> 
> After the batch deadline expires, **unfinished** commands are **skipped** (no further blocking), while **already completed** successes and failures are still observed and folded into **`BatchException`** as before. **Zero or negative** timeouts keep **unbounded** waits; completed futures use a zero-length await instead of a timed wait.
> 
> Adds **`BatchExecutableCommandUnitTests`** covering empty batches, aggregation, whole-batch budgeting, post-timeout behavior, deadline edge cases, and interrupt handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f61a3b52b95cf2d7c9ace734a965489c345dcc27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->