### PR TITLE
Ali/commands factory

### DIFF
--- a/src/main/java/io/lettuce/core/StatefulRedisConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/StatefulRedisConnectionImpl.java
@@ -25,8 +25,11 @@ import static io.lettuce.core.protocol.CommandType.*;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -126,6 +129,18 @@ public class StatefulRedisConnectionImpl<K, V> extends RedisChannelHandler<K, V>
      */
     protected RedisCommands<K, V> newRedisSyncCommandsImpl() {
         return syncHandler(async(), RedisCommands.class, RedisClusterCommands.class);
+    }
+
+    private Map<Function<StatefulRedisConnection<K, V>, ?>, Object> cache = new HashMap<>();
+
+    public <T> T getCachedBySupplier(Function<StatefulRedisConnection<K, V>, T> supplier) {
+        @SuppressWarnings("unchecked")
+        T t = (T) cache.get(supplier);
+        if (t == null) {
+            t = supplier.apply(this);
+            cache.put(supplier, t);
+        }
+        return t;
     }
 
     /**

--- a/src/main/java/io/lettuce/core/StatefulRedisConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/StatefulRedisConnectionImpl.java
@@ -25,15 +25,14 @@ import static io.lettuce.core.protocol.CommandType.*;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.internal.SuppliedItemStore;
+import io.lettuce.core.internal.SupplierCaching;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.api.push.PushListener;
 import io.lettuce.core.api.reactive.RedisReactiveCommands;
@@ -57,7 +56,8 @@ import reactor.core.publisher.Mono;
  * @param <V> Value type.
  * @author Mark Paluch
  */
-public class StatefulRedisConnectionImpl<K, V> extends RedisChannelHandler<K, V> implements StatefulRedisConnection<K, V> {
+public class StatefulRedisConnectionImpl<K, V> extends RedisChannelHandler<K, V>
+        implements StatefulRedisConnection<K, V>, SupplierCaching<StatefulRedisConnection<K, V>> {
 
     protected final RedisCodec<K, V> codec;
 
@@ -131,16 +131,11 @@ public class StatefulRedisConnectionImpl<K, V> extends RedisChannelHandler<K, V>
         return syncHandler(async(), RedisCommands.class, RedisClusterCommands.class);
     }
 
-    private Map<Function<StatefulRedisConnection<K, V>, ?>, Object> cache = new HashMap<>();
+    private final SuppliedItemStore<StatefulRedisConnection<K, V>> commandsCache = new SuppliedItemStore<>(this);
 
-    public <T> T getCachedBySupplier(Function<StatefulRedisConnection<K, V>, T> supplier) {
-        @SuppressWarnings("unchecked")
-        T t = (T) cache.get(supplier);
-        if (t == null) {
-            t = supplier.apply(this);
-            cache.put(supplier, t);
-        }
-        return t;
+    @Override
+    public SuppliedItemStore<StatefulRedisConnection<K, V>> getStore() {
+        return commandsCache;
     }
 
     /**

--- a/src/main/java/io/lettuce/core/api/RedisCommandsFactory.java
+++ b/src/main/java/io/lettuce/core/api/RedisCommandsFactory.java
@@ -2,11 +2,10 @@ package io.lettuce.core.api;
 
 import java.util.function.Function;
 import io.lettuce.core.RedisReactiveCommandsImpl;
-import io.lettuce.core.StatefulRedisConnectionImpl;
 import io.lettuce.core.api.reactive.RedisReactiveCommands;
+import io.lettuce.core.internal.SupplierCaching;
 import io.lettuce.core.pubsub.RedisPubSubReactiveCommandsImpl;
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
-import io.lettuce.core.pubsub.StatefulRedisPubSubConnectionImpl;
 import io.lettuce.core.pubsub.api.reactive.RedisPubSubReactiveCommands;
 
 public final class RedisCommandsFactory {
@@ -24,13 +23,12 @@ public final class RedisCommandsFactory {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <K, V> RedisReactiveCommands<K, V> reactive(StatefulRedisConnection<K, V> conn) {
-        return (RedisReactiveCommands<K, V>) ((StatefulRedisConnectionImpl) conn)
-                .getCachedBySupplier(REACTIVE_COMMANDS_PROVIDER);
+        return (RedisReactiveCommands<K, V>) ((SupplierCaching) conn).getCachedBySupplier(REACTIVE_COMMANDS_PROVIDER);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <K, V> RedisPubSubReactiveCommands<K, V> pubsubReactive(StatefulRedisPubSubConnection<K, V> conn) {
-        return (RedisPubSubReactiveCommands<K, V>) ((StatefulRedisPubSubConnectionImpl) conn)
+        return (RedisPubSubReactiveCommands<K, V>) ((SupplierCaching) conn)
                 .getCachedBySupplier(PUBSUB_REACTIVE_COMMANDS_PROVIDER);
     }
 

--- a/src/main/java/io/lettuce/core/api/RedisCommandsFactory.java
+++ b/src/main/java/io/lettuce/core/api/RedisCommandsFactory.java
@@ -1,0 +1,37 @@
+package io.lettuce.core.api;
+
+import java.util.function.Function;
+import io.lettuce.core.RedisReactiveCommandsImpl;
+import io.lettuce.core.StatefulRedisConnectionImpl;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
+import io.lettuce.core.pubsub.RedisPubSubReactiveCommandsImpl;
+import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
+import io.lettuce.core.pubsub.StatefulRedisPubSubConnectionImpl;
+import io.lettuce.core.pubsub.api.reactive.RedisPubSubReactiveCommands;
+
+public final class RedisCommandsFactory {
+
+    private RedisCommandsFactory() {
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static final Function<StatefulRedisConnection<?, ?>, RedisReactiveCommands<?, ?>> REACTIVE_COMMANDS_PROVIDER = conn -> new RedisReactiveCommandsImpl(
+            conn, conn.getCodec(), () -> conn.getOptions().getJsonParser().get());
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static final Function<StatefulRedisPubSubConnection<?, ?>, RedisPubSubReactiveCommands<?, ?>> PUBSUB_REACTIVE_COMMANDS_PROVIDER = conn -> new RedisPubSubReactiveCommandsImpl(
+            conn, conn.getCodec());
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static <K, V> RedisReactiveCommands<K, V> reactive(StatefulRedisConnection<K, V> conn) {
+        return (RedisReactiveCommands<K, V>) ((StatefulRedisConnectionImpl) conn)
+                .getCachedBySupplier(REACTIVE_COMMANDS_PROVIDER);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static <K, V> RedisPubSubReactiveCommands<K, V> pubsubReactive(StatefulRedisPubSubConnection<K, V> conn) {
+        return (RedisPubSubReactiveCommands<K, V>) ((StatefulRedisPubSubConnectionImpl) conn)
+                .getCachedBySupplier(PUBSUB_REACTIVE_COMMANDS_PROVIDER);
+    }
+
+}

--- a/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterConnectionImpl.java
@@ -27,12 +27,9 @@ import java.lang.reflect.Proxy;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -57,6 +54,8 @@ import io.lettuce.core.cluster.models.partitions.Partitions;
 import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.internal.LettuceAssert;
+import io.lettuce.core.internal.SuppliedItemStore;
+import io.lettuce.core.internal.SupplierCaching;
 import io.lettuce.core.json.JsonParser;
 import io.lettuce.core.protocol.CommandArgsAccessor;
 import io.lettuce.core.protocol.CompleteableCommand;
@@ -75,7 +74,7 @@ import reactor.core.publisher.Mono;
  * @since 4.0
  */
 public class StatefulRedisClusterConnectionImpl<K, V> extends RedisChannelHandler<K, V>
-        implements StatefulRedisClusterConnection<K, V> {
+        implements StatefulRedisClusterConnection<K, V>, SupplierCaching<StatefulRedisClusterConnection<K, V>> {
 
     private final ClusterPushHandler pushHandler;
 
@@ -150,16 +149,11 @@ public class StatefulRedisClusterConnectionImpl<K, V> extends RedisChannelHandle
         return new RedisAdvancedClusterAsyncCommandsImpl((StatefulRedisClusterConnection<K, V>) this, codec, parser);
     }
 
-    private Map<Function<StatefulRedisClusterConnection<K, V>, ?>, Object> cache = new HashMap<>();
+    private final SuppliedItemStore<StatefulRedisClusterConnection<K, V>> commandsCache = new SuppliedItemStore<>(this);
 
-    public <T> T getCachedBySupplier(Function<StatefulRedisClusterConnection<K, V>, T> supplier) {
-        @SuppressWarnings("unchecked")
-        T t = (T) cache.get(supplier);
-        if (t == null) {
-            t = supplier.apply(this);
-            cache.put(supplier, t);
-        }
-        return t;
+    @Override
+    public SuppliedItemStore<StatefulRedisClusterConnection<K, V>> getStore() {
+        return commandsCache;
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterConnectionImpl.java
@@ -27,9 +27,12 @@ import java.lang.reflect.Proxy;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -145,6 +148,18 @@ public class StatefulRedisClusterConnectionImpl<K, V> extends RedisChannelHandle
 
     protected RedisAdvancedClusterAsyncCommandsImpl<K, V> newRedisAdvancedClusterAsyncCommandsImpl() {
         return new RedisAdvancedClusterAsyncCommandsImpl((StatefulRedisClusterConnection<K, V>) this, codec, parser);
+    }
+
+    private Map<Function<StatefulRedisClusterConnection<K, V>, ?>, Object> cache = new HashMap<>();
+
+    public <T> T getCachedBySupplier(Function<StatefulRedisClusterConnection<K, V>, T> supplier) {
+        @SuppressWarnings("unchecked")
+        T t = (T) cache.get(supplier);
+        if (t == null) {
+            t = supplier.apply(this);
+            cache.put(supplier, t);
+        }
+        return t;
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterPubSubConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterPubSubConnectionImpl.java
@@ -54,7 +54,7 @@ import io.lettuce.core.pubsub.api.sync.RedisPubSubCommands;
 /**
  * @author Mark Paluch
  */
-class StatefulRedisClusterPubSubConnectionImpl<K, V> extends StatefulRedisPubSubConnectionImpl<K, V>
+public class StatefulRedisClusterPubSubConnectionImpl<K, V> extends StatefulRedisPubSubConnectionImpl<K, V>
         implements StatefulRedisClusterPubSubConnection<K, V> {
 
     private final PubSubClusterEndpoint<K, V> endpoint;

--- a/src/main/java/io/lettuce/core/cluster/api/ClusterCommandsFactory.java
+++ b/src/main/java/io/lettuce/core/cluster/api/ClusterCommandsFactory.java
@@ -3,36 +3,35 @@ package io.lettuce.core.cluster.api;
 import java.util.function.Function;
 import io.lettuce.core.cluster.RedisAdvancedClusterReactiveCommandsImpl;
 import io.lettuce.core.cluster.RedisClusterPubSubReactiveCommandsImpl;
-import io.lettuce.core.cluster.StatefulRedisClusterConnectionImpl;
-import io.lettuce.core.cluster.StatefulRedisClusterPubSubConnectionImpl;
 import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
 import io.lettuce.core.cluster.pubsub.StatefulRedisClusterPubSubConnection;
 import io.lettuce.core.cluster.pubsub.api.reactive.RedisClusterPubSubReactiveCommands;
+import io.lettuce.core.internal.SupplierCaching;
 
 public final class ClusterCommandsFactory {
 
-        private ClusterCommandsFactory() {
-        }
+    private ClusterCommandsFactory() {
+    }
 
-        @SuppressWarnings({ "unchecked", "rawtypes" })
-        private static final Function<StatefulRedisClusterConnection<?, ?>, RedisAdvancedClusterReactiveCommands<?, ?>> REACTIVE_COMMANDS_PROVIDER = conn -> new RedisAdvancedClusterReactiveCommandsImpl(
-                        conn, conn.getCodec(), conn.getOptions().getJsonParser());
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static final Function<StatefulRedisClusterConnection<?, ?>, RedisAdvancedClusterReactiveCommands<?, ?>> REACTIVE_COMMANDS_PROVIDER = conn -> new RedisAdvancedClusterReactiveCommandsImpl(
+            conn, conn.getCodec(), conn.getOptions().getJsonParser());
 
-        @SuppressWarnings({ "unchecked", "rawtypes" })
-        private static final Function<StatefulRedisClusterPubSubConnection<?, ?>, RedisClusterPubSubReactiveCommands<?, ?>> PUBSUB_REACTIVE_COMMANDS_PROVIDER = conn -> new RedisClusterPubSubReactiveCommandsImpl(
-                        conn, conn.getCodec());
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static final Function<StatefulRedisClusterPubSubConnection<?, ?>, RedisClusterPubSubReactiveCommands<?, ?>> PUBSUB_REACTIVE_COMMANDS_PROVIDER = conn -> new RedisClusterPubSubReactiveCommandsImpl(
+            conn, conn.getCodec());
 
-        @SuppressWarnings({ "unchecked", "rawtypes" })
-        public static <K, V> RedisAdvancedClusterReactiveCommands<K, V> reactive(StatefulRedisClusterConnection<K, V> conn) {
-                return (RedisAdvancedClusterReactiveCommands<K, V>) ((StatefulRedisClusterConnectionImpl) conn)
-                                .getCachedBySupplier(REACTIVE_COMMANDS_PROVIDER);
-        }
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static <K, V> RedisAdvancedClusterReactiveCommands<K, V> reactive(StatefulRedisClusterConnection<K, V> conn) {
+        return (RedisAdvancedClusterReactiveCommands<K, V>) ((SupplierCaching) conn)
+                .getCachedBySupplier(REACTIVE_COMMANDS_PROVIDER);
+    }
 
-        @SuppressWarnings({ "unchecked", "rawtypes" })
-        public static <K, V> RedisClusterPubSubReactiveCommands<K, V> pubsubReactive(
-                        StatefulRedisClusterPubSubConnection<K, V> conn) {
-                return (RedisClusterPubSubReactiveCommands<K, V>) ((StatefulRedisClusterPubSubConnectionImpl) conn)
-                                .getCachedBySupplier(PUBSUB_REACTIVE_COMMANDS_PROVIDER);
-        }
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static <K, V> RedisClusterPubSubReactiveCommands<K, V> pubsubReactive(
+            StatefulRedisClusterPubSubConnection<K, V> conn) {
+        return (RedisClusterPubSubReactiveCommands<K, V>) ((SupplierCaching) conn)
+                .getCachedBySupplier(PUBSUB_REACTIVE_COMMANDS_PROVIDER);
+    }
 
 }

--- a/src/main/java/io/lettuce/core/cluster/api/ClusterCommandsFactory.java
+++ b/src/main/java/io/lettuce/core/cluster/api/ClusterCommandsFactory.java
@@ -1,0 +1,38 @@
+package io.lettuce.core.cluster.api;
+
+import java.util.function.Function;
+import io.lettuce.core.cluster.RedisAdvancedClusterReactiveCommandsImpl;
+import io.lettuce.core.cluster.RedisClusterPubSubReactiveCommandsImpl;
+import io.lettuce.core.cluster.StatefulRedisClusterConnectionImpl;
+import io.lettuce.core.cluster.StatefulRedisClusterPubSubConnectionImpl;
+import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
+import io.lettuce.core.cluster.pubsub.StatefulRedisClusterPubSubConnection;
+import io.lettuce.core.cluster.pubsub.api.reactive.RedisClusterPubSubReactiveCommands;
+
+public final class ClusterCommandsFactory {
+
+        private ClusterCommandsFactory() {
+        }
+
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        private static final Function<StatefulRedisClusterConnection<?, ?>, RedisAdvancedClusterReactiveCommands<?, ?>> REACTIVE_COMMANDS_PROVIDER = conn -> new RedisAdvancedClusterReactiveCommandsImpl(
+                        conn, conn.getCodec(), conn.getOptions().getJsonParser());
+
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        private static final Function<StatefulRedisClusterPubSubConnection<?, ?>, RedisClusterPubSubReactiveCommands<?, ?>> PUBSUB_REACTIVE_COMMANDS_PROVIDER = conn -> new RedisClusterPubSubReactiveCommandsImpl(
+                        conn, conn.getCodec());
+
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        public static <K, V> RedisAdvancedClusterReactiveCommands<K, V> reactive(StatefulRedisClusterConnection<K, V> conn) {
+                return (RedisAdvancedClusterReactiveCommands<K, V>) ((StatefulRedisClusterConnectionImpl) conn)
+                                .getCachedBySupplier(REACTIVE_COMMANDS_PROVIDER);
+        }
+
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        public static <K, V> RedisClusterPubSubReactiveCommands<K, V> pubsubReactive(
+                        StatefulRedisClusterPubSubConnection<K, V> conn) {
+                return (RedisClusterPubSubReactiveCommands<K, V>) ((StatefulRedisClusterPubSubConnectionImpl) conn)
+                                .getCachedBySupplier(PUBSUB_REACTIVE_COMMANDS_PROVIDER);
+        }
+
+}

--- a/src/main/java/io/lettuce/core/failover/StatefulRedisMultiDbConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/failover/StatefulRedisMultiDbConnectionImpl.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Proxy;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -18,6 +19,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -65,7 +67,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
  * @since 7.4
  */
 @Experimental
-class StatefulRedisMultiDbConnectionImpl<C extends StatefulRedisConnection<K, V>, K, V>
+public class StatefulRedisMultiDbConnectionImpl<C extends StatefulRedisConnection<K, V>, K, V>
         implements StatefulRedisMultiDbConnection<K, V> {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(StatefulRedisMultiDbConnectionImpl.class);
@@ -460,6 +462,18 @@ class StatefulRedisMultiDbConnectionImpl<C extends StatefulRedisConnection<K, V>
      */
     protected RedisAsyncCommandsImpl<K, V> newRedisAsyncCommandsImpl() {
         return new RedisAsyncCommandsImpl<>(this, codec, () -> this.getOptions().getJsonParser().get());
+    }
+
+    private Map<Function<StatefulRedisMultiDbConnection<K, V>, ?>, Object> cached = new HashMap<>();
+
+    public <T> T getCachedBySupplier(Function<StatefulRedisMultiDbConnection<K, V>, T> supplier) {
+        @SuppressWarnings("unchecked")
+        T t = (T) cached.get(supplier);
+        if (t == null) {
+            t = supplier.apply(this);
+            cached.put(supplier, t);
+        }
+        return t;
     }
 
     /**

--- a/src/main/java/io/lettuce/core/failover/StatefulRedisMultiDbConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/failover/StatefulRedisMultiDbConnectionImpl.java
@@ -5,7 +5,6 @@ import java.lang.reflect.Proxy;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -19,7 +18,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -53,6 +51,8 @@ import io.lettuce.core.failover.health.HealthStatusManager;
 import io.lettuce.core.internal.AbstractInvocationHandler;
 import io.lettuce.core.internal.Exceptions;
 import io.lettuce.core.internal.LettuceAssert;
+import io.lettuce.core.internal.SuppliedItemStore;
+import io.lettuce.core.internal.SupplierCaching;
 import io.lettuce.core.protocol.RedisCommand;
 import io.lettuce.core.resource.ClientResources;
 import io.netty.util.internal.logging.InternalLogger;
@@ -68,7 +68,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
  */
 @Experimental
 public class StatefulRedisMultiDbConnectionImpl<C extends StatefulRedisConnection<K, V>, K, V>
-        implements StatefulRedisMultiDbConnection<K, V> {
+        implements StatefulRedisMultiDbConnection<K, V>, SupplierCaching<StatefulRedisMultiDbConnection<K, V>> {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(StatefulRedisMultiDbConnectionImpl.class);
 
@@ -464,16 +464,11 @@ public class StatefulRedisMultiDbConnectionImpl<C extends StatefulRedisConnectio
         return new RedisAsyncCommandsImpl<>(this, codec, () -> this.getOptions().getJsonParser().get());
     }
 
-    private Map<Function<StatefulRedisMultiDbConnection<K, V>, ?>, Object> cached = new HashMap<>();
+    private final SuppliedItemStore<StatefulRedisMultiDbConnection<K, V>> commandsCache = new SuppliedItemStore<>(this);
 
-    public <T> T getCachedBySupplier(Function<StatefulRedisMultiDbConnection<K, V>, T> supplier) {
-        @SuppressWarnings("unchecked")
-        T t = (T) cached.get(supplier);
-        if (t == null) {
-            t = supplier.apply(this);
-            cached.put(supplier, t);
-        }
-        return t;
+    @Override
+    public SuppliedItemStore<StatefulRedisMultiDbConnection<K, V>> getStore() {
+        return commandsCache;
     }
 
     /**

--- a/src/main/java/io/lettuce/core/failover/StatefulRedisMultiDbPubSubConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/failover/StatefulRedisMultiDbPubSubConnectionImpl.java
@@ -31,7 +31,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
  * @since 7.4
  */
 @Experimental
-class StatefulRedisMultiDbPubSubConnectionImpl<K, V>
+public class StatefulRedisMultiDbPubSubConnectionImpl<K, V>
         extends StatefulRedisMultiDbConnectionImpl<StatefulRedisPubSubConnection<K, V>, K, V>
         implements StatefulRedisMultiDbPubSubConnection<K, V> {
 

--- a/src/main/java/io/lettuce/core/failover/api/MultiDbCommandsFactory.java
+++ b/src/main/java/io/lettuce/core/failover/api/MultiDbCommandsFactory.java
@@ -3,8 +3,7 @@ package io.lettuce.core.failover.api;
 import java.util.function.Function;
 import io.lettuce.core.RedisReactiveCommandsImpl;
 import io.lettuce.core.api.reactive.RedisReactiveCommands;
-import io.lettuce.core.failover.StatefulRedisMultiDbConnectionImpl;
-import io.lettuce.core.failover.StatefulRedisMultiDbPubSubConnectionImpl;
+import io.lettuce.core.internal.SupplierCaching;
 import io.lettuce.core.pubsub.RedisPubSubReactiveCommandsImpl;
 import io.lettuce.core.pubsub.api.reactive.RedisPubSubReactiveCommands;
 
@@ -23,13 +22,12 @@ public final class MultiDbCommandsFactory {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <K, V> RedisReactiveCommands<K, V> reactive(StatefulRedisMultiDbConnection<K, V> conn) {
-        return (RedisReactiveCommands<K, V>) ((StatefulRedisMultiDbConnectionImpl) conn)
-                .getCachedBySupplier(REACTIVE_COMMANDS_PROVIDER);
+        return (RedisReactiveCommands<K, V>) ((SupplierCaching) conn).getCachedBySupplier(REACTIVE_COMMANDS_PROVIDER);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <K, V> RedisPubSubReactiveCommands<K, V> pubsubReactive(StatefulRedisMultiDbPubSubConnection<K, V> conn) {
-        return (RedisPubSubReactiveCommands<K, V>) ((StatefulRedisMultiDbPubSubConnectionImpl) conn)
+        return (RedisPubSubReactiveCommands<K, V>) ((SupplierCaching) conn)
                 .getCachedBySupplier(PUBSUB_REACTIVE_COMMANDS_PROVIDER);
     }
 

--- a/src/main/java/io/lettuce/core/failover/api/MultiDbCommandsFactory.java
+++ b/src/main/java/io/lettuce/core/failover/api/MultiDbCommandsFactory.java
@@ -1,0 +1,36 @@
+package io.lettuce.core.failover.api;
+
+import java.util.function.Function;
+import io.lettuce.core.RedisReactiveCommandsImpl;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
+import io.lettuce.core.failover.StatefulRedisMultiDbConnectionImpl;
+import io.lettuce.core.failover.StatefulRedisMultiDbPubSubConnectionImpl;
+import io.lettuce.core.pubsub.RedisPubSubReactiveCommandsImpl;
+import io.lettuce.core.pubsub.api.reactive.RedisPubSubReactiveCommands;
+
+public final class MultiDbCommandsFactory {
+
+    private MultiDbCommandsFactory() {
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static final Function<StatefulRedisMultiDbConnection<?, ?>, RedisReactiveCommands<?, ?>> REACTIVE_COMMANDS_PROVIDER = conn -> new RedisReactiveCommandsImpl(
+            conn, conn.getCodec(), () -> conn.getOptions().getJsonParser().get());
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static final Function<StatefulRedisMultiDbPubSubConnection<?, ?>, RedisPubSubReactiveCommands<?, ?>> PUBSUB_REACTIVE_COMMANDS_PROVIDER = conn -> new RedisPubSubReactiveCommandsImpl(
+            conn, conn.getCodec());
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static <K, V> RedisReactiveCommands<K, V> reactive(StatefulRedisMultiDbConnection<K, V> conn) {
+        return (RedisReactiveCommands<K, V>) ((StatefulRedisMultiDbConnectionImpl) conn)
+                .getCachedBySupplier(REACTIVE_COMMANDS_PROVIDER);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static <K, V> RedisPubSubReactiveCommands<K, V> pubsubReactive(StatefulRedisMultiDbPubSubConnection<K, V> conn) {
+        return (RedisPubSubReactiveCommands<K, V>) ((StatefulRedisMultiDbPubSubConnectionImpl) conn)
+                .getCachedBySupplier(PUBSUB_REACTIVE_COMMANDS_PROVIDER);
+    }
+
+}

--- a/src/main/java/io/lettuce/core/internal/SuppliedItemStore.java
+++ b/src/main/java/io/lettuce/core/internal/SuppliedItemStore.java
@@ -22,12 +22,7 @@ public final class SuppliedItemStore<C> {
 
     @SuppressWarnings("unchecked")
     public <T> T get(Function<C, T> supplier) {
-        T t = (T) cache.get(supplier);
-        if (t == null) {
-            t = supplier.apply(owner);
-            cache.put(supplier, t);
-        }
-        return t;
+        return (T) cache.computeIfAbsent(supplier, s -> s.apply(owner));
     }
 
 }

--- a/src/main/java/io/lettuce/core/internal/SuppliedItemStore.java
+++ b/src/main/java/io/lettuce/core/internal/SuppliedItemStore.java
@@ -1,0 +1,33 @@
+package io.lettuce.core.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Memoizing cache keyed by a {@link Function} provider. Each provider is applied at most once against the cache owner; the
+ * resulting instance is then returned on subsequent lookups for the same provider.
+ *
+ * @param <C> the owner type passed to providers
+ */
+public final class SuppliedItemStore<C> {
+
+    private final C owner;
+
+    private final Map<Function<C, ?>, Object> cache = new HashMap<>();
+
+    public SuppliedItemStore(C owner) {
+        this.owner = owner;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T get(Function<C, T> supplier) {
+        T t = (T) cache.get(supplier);
+        if (t == null) {
+            t = supplier.apply(owner);
+            cache.put(supplier, t);
+        }
+        return t;
+    }
+
+}

--- a/src/main/java/io/lettuce/core/internal/SupplierCaching.java
+++ b/src/main/java/io/lettuce/core/internal/SupplierCaching.java
@@ -1,0 +1,18 @@
+package io.lettuce.core.internal;
+
+import java.util.function.Function;
+
+/**
+ * Mixin interface for types that expose a {@link SuppliedItemStore} to memoize derived instances.
+ *
+ * @param <C> the owner type passed to providers
+ */
+public interface SupplierCaching<C> {
+
+    SuppliedItemStore<C> getStore();
+
+    default <T> T getCachedBySupplier(Function<C, T> supplier) {
+        return getStore().get(supplier);
+    }
+
+}

--- a/src/main/java/io/lettuce/core/sentinel/StatefulRedisSentinelConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/sentinel/StatefulRedisSentinelConnectionImpl.java
@@ -21,6 +21,9 @@ package io.lettuce.core.sentinel;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import io.lettuce.core.ConnectionState;
@@ -107,6 +110,18 @@ public class StatefulRedisSentinelConnectionImpl<K, V> extends RedisChannelHandl
     @Override
     public RedisSentinelReactiveCommands<K, V> reactive() {
         return reactive;
+    }
+
+    private Map<Function<StatefulRedisSentinelConnection<K, V>, ?>, Object> cache = new HashMap<>();
+
+    public <T> T getCachedBySupplier(Function<StatefulRedisSentinelConnection<K, V>, T> supplier) {
+        @SuppressWarnings("unchecked")
+        T t = (T) cache.get(supplier);
+        if (t == null) {
+            t = supplier.apply(this);
+            cache.put(supplier, t);
+        }
+        return t;
     }
 
     /**

--- a/src/main/java/io/lettuce/core/sentinel/StatefulRedisSentinelConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/sentinel/StatefulRedisSentinelConnectionImpl.java
@@ -21,12 +21,11 @@ package io.lettuce.core.sentinel;
 
 import java.time.Duration;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import io.lettuce.core.ConnectionState;
+import io.lettuce.core.internal.SuppliedItemStore;
+import io.lettuce.core.internal.SupplierCaching;
 import io.lettuce.core.RedisChannelHandler;
 import io.lettuce.core.RedisChannelWriter;
 import io.lettuce.core.codec.RedisCodec;
@@ -45,7 +44,7 @@ import static io.lettuce.core.ClientOptions.DEFAULT_JSON_PARSER;
  * @author Mark Paluch
  */
 public class StatefulRedisSentinelConnectionImpl<K, V> extends RedisChannelHandler<K, V>
-        implements StatefulRedisSentinelConnection<K, V> {
+        implements StatefulRedisSentinelConnection<K, V>, SupplierCaching<StatefulRedisSentinelConnection<K, V>> {
 
     protected final RedisCodec<K, V> codec;
 
@@ -112,16 +111,11 @@ public class StatefulRedisSentinelConnectionImpl<K, V> extends RedisChannelHandl
         return reactive;
     }
 
-    private Map<Function<StatefulRedisSentinelConnection<K, V>, ?>, Object> cache = new HashMap<>();
+    private final SuppliedItemStore<StatefulRedisSentinelConnection<K, V>> commandsCache = new SuppliedItemStore<>(this);
 
-    public <T> T getCachedBySupplier(Function<StatefulRedisSentinelConnection<K, V>, T> supplier) {
-        @SuppressWarnings("unchecked")
-        T t = (T) cache.get(supplier);
-        if (t == null) {
-            t = supplier.apply(this);
-            cache.put(supplier, t);
-        }
-        return t;
+    @Override
+    public SuppliedItemStore<StatefulRedisSentinelConnection<K, V>> getStore() {
+        return commandsCache;
     }
 
     /**

--- a/src/main/java/io/lettuce/core/sentinel/api/SentinelCommandsFactory.java
+++ b/src/main/java/io/lettuce/core/sentinel/api/SentinelCommandsFactory.java
@@ -1,8 +1,8 @@
 package io.lettuce.core.sentinel.api;
 
 import java.util.function.Function;
+import io.lettuce.core.internal.SupplierCaching;
 import io.lettuce.core.sentinel.RedisSentinelReactiveCommandsImpl;
-import io.lettuce.core.sentinel.StatefulRedisSentinelConnectionImpl;
 import io.lettuce.core.sentinel.api.reactive.RedisSentinelReactiveCommands;
 
 public final class SentinelCommandsFactory {
@@ -16,8 +16,7 @@ public final class SentinelCommandsFactory {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <K, V> RedisSentinelReactiveCommands<K, V> reactive(StatefulRedisSentinelConnection<K, V> conn) {
-        return (RedisSentinelReactiveCommands<K, V>) ((StatefulRedisSentinelConnectionImpl) conn)
-                .getCachedBySupplier(REACTIVE_COMMANDS_PROVIDER);
+        return (RedisSentinelReactiveCommands<K, V>) ((SupplierCaching) conn).getCachedBySupplier(REACTIVE_COMMANDS_PROVIDER);
     }
 
 }

--- a/src/main/java/io/lettuce/core/sentinel/api/SentinelCommandsFactory.java
+++ b/src/main/java/io/lettuce/core/sentinel/api/SentinelCommandsFactory.java
@@ -1,0 +1,23 @@
+package io.lettuce.core.sentinel.api;
+
+import java.util.function.Function;
+import io.lettuce.core.sentinel.RedisSentinelReactiveCommandsImpl;
+import io.lettuce.core.sentinel.StatefulRedisSentinelConnectionImpl;
+import io.lettuce.core.sentinel.api.reactive.RedisSentinelReactiveCommands;
+
+public final class SentinelCommandsFactory {
+
+    private SentinelCommandsFactory() {
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static final Function<StatefulRedisSentinelConnection<?, ?>, RedisSentinelReactiveCommands<?, ?>> REACTIVE_COMMANDS_PROVIDER = conn -> new RedisSentinelReactiveCommandsImpl(
+            conn, conn.getCodec(), () -> conn.getOptions().getJsonParser().get());
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static <K, V> RedisSentinelReactiveCommands<K, V> reactive(StatefulRedisSentinelConnection<K, V> conn) {
+        return (RedisSentinelReactiveCommands<K, V>) ((StatefulRedisSentinelConnectionImpl) conn)
+                .getCachedBySupplier(REACTIVE_COMMANDS_PROVIDER);
+    }
+
+}


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches several core connection implementations and introduces a new caching path for reactive commands; `SuppliedItemStore` uses a non-concurrent `HashMap`, which may matter under concurrent factory use on a shared connection.
> 
> **Overview**
> Introduces **memoized command construction** on stateful connections via `SuppliedItemStore` and the `SupplierCaching` mixin, wired into standalone, cluster, sentinel, and multi-DB connection implementations.
> 
> Adds **`*CommandsFactory` helpers** (`RedisCommandsFactory`, `ClusterCommandsFactory`, `MultiDbCommandsFactory`, `SentinelCommandsFactory`) that return cached **reactive** (and pub/sub reactive) APIs using shared `Function` providers—building implementations from the connection’s codec and **current** `ClientOptions` JSON parser rather than only the constructor-time reactive field.
> 
> Also **widens visibility** of `StatefulRedisClusterPubSubConnectionImpl`, `StatefulRedisMultiDbConnectionImpl`, and `StatefulRedisMultiDbPubSubConnectionImpl` from package-private to `public`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50a0dbccb4131e7d3294ce907725cf03a597dff2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->