### PR TITLE
Add deprecation annotation to coroutine multi DSL #2371

### DIFF
--- a/src/main/kotlin/io/lettuce/core/api/coroutines/RedisCoroutinesCommandsExtensions.kt
+++ b/src/main/kotlin/io/lettuce/core/api/coroutines/RedisCoroutinesCommandsExtensions.kt
@@ -26,9 +26,11 @@ import io.lettuce.core.TransactionResult
  * Allows to create transaction DSL block with [RedisCoroutinesCommands].
  *
  * @author Mikhael Sokolov
+ * @author Euiyoung Nam
  * @since 6.0
  * @deprecated since 6.1.6
  */
+@Deprecated("since 6.1.6, coroutine transaction DSL commands complete only after EXEC")
 @ExperimentalLettuceCoroutinesApi
 suspend inline fun <K : Any, V : Any> RedisCoroutinesCommands<K, V>.multi(action: RedisCoroutinesCommands<K, V>.() -> Unit): TransactionResult? = try {
     multi()


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

Refs #2371

This PR adds the missing Kotlin `@Deprecated` annotation to the DSL-style coroutine transaction extension `RedisCoroutinesCommands.multi { ... }`.

The extension was already documented as deprecated since 6.1.6, but it did not produce compiler or IDE warnings. This change aligns the Kotlin API annotation with the existing KDoc deprecation notice and does not change runtime behavior.

 <!--
Great! Live long and prosper.
-->