### PR TITLE
Add `connection.commands(factory)` accessor and deprecate `reactive()`

### DIFF
--- a/src/main/java/io/lettuce/core/RedisChannelHandler.java
+++ b/src/main/java/io/lettuce/core/RedisChannelHandler.java
@@ -13,6 +13,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import io.lettuce.core.api.AsyncCloseable;
 import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.internal.LettuceAssert;
+import io.lettuce.core.internal.Store;
 import io.lettuce.core.protocol.CommandExpiryWriter;
 import io.lettuce.core.protocol.CommandWrapper;
 import io.lettuce.core.protocol.ConnectionFacade;
@@ -56,6 +57,8 @@ public abstract class RedisChannelHandler<K, V> implements Closeable, Connection
     private final boolean tracingEnabled;
 
     private final boolean debugEnabled = logger.isDebugEnabled();
+
+    protected final Store store = new Store();
 
     private final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
 

--- a/src/main/java/io/lettuce/core/StatefulRedisConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/StatefulRedisConnectionImpl.java
@@ -30,7 +30,9 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import io.lettuce.core.api.CommandsFactory;
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.internal.LettuceAssert;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.api.push.PushListener;
 import io.lettuce.core.api.reactive.RedisReactiveCommands;
@@ -42,7 +44,6 @@ import io.lettuce.core.json.JsonParser;
 import io.lettuce.core.output.MultiOutput;
 import io.lettuce.core.output.StatusOutput;
 import io.lettuce.core.protocol.*;
-import reactor.core.publisher.Mono;
 
 /**
  * A thread-safe connection to a Redis server. Multiple threads may share one {@link StatefulRedisConnectionImpl}
@@ -62,6 +63,11 @@ public class StatefulRedisConnectionImpl<K, V> extends RedisChannelHandler<K, V>
 
     protected final RedisAsyncCommandsImpl<K, V> async;
 
+    /**
+     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisReactiveCommands#factory()} instead; scheduled for
+     *             removal in Lettuce 8.0.
+     */
+    @Deprecated
     protected final RedisReactiveCommandsImpl<K, V> reactive;
 
     private final ConnectionState state = new ConnectionState();
@@ -115,6 +121,12 @@ public class StatefulRedisConnectionImpl<K, V> extends RedisChannelHandler<K, V>
     }
 
     @Override
+    public <T> T commands(CommandsFactory<StatefulRedisConnection<K, V>, T> f) {
+        LettuceAssert.notNull(f, "CommandsFactory must not be null");
+        return store.compute(f.key(), () -> f.apply(this));
+    }
+
+    @Override
     public RedisAsyncCommands<K, V> async() {
         return async;
     }
@@ -137,6 +149,11 @@ public class StatefulRedisConnectionImpl<K, V> extends RedisChannelHandler<K, V>
         return new RedisAsyncCommandsImpl<>(this, codec, parser);
     }
 
+    /**
+     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisReactiveCommands#factory()} instead; scheduled for
+     *             removal in Lettuce 8.0.
+     */
+    @Deprecated
     @Override
     public RedisReactiveCommands<K, V> reactive() {
         return reactive;
@@ -146,7 +163,10 @@ public class StatefulRedisConnectionImpl<K, V> extends RedisChannelHandler<K, V>
      * Create a new instance of {@link RedisReactiveCommandsImpl}. Can be overriden to extend.
      *
      * @return a new instance
+     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisReactiveCommands#factory()} instead; scheduled for
+     *             removal in Lettuce 8.0.
      */
+    @Deprecated
     protected RedisReactiveCommandsImpl<K, V> newRedisReactiveCommandsImpl() {
         return new RedisReactiveCommandsImpl<>(this, codec, parser);
     }

--- a/src/main/java/io/lettuce/core/api/ClusterPubSubCommandsFactory.java
+++ b/src/main/java/io/lettuce/core/api/ClusterPubSubCommandsFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026-Present, Redis Ltd. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+package io.lettuce.core.api;
+
+import java.util.function.Function;
+
+import io.lettuce.core.cluster.pubsub.StatefulRedisClusterPubSubConnection;
+
+/**
+ * A {@link CommandsFactory} that creates a command API bound to a {@link StatefulRedisClusterPubSubConnection Cluster Pub/Sub
+ * connection}, for use with {@link StatefulRedisClusterPubSubConnection#commands(ClusterPubSubCommandsFactory)}.
+ *
+ * @param <C> the Cluster Pub/Sub connection type this factory accepts
+ * @param <T> the command API type this factory creates
+ * @author Aleksandar Todorov
+ * @since 7.7
+ */
+public interface ClusterPubSubCommandsFactory<C extends StatefulRedisClusterPubSubConnection<?, ?>, T>
+        extends PubSubCommandsFactory<C, T> {
+
+    /**
+     * Creates a {@code ClusterPubSubCommandsFactory} from a cache {@code key} and a {@code builder}.
+     *
+     * @param key the cache key, see {@link #key()}
+     * @param builder creates the command API from a Cluster Pub/Sub connection
+     * @param <C> the Cluster Pub/Sub connection type
+     * @param <T> the command API type
+     * @return a new factory
+     */
+    static <C extends StatefulRedisClusterPubSubConnection<?, ?>, T> ClusterPubSubCommandsFactory<C, T> of(Object key,
+            Function<C, T> builder) {
+        return new ClusterPubSubCommandsFactory<C, T>() {
+
+            @Override
+            public Object key() {
+                return key;
+            }
+
+            @Override
+            public T apply(C connection) {
+                return builder.apply(connection);
+            }
+
+        };
+    }
+
+}

--- a/src/main/java/io/lettuce/core/api/CommandsFactory.java
+++ b/src/main/java/io/lettuce/core/api/CommandsFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026-Present, Redis Ltd. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+package io.lettuce.core.api;
+
+import java.util.function.Function;
+
+/**
+ * Creates a command API bound to a connection, for use with {@link StatefulRedisConnection#commands(CommandsFactory)}. A
+ * command API that can be obtained this way provides a static {@code factory()} method that returns its
+ * {@code CommandsFactory}; alternatively, build one with {@link #of(Object, Function)}.
+ *
+ * @param <C> the connection type this factory accepts
+ * @param <T> the command API type this factory creates
+ * @author Aleksandar Todorov
+ * @since 7.7
+ */
+public interface CommandsFactory<C, T> extends Function<C, T> {
+
+    /**
+     * Returns the key under which the created command API is cached on the connection. A connection holds one instance per key.
+     *
+     * @return the cache key
+     */
+    Object key();
+
+    /**
+     * Creates a {@code CommandsFactory} from a cache {@code key} and a {@code builder}.
+     *
+     * @param key the cache key, see {@link #key()}
+     * @param builder creates the command API from a connection
+     * @param <C> the connection type
+     * @param <T> the command API type
+     * @return a new factory
+     */
+    static <C, T> CommandsFactory<C, T> of(Object key, Function<C, T> builder) {
+        return new CommandsFactory<C, T>() {
+
+            @Override
+            public Object key() {
+                return key;
+            }
+
+            @Override
+            public T apply(C connection) {
+                return builder.apply(connection);
+            }
+
+        };
+    }
+
+}

--- a/src/main/java/io/lettuce/core/api/PubSubCommandsFactory.java
+++ b/src/main/java/io/lettuce/core/api/PubSubCommandsFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026-Present, Redis Ltd. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+package io.lettuce.core.api;
+
+import java.util.function.Function;
+
+import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
+
+/**
+ * A {@link CommandsFactory} that creates a command API bound to a {@link StatefulRedisPubSubConnection Pub/Sub connection}, for
+ * use with {@link StatefulRedisPubSubConnection#commands(PubSubCommandsFactory)}.
+ *
+ * @param <C> the Pub/Sub connection type this factory accepts
+ * @param <T> the command API type this factory creates
+ * @author Aleksandar Todorov
+ * @since 7.7
+ */
+public interface PubSubCommandsFactory<C extends StatefulRedisPubSubConnection<?, ?>, T> extends CommandsFactory<C, T> {
+
+    /**
+     * Creates a {@code PubSubCommandsFactory} from a cache {@code key} and a {@code builder}.
+     *
+     * @param key the cache key, see {@link #key()}
+     * @param builder creates the command API from a Pub/Sub connection
+     * @param <C> the Pub/Sub connection type
+     * @param <T> the command API type
+     * @return a new factory
+     */
+    static <C extends StatefulRedisPubSubConnection<?, ?>, T> PubSubCommandsFactory<C, T> of(Object key,
+            Function<C, T> builder) {
+        return new PubSubCommandsFactory<C, T>() {
+
+            @Override
+            public Object key() {
+                return key;
+            }
+
+            @Override
+            public T apply(C connection) {
+                return builder.apply(connection);
+            }
+
+        };
+    }
+
+}

--- a/src/main/java/io/lettuce/core/api/StatefulRedisConnection.java
+++ b/src/main/java/io/lettuce/core/api/StatefulRedisConnection.java
@@ -27,6 +27,9 @@ public interface StatefulRedisConnection<K, V> extends StatefulConnection<K, V> 
 
     /**
      * Returns the {@link RedisCommands} API for the current connection. Does not create a new connection.
+     * <p>
+     * Note: this accessor is scheduled for removal in a future major release; a {@code commands(...)}-based replacement is
+     * planned.
      *
      * @return the synchronous API for the underlying connection.
      */
@@ -34,6 +37,9 @@ public interface StatefulRedisConnection<K, V> extends StatefulConnection<K, V> 
 
     /**
      * Returns the {@link RedisAsyncCommands} API for the current connection. Does not create a new connection.
+     * <p>
+     * Note: this accessor is scheduled for removal in a future major release; a {@code commands(...)}-based replacement is
+     * planned.
      *
      * @return the asynchronous API for the underlying connection.
      */
@@ -43,7 +49,10 @@ public interface StatefulRedisConnection<K, V> extends StatefulConnection<K, V> 
      * Returns the {@link RedisReactiveCommands} API for the current connection. Does not create a new connection.
      *
      * @return the reactive API for the underlying connection.
+     * @deprecated since 7.7, use {@link #commands(CommandsFactory)} with {@link RedisReactiveCommands#factory()} instead;
+     *             scheduled for removal in Lettuce 8.0.
      */
+    @Deprecated
     RedisReactiveCommands<K, V> reactive();
 
     /**
@@ -61,5 +70,18 @@ public interface StatefulRedisConnection<K, V> extends StatefulConnection<K, V> 
      * @since 6.0
      */
     void removeListener(PushListener listener);
+
+    /**
+     * Returns the command API created by {@code factory}, bound to this connection. Does not create a new connection.
+     * <p>
+     * The command API is created once per connection and cached; calling this method again with the same {@code factory}
+     * returns the same instance.
+     *
+     * @param factory the command API factory, must not be {@code null}
+     * @param <T> the command API type
+     * @return the command API bound to this connection
+     * @since 7.7
+     */
+    <T> T commands(CommandsFactory<StatefulRedisConnection<K, V>, T> factory);
 
 }

--- a/src/main/java/io/lettuce/core/api/reactive/RedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/api/reactive/RedisReactiveCommands.java
@@ -19,6 +19,8 @@
  */
 package io.lettuce.core.api.reactive;
 
+import io.lettuce.core.RedisReactiveCommandsImpl;
+import io.lettuce.core.api.CommandsFactory;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.cluster.api.reactive.RedisClusterReactiveCommands;
 import reactor.core.publisher.Mono;
@@ -83,5 +85,43 @@ public interface RedisReactiveCommands<K, V>
      */
     @Deprecated
     StatefulRedisConnection<K, V> getStatefulConnection();
+
+    /**
+     * Returns the {@link CommandsFactory} that creates {@link RedisReactiveCommands}, for use with
+     * {@link io.lettuce.core.api.StatefulRedisConnection#commands(CommandsFactory)}:
+     *
+     * <pre>
+     * 
+     * {
+     *     &#64;code
+     *     RedisReactiveCommands<K, V> reactive = connection.commands(RedisReactiveCommands.factory());
+     * }
+     * </pre>
+     *
+     * @param <K> Key type
+     * @param <V> Value type
+     * @return the factory that creates {@link RedisReactiveCommands}
+     * @since 7.7
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    static <K, V> CommandsFactory<StatefulRedisConnection<K, V>, RedisReactiveCommands<K, V>> factory() {
+        return (CommandsFactory) FactoryHolder.INSTANCE;
+    }
+
+    /**
+     * Holds the singleton factory so {@link #factory()} returns one shared instance (no per-call allocation); {@code factory()}
+     * re-applies {@code <K, V>}.
+     */
+    final class FactoryHolder {
+
+        private FactoryHolder() {
+        }
+
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        private static final CommandsFactory INSTANCE = CommandsFactory.of(RedisReactiveCommands.class,
+                (StatefulRedisConnection c) -> new RedisReactiveCommandsImpl(c, c.getCodec(),
+                        () -> c.getOptions().getJsonParser().get()));
+
+    }
 
 }

--- a/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterConnectionImpl.java
@@ -42,6 +42,7 @@ import io.lettuce.core.RedisChannelWriter;
 import io.lettuce.core.RedisException;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.CommandsFactory;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.api.async.RedisAdvancedClusterAsyncCommands;
 import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
@@ -60,7 +61,6 @@ import io.lettuce.core.protocol.CompleteableCommand;
 import io.lettuce.core.protocol.ConnectionIntent;
 import io.lettuce.core.protocol.ConnectionWatchdog;
 import io.lettuce.core.protocol.RedisCommand;
-import reactor.core.publisher.Mono;
 
 /**
  * A thread-safe connection to a Redis Cluster. Multiple threads may share one {@link StatefulRedisClusterConnectionImpl}
@@ -84,6 +84,11 @@ public class StatefulRedisClusterConnectionImpl<K, V> extends RedisChannelHandle
 
     protected final RedisAdvancedClusterAsyncCommandsImpl<K, V> async;
 
+    /**
+     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisAdvancedClusterReactiveCommands#factory()} instead;
+     *             scheduled for removal in Lettuce 8.0.
+     */
+    @Deprecated
     protected final RedisAdvancedClusterReactiveCommandsImpl<K, V> reactive;
 
     private final ClusterConnectionState connectionState = new ClusterConnectionState();
@@ -131,6 +136,12 @@ public class StatefulRedisClusterConnectionImpl<K, V> extends RedisChannelHandle
         return codec;
     }
 
+    @Override
+    public <T> T commands(CommandsFactory<StatefulRedisClusterConnection<K, V>, T> f) {
+        LettuceAssert.notNull(f, "CommandsFactory must not be null");
+        return store.compute(f.key(), () -> f.apply(this));
+    }
+
     protected RedisAdvancedClusterReactiveCommandsImpl<K, V> newRedisAdvancedClusterReactiveCommandsImpl() {
         return new RedisAdvancedClusterReactiveCommandsImpl<>((StatefulRedisClusterConnection<K, V>) this, codec, parser);
     }
@@ -162,6 +173,11 @@ public class StatefulRedisClusterConnectionImpl<K, V> extends RedisChannelHandle
         return async;
     }
 
+    /**
+     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisAdvancedClusterReactiveCommands#factory()} instead;
+     *             scheduled for removal in Lettuce 8.0.
+     */
+    @Deprecated
     @Override
     public RedisAdvancedClusterReactiveCommands<K, V> reactive() {
         return reactive;

--- a/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterPubSubConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterPubSubConnectionImpl.java
@@ -32,6 +32,7 @@ import io.lettuce.core.RedisException;
 import io.lettuce.core.RedisFuture;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.cluster.api.push.RedisClusterPushListener;
+import io.lettuce.core.api.ClusterPubSubCommandsFactory;
 import io.lettuce.core.cluster.models.partitions.Partitions;
 import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
 import io.lettuce.core.cluster.pubsub.RedisClusterPubSubListener;
@@ -110,11 +111,21 @@ class StatefulRedisClusterPubSubConnectionImpl<K, V> extends StatefulRedisPubSub
                 NodeSelectionPubSubCommands.class, async());
     }
 
+    /**
+     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisClusterPubSubReactiveCommands#factory()} instead;
+     *             scheduled for removal in Lettuce 8.0.
+     */
+    @Deprecated
     @Override
     public RedisClusterPubSubReactiveCommands<K, V> reactive() {
         return (RedisClusterPubSubReactiveCommands<K, V>) super.reactive();
     }
 
+    /**
+     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisClusterPubSubReactiveCommands#factory()} instead;
+     *             scheduled for removal in Lettuce 8.0.
+     */
+    @Deprecated
     @Override
     protected RedisPubSubReactiveCommandsImpl<K, V> newRedisReactiveCommandsImpl() {
         return new RedisClusterPubSubReactiveCommandsImpl<K, V>(this, codec);
@@ -271,6 +282,12 @@ class StatefulRedisClusterPubSubConnectionImpl<K, V> extends StatefulRedisPubSub
 
         ClientOptions options = getOptions();
         return options instanceof ClusterClientOptions ? (ClusterClientOptions) options : null;
+    }
+
+    @Override
+    public <T> T commands(ClusterPubSubCommandsFactory<StatefulRedisClusterPubSubConnection<K, V>, T> factory) {
+        LettuceAssert.notNull(factory, "CommandsFactory must not be null");
+        return store.compute(factory.key(), () -> factory.apply(this));
     }
 
 }

--- a/src/main/java/io/lettuce/core/cluster/api/StatefulRedisClusterConnection.java
+++ b/src/main/java/io/lettuce/core/cluster/api/StatefulRedisClusterConnection.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import io.lettuce.core.ReadFrom;
 import io.lettuce.core.RedisChannelWriter;
 import io.lettuce.core.RedisException;
+import io.lettuce.core.api.CommandsFactory;
 import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.cluster.ClusterClientOptions;
@@ -47,6 +48,9 @@ public interface StatefulRedisClusterConnection<K, V> extends StatefulConnection
 
     /**
      * Returns the {@link RedisAdvancedClusterCommands} API for the current connection. Does not create a new connection.
+     * <p>
+     * Note: this accessor is scheduled for removal in a future major release; a {@code commands(...)}-based replacement is
+     * planned.
      *
      * @return the synchronous API for the underlying connection.
      */
@@ -54,6 +58,9 @@ public interface StatefulRedisClusterConnection<K, V> extends StatefulConnection
 
     /**
      * Returns the {@link RedisAdvancedClusterAsyncCommands} API for the current connection. Does not create a new connection.
+     * <p>
+     * Note: this accessor is scheduled for removal in a future major release; a {@code commands(...)}-based replacement is
+     * planned.
      *
      * @return the asynchronous API for the underlying connection.
      */
@@ -64,7 +71,10 @@ public interface StatefulRedisClusterConnection<K, V> extends StatefulConnection
      * connection.
      *
      * @return the reactive API for the underlying connection.
+     * @deprecated since 7.7, use {@link #commands(CommandsFactory)} with {@link RedisAdvancedClusterReactiveCommands#factory()}
+     *             instead; scheduled for removal in Lettuce 8.0.
      */
+    @Deprecated
     RedisAdvancedClusterReactiveCommands<K, V> reactive();
 
     /**
@@ -284,5 +294,18 @@ public interface StatefulRedisClusterConnection<K, V> extends StatefulConnection
      * @since 6.0
      */
     void removeListener(RedisClusterPushListener listener);
+
+    /**
+     * Returns the command API created by {@code factory}, bound to this connection. Does not create a new connection.
+     * <p>
+     * The command API is created once per connection and cached; calling this method again with the same {@code factory}
+     * returns the same instance.
+     *
+     * @param factory the command API factory, must not be {@code null}
+     * @param <T> the command API type
+     * @return the command API bound to this connection
+     * @since 7.7
+     */
+    <T> T commands(CommandsFactory<StatefulRedisClusterConnection<K, V>, T> factory);
 
 }

--- a/src/main/java/io/lettuce/core/cluster/api/reactive/RedisAdvancedClusterReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/api/reactive/RedisAdvancedClusterReactiveCommands.java
@@ -33,8 +33,10 @@ import io.lettuce.core.StreamScanCursor;
 import io.lettuce.core.api.reactive.RedisKeyReactiveCommands;
 import io.lettuce.core.api.reactive.RedisScriptingReactiveCommands;
 import io.lettuce.core.api.reactive.RedisServerReactiveCommands;
+import io.lettuce.core.api.CommandsFactory;
 import io.lettuce.core.api.reactive.RedisStringReactiveCommands;
 import io.lettuce.core.cluster.ClusterClientOptions;
+import io.lettuce.core.cluster.RedisAdvancedClusterReactiveCommandsImpl;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.output.KeyStreamingChannel;
 
@@ -367,5 +369,44 @@ public interface RedisAdvancedClusterReactiveCommands<K, V> extends RedisCluster
      * @return Long integer-reply the number of found keys.
      */
     Mono<Long> touch(K... keys);
+
+    /**
+     * Returns the {@link CommandsFactory} that creates {@link RedisAdvancedClusterReactiveCommands}, for use with
+     * {@link io.lettuce.core.cluster.api.StatefulRedisClusterConnection#commands(CommandsFactory)}:
+     *
+     * <pre>
+     * 
+     * {
+     *     &#64;code
+     *     RedisAdvancedClusterReactiveCommands<K, V> reactive = connection
+     *             .commands(RedisAdvancedClusterReactiveCommands.factory());
+     * }
+     * </pre>
+     *
+     * @param <K> Key type
+     * @param <V> Value type
+     * @return the factory that creates {@link RedisAdvancedClusterReactiveCommands}
+     * @since 7.7
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    static <K, V> CommandsFactory<StatefulRedisClusterConnection<K, V>, RedisAdvancedClusterReactiveCommands<K, V>> factory() {
+        return (CommandsFactory) FactoryHolder.INSTANCE;
+    }
+
+    /**
+     * Holds the singleton factory so {@link #factory()} returns one shared instance (no per-call allocation); {@code factory()}
+     * re-applies {@code <K, V>}.
+     */
+    final class FactoryHolder {
+
+        private FactoryHolder() {
+        }
+
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        private static final CommandsFactory INSTANCE = CommandsFactory.of(RedisAdvancedClusterReactiveCommands.class,
+                (StatefulRedisClusterConnection c) -> new RedisAdvancedClusterReactiveCommandsImpl(c, c.getCodec(),
+                        () -> c.getOptions().getJsonParser().get()));
+
+    }
 
 }

--- a/src/main/java/io/lettuce/core/cluster/pubsub/StatefulRedisClusterPubSubConnection.java
+++ b/src/main/java/io/lettuce/core/cluster/pubsub/StatefulRedisClusterPubSubConnection.java
@@ -4,6 +4,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
 import io.lettuce.core.RedisException;
+import io.lettuce.core.api.ClusterPubSubCommandsFactory;
 import io.lettuce.core.cluster.ClusterClientOptions;
 import io.lettuce.core.cluster.api.push.RedisClusterPushListener;
 import io.lettuce.core.cluster.api.sync.NodeSelection;
@@ -60,6 +61,9 @@ public interface StatefulRedisClusterPubSubConnection<K, V> extends StatefulRedi
 
     /**
      * Returns the {@link RedisClusterPubSubCommands} API for the current connection. Does not create a new connection.
+     * <p>
+     * Note: this accessor is scheduled for removal in a future major release; a {@code commands(...)}-based replacement is
+     * planned.
      *
      * @return the synchronous API for the underlying connection.
      */
@@ -67,6 +71,9 @@ public interface StatefulRedisClusterPubSubConnection<K, V> extends StatefulRedi
 
     /**
      * Returns the {@link RedisClusterPubSubAsyncCommands} API for the current connection. Does not create a new connection.
+     * <p>
+     * Note: this accessor is scheduled for removal in a future major release; a {@code commands(...)}-based replacement is
+     * planned.
      *
      * @return the asynchronous API for the underlying connection.
      */
@@ -76,7 +83,10 @@ public interface StatefulRedisClusterPubSubConnection<K, V> extends StatefulRedi
      * Returns the {@link RedisClusterPubSubReactiveCommands} API for the current connection. Does not create a new connection.
      *
      * @return the reactive API for the underlying connection.
+     * @deprecated since 7.7, use {@link #commands(ClusterPubSubCommandsFactory)} with
+     *             {@link RedisClusterPubSubReactiveCommands#factory()} instead; scheduled for removal in Lettuce 8.0.
      */
+    @Deprecated
     RedisClusterPubSubReactiveCommands<K, V> reactive();
 
     /**
@@ -188,5 +198,18 @@ public interface StatefulRedisClusterPubSubConnection<K, V> extends StatefulRedi
      * @since 6.0
      */
     void removeListener(RedisClusterPushListener listener);
+
+    /**
+     * Returns the command API created by {@code factory}, bound to this connection. Does not create a new connection.
+     * <p>
+     * The command API is created once per connection and cached; calling this method again with the same {@code factory}
+     * returns the same instance.
+     *
+     * @param factory the command API factory, must not be {@code null}
+     * @param <T> the command API type
+     * @return the command API bound to this connection
+     * @since 7.7
+     */
+    <T> T commands(ClusterPubSubCommandsFactory<StatefulRedisClusterPubSubConnection<K, V>, T> factory);
 
 }

--- a/src/main/java/io/lettuce/core/cluster/pubsub/api/reactive/RedisClusterPubSubReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/cluster/pubsub/api/reactive/RedisClusterPubSubReactiveCommands.java
@@ -2,6 +2,8 @@ package io.lettuce.core.cluster.pubsub.api.reactive;
 
 import java.util.function.Predicate;
 
+import io.lettuce.core.api.ClusterPubSubCommandsFactory;
+import io.lettuce.core.cluster.RedisClusterPubSubReactiveCommandsImpl;
 import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
 import io.lettuce.core.cluster.pubsub.StatefulRedisClusterPubSubConnection;
 import io.lettuce.core.pubsub.api.reactive.RedisPubSubReactiveCommands;
@@ -106,5 +108,44 @@ public interface RedisClusterPubSubReactiveCommands<K, V> extends RedisPubSubRea
      * @return API with reactive executed commands on a selection of cluster nodes matching {@code predicate}
      */
     PubSubReactiveNodeSelection<K, V> nodes(Predicate<RedisClusterNode> predicate);
+
+    /**
+     * Returns the {@link ClusterPubSubCommandsFactory} that creates {@link RedisClusterPubSubReactiveCommands}, for use with
+     * {@link io.lettuce.core.cluster.pubsub.StatefulRedisClusterPubSubConnection#commands(ClusterPubSubCommandsFactory)}:
+     *
+     * <pre>
+     * 
+     * {
+     *     &#64;code
+     *     RedisClusterPubSubReactiveCommands<K, V> reactive = connection
+     *             .commands(RedisClusterPubSubReactiveCommands.factory());
+     * }
+     * </pre>
+     *
+     * @param <K> Key type
+     * @param <V> Value type
+     * @return the factory that creates {@link RedisClusterPubSubReactiveCommands}
+     * @since 7.7
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    static <K, V> ClusterPubSubCommandsFactory<StatefulRedisClusterPubSubConnection<K, V>, RedisClusterPubSubReactiveCommands<K, V>> factory() {
+        return (ClusterPubSubCommandsFactory) FactoryHolder.INSTANCE;
+    }
+
+    /**
+     * Holds the singleton factory so {@link #factory()} returns one shared instance (no per-call allocation); {@code factory()}
+     * re-applies {@code <K, V>}.
+     */
+    final class FactoryHolder {
+
+        private FactoryHolder() {
+        }
+
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        private static final ClusterPubSubCommandsFactory INSTANCE = ClusterPubSubCommandsFactory.of(
+                RedisClusterPubSubReactiveCommands.class,
+                (StatefulRedisClusterPubSubConnection c) -> new RedisClusterPubSubReactiveCommandsImpl(c, c.getCodec()));
+
+    }
 
 }

--- a/src/main/java/io/lettuce/core/failover/StatefulRedisMultiDbConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/failover/StatefulRedisMultiDbConnectionImpl.java
@@ -30,6 +30,7 @@ import io.lettuce.core.RedisConnectionStateListener;
 import io.lettuce.core.RedisReactiveCommandsImpl;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.annotations.Experimental;
+import io.lettuce.core.api.CommandsFactory;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.api.push.PushListener;
@@ -51,6 +52,7 @@ import io.lettuce.core.failover.health.HealthStatusManager;
 import io.lettuce.core.internal.AbstractInvocationHandler;
 import io.lettuce.core.internal.Exceptions;
 import io.lettuce.core.internal.LettuceAssert;
+import io.lettuce.core.internal.Store;
 import io.lettuce.core.protocol.RedisCommand;
 import io.lettuce.core.resource.ClientResources;
 import io.netty.util.internal.logging.InternalLogger;
@@ -81,9 +83,16 @@ class StatefulRedisMultiDbConnectionImpl<C extends StatefulRedisConnection<K, V>
 
     protected final RedisAsyncCommandsImpl<K, V> async;
 
+    /**
+     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisReactiveCommands#factory()} instead; scheduled for
+     *             removal in Lettuce 8.0.
+     */
+    @Deprecated
     protected final RedisReactiveCommandsImpl<K, V> reactive;
 
     protected final RedisCodec<K, V> codec;
+
+    protected final Store store = new Store();
 
     protected final Set<PushListener> pushListeners = ConcurrentHashMap.newKeySet();
 
@@ -466,7 +475,10 @@ class StatefulRedisMultiDbConnectionImpl<C extends StatefulRedisConnection<K, V>
      * Returns the reactive API. The API is a dynamic proxy that remains valid across database switches.
      *
      * @return the reactive commands API.
+     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisReactiveCommands#factory()} instead; scheduled for
+     *             removal in Lettuce 8.0.
      */
+    @Deprecated
     @Override
     public RedisReactiveCommands<K, V> reactive() {
         return reactive;
@@ -476,7 +488,10 @@ class StatefulRedisMultiDbConnectionImpl<C extends StatefulRedisConnection<K, V>
      * Create a new instance of {@link RedisReactiveCommandsImpl}. Can be overridden to extend.
      *
      * @return a new instance
+     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisReactiveCommands#factory()} instead; scheduled for
+     *             removal in Lettuce 8.0.
      */
+    @Deprecated
     protected RedisReactiveCommandsImpl<K, V> newRedisReactiveCommandsImpl() {
         return new RedisReactiveCommandsImpl<>(this, codec, () -> this.getOptions().getJsonParser().get());
     }
@@ -713,6 +728,11 @@ class StatefulRedisMultiDbConnectionImpl<C extends StatefulRedisConnection<K, V>
     @Override
     public RedisCodec<K, V> getCodec() {
         return codec;
+    }
+
+    @Override
+    public <T> T commands(CommandsFactory<StatefulRedisConnection<K, V>, T> f) {
+        return store.compute(f.key(), () -> f.apply(this));
     }
 
     /**

--- a/src/main/java/io/lettuce/core/failover/StatefulRedisMultiDbPubSubConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/failover/StatefulRedisMultiDbPubSubConnectionImpl.java
@@ -10,7 +10,9 @@ import java.util.function.Function;
 import io.lettuce.core.RedisFuture;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.annotations.Experimental;
+import io.lettuce.core.api.PubSubCommandsFactory;
 import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.internal.LettuceAssert;
 import io.lettuce.core.failover.api.MultiDbOptions;
 import io.lettuce.core.failover.api.StatefulRedisMultiDbPubSubConnection;
 import io.lettuce.core.failover.event.SwitchReason;
@@ -61,6 +63,12 @@ class StatefulRedisMultiDbPubSubConnectionImpl<K, V>
     }
 
     @Override
+    public <T> T commands(PubSubCommandsFactory<StatefulRedisPubSubConnection<K, V>, T> factory) {
+        LettuceAssert.notNull(factory, "CommandsFactory must not be null");
+        return store.compute(factory.key(), () -> factory.apply(this));
+    }
+
+    @Override
     public void addListener(RedisPubSubListener<K, V> listener) {
         doBySharedLock(() -> {
             pubSubListeners.add(listener);
@@ -97,12 +105,22 @@ class StatefulRedisMultiDbPubSubConnectionImpl<K, V>
         return syncHandler(async(), RedisPubSubCommands.class);
     }
 
+    /**
+     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisPubSubReactiveCommands#factory()} instead; scheduled
+     *             for removal in Lettuce 8.0.
+     */
+    @Deprecated
     @Override
     @SuppressWarnings("unchecked")
     public RedisPubSubReactiveCommands<K, V> reactive() {
         return (RedisPubSubReactiveCommands<K, V>) reactive;
     }
 
+    /**
+     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisPubSubReactiveCommands#factory()} instead; scheduled
+     *             for removal in Lettuce 8.0.
+     */
+    @Deprecated
     @Override
     protected RedisPubSubReactiveCommandsImpl<K, V> newRedisReactiveCommandsImpl() {
         return new RedisPubSubReactiveCommandsImpl<>(this, codec);

--- a/src/main/java/io/lettuce/core/internal/Store.java
+++ b/src/main/java/io/lettuce/core/internal/Store.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026-Present, Redis Ltd. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+package io.lettuce.core.internal;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+/**
+ * A thread-safe, lazily-populated cache keyed by an opaque {@link Object}. The value for a key is built on its first access and
+ * reused for every subsequent access with that key.
+ * <p>
+ * Each connection holds one {@code Store} to cache the command APIs created through its {@code commands(...)} accessors, so a
+ * given factory key yields a single instance per connection.
+ *
+ * @author Aleksandar Todorov
+ * @since 7.7
+ */
+public final class Store {
+
+    private final Map<Object, Object> store = new ConcurrentHashMap<>();
+
+    /**
+     * Returns the value cached under {@code key}, building it via {@code builder} on first access. The builder runs at most
+     * once per key.
+     *
+     * @param key the cache key
+     * @param builder builds the value on a cache miss
+     * @param <T> the value type
+     * @return the cached or newly built value
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T compute(Object key, Supplier<T> builder) {
+        return (T) store.computeIfAbsent(key, k -> builder.get());
+    }
+
+}

--- a/src/main/java/io/lettuce/core/masterslave/MasterSlaveConnectionWrapper.java
+++ b/src/main/java/io/lettuce/core/masterslave/MasterSlaveConnectionWrapper.java
@@ -7,6 +7,8 @@ import java.util.concurrent.CompletableFuture;
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.ReadFrom;
 import io.lettuce.core.RedisConnectionStateListener;
+import io.lettuce.core.api.CommandsFactory;
+import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.api.push.PushListener;
 import io.lettuce.core.api.reactive.RedisReactiveCommands;
@@ -55,6 +57,11 @@ class MasterSlaveConnectionWrapper<K, V> implements StatefulRedisMasterSlaveConn
         return delegate.async();
     }
 
+    /**
+     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisReactiveCommands#factory()} instead; scheduled for
+     *             removal in Lettuce 8.0.
+     */
+    @Deprecated
     @Override
     public RedisReactiveCommands<K, V> reactive() {
         return delegate.reactive();
@@ -133,6 +140,11 @@ class MasterSlaveConnectionWrapper<K, V> implements StatefulRedisMasterSlaveConn
     @Override
     public void flushCommands() {
         delegate.flushCommands();
+    }
+
+    @Override
+    public <T> T commands(CommandsFactory<StatefulRedisConnection<K, V>, T> f) {
+        return delegate.commands(f);
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnection.java
+++ b/src/main/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnection.java
@@ -1,5 +1,6 @@
 package io.lettuce.core.pubsub;
 
+import io.lettuce.core.api.PubSubCommandsFactory;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.pubsub.api.async.RedisPubSubAsyncCommands;
 import io.lettuce.core.pubsub.api.reactive.RedisPubSubReactiveCommands;
@@ -24,6 +25,9 @@ public interface StatefulRedisPubSubConnection<K, V> extends StatefulRedisConnec
 
     /**
      * Returns the {@link RedisPubSubCommands} API for the current connection. Does not create a new connection.
+     * <p>
+     * Note: this accessor is scheduled for removal in a future major release; a {@code commands(...)}-based replacement is
+     * planned.
      *
      * @return the synchronous API for the underlying connection.
      */
@@ -31,6 +35,9 @@ public interface StatefulRedisPubSubConnection<K, V> extends StatefulRedisConnec
 
     /**
      * Returns the {@link RedisPubSubAsyncCommands} API for the current connection. Does not create a new connection.
+     * <p>
+     * Note: this accessor is scheduled for removal in a future major release; a {@code commands(...)}-based replacement is
+     * planned.
      *
      * @return the asynchronous API for the underlying connection.
      */
@@ -40,7 +47,10 @@ public interface StatefulRedisPubSubConnection<K, V> extends StatefulRedisConnec
      * Returns the {@link RedisPubSubReactiveCommands} API for the current connection. Does not create a new connection.
      *
      * @return the reactive API for the underlying connection.
+     * @deprecated since 7.7, use {@link #commands(PubSubCommandsFactory)} with {@link RedisPubSubReactiveCommands#factory()}
+     *             instead; scheduled for removal in Lettuce 8.0.
      */
+    @Deprecated
     RedisPubSubReactiveCommands<K, V> reactive();
 
     /**
@@ -56,5 +66,18 @@ public interface StatefulRedisPubSubConnection<K, V> extends StatefulRedisConnec
      * @param listener the listener, must not be {@code null}.
      */
     void removeListener(RedisPubSubListener<K, V> listener);
+
+    /**
+     * Returns the command API created by {@code factory}, bound to this connection. Does not create a new connection.
+     * <p>
+     * The command API is created once per connection and cached; calling this method again with the same {@code factory}
+     * returns the same instance.
+     *
+     * @param factory the command API factory, must not be {@code null}
+     * @param <T> the command API type
+     * @return the command API bound to this connection
+     * @since 7.7
+     */
+    <T> T commands(PubSubCommandsFactory<StatefulRedisPubSubConnection<K, V>, T> factory);
 
 }

--- a/src/main/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnectionImpl.java
@@ -29,7 +29,9 @@ import io.lettuce.core.RedisChannelWriter;
 import io.lettuce.core.RedisCommandExecutionException;
 import io.lettuce.core.RedisFuture;
 import io.lettuce.core.StatefulRedisConnectionImpl;
+import io.lettuce.core.api.PubSubCommandsFactory;
 import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.internal.LettuceAssert;
 import io.lettuce.core.protocol.ConnectionWatchdog;
 import io.lettuce.core.pubsub.api.async.RedisPubSubAsyncCommands;
 import io.lettuce.core.pubsub.api.reactive.RedisPubSubReactiveCommands;
@@ -109,11 +111,21 @@ public class StatefulRedisPubSubConnectionImpl<K, V> extends StatefulRedisConnec
         return syncHandler(async(), RedisPubSubCommands.class);
     }
 
+    /**
+     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisPubSubReactiveCommands#factory()} instead; scheduled
+     *             for removal in Lettuce 8.0.
+     */
+    @Deprecated
     @Override
     public RedisPubSubReactiveCommands<K, V> reactive() {
         return (RedisPubSubReactiveCommands<K, V>) reactive;
     }
 
+    /**
+     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisPubSubReactiveCommands#factory()} instead; scheduled
+     *             for removal in Lettuce 8.0.
+     */
+    @Deprecated
     @Override
     protected RedisPubSubReactiveCommandsImpl<K, V> newRedisReactiveCommandsImpl() {
         return new RedisPubSubReactiveCommandsImpl<>(this, codec);
@@ -161,6 +173,12 @@ public class StatefulRedisPubSubConnectionImpl<K, V> extends StatefulRedisConnec
                 return null;
             });
         }
+    }
+
+    @Override
+    public <T> T commands(PubSubCommandsFactory<StatefulRedisPubSubConnection<K, V>, T> factory) {
+        LettuceAssert.notNull(factory, "CommandsFactory must not be null");
+        return store.compute(factory.key(), () -> factory.apply(this));
     }
 
 }

--- a/src/main/java/io/lettuce/core/pubsub/api/reactive/RedisPubSubReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/pubsub/api/reactive/RedisPubSubReactiveCommands.java
@@ -3,7 +3,9 @@ package io.lettuce.core.pubsub.api.reactive;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
+import io.lettuce.core.api.PubSubCommandsFactory;
 import io.lettuce.core.api.reactive.RedisReactiveCommands;
+import io.lettuce.core.pubsub.RedisPubSubReactiveCommandsImpl;
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 
 /**
@@ -123,5 +125,42 @@ public interface RedisPubSubReactiveCommands<K, V> extends RedisReactiveCommands
      */
     @Deprecated
     StatefulRedisPubSubConnection<K, V> getStatefulConnection();
+
+    /**
+     * Returns the {@link PubSubCommandsFactory} that creates {@link RedisPubSubReactiveCommands}, for use with
+     * {@link io.lettuce.core.pubsub.StatefulRedisPubSubConnection#commands(PubSubCommandsFactory)}:
+     *
+     * <pre>
+     * 
+     * {
+     *     &#64;code
+     *     RedisPubSubReactiveCommands<K, V> reactive = connection.commands(RedisPubSubReactiveCommands.factory());
+     * }
+     * </pre>
+     *
+     * @param <K> Key type
+     * @param <V> Value type
+     * @return the factory that creates {@link RedisPubSubReactiveCommands}
+     * @since 7.7
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    static <K, V> PubSubCommandsFactory<StatefulRedisPubSubConnection<K, V>, RedisPubSubReactiveCommands<K, V>> factory() {
+        return (PubSubCommandsFactory) FactoryHolder.INSTANCE;
+    }
+
+    /**
+     * Holds the singleton factory so {@link #factory()} returns one shared instance (no per-call allocation); {@code factory()}
+     * re-applies {@code <K, V>}.
+     */
+    final class FactoryHolder {
+
+        private FactoryHolder() {
+        }
+
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        private static final PubSubCommandsFactory INSTANCE = PubSubCommandsFactory.of(RedisPubSubReactiveCommands.class,
+                (StatefulRedisPubSubConnection c) -> new RedisPubSubReactiveCommandsImpl(c, c.getCodec()));
+
+    }
 
 }

--- a/src/main/java/io/lettuce/core/sentinel/StatefulRedisSentinelConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/sentinel/StatefulRedisSentinelConnectionImpl.java
@@ -31,6 +31,8 @@ import io.lettuce.core.codec.StringCodec;
 import io.lettuce.core.json.JsonParser;
 import io.lettuce.core.output.StatusOutput;
 import io.lettuce.core.protocol.*;
+import io.lettuce.core.api.CommandsFactory;
+import io.lettuce.core.internal.LettuceAssert;
 import io.lettuce.core.sentinel.api.StatefulRedisSentinelConnection;
 import io.lettuce.core.sentinel.api.async.RedisSentinelAsyncCommands;
 import io.lettuce.core.sentinel.api.reactive.RedisSentinelReactiveCommands;
@@ -50,6 +52,11 @@ public class StatefulRedisSentinelConnectionImpl<K, V> extends RedisChannelHandl
 
     protected final RedisSentinelAsyncCommands<K, V> async;
 
+    /**
+     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisSentinelReactiveCommands#factory()} instead; scheduled
+     *             for removal in Lettuce 8.0.
+     */
+    @Deprecated
     protected final RedisSentinelReactiveCommands<K, V> reactive;
 
     private final SentinelConnectionState connectionState = new SentinelConnectionState();
@@ -104,6 +111,11 @@ public class StatefulRedisSentinelConnectionImpl<K, V> extends RedisChannelHandl
         return async;
     }
 
+    /**
+     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisSentinelReactiveCommands#factory()} instead; scheduled
+     *             for removal in Lettuce 8.0.
+     */
+    @Deprecated
     @Override
     public RedisSentinelReactiveCommands<K, V> reactive() {
         return reactive;
@@ -131,6 +143,12 @@ public class StatefulRedisSentinelConnectionImpl<K, V> extends RedisChannelHandl
     @Override
     public RedisCodec<K, V> getCodec() {
         return codec;
+    }
+
+    @Override
+    public <T> T commands(CommandsFactory<StatefulRedisSentinelConnection<K, V>, T> f) {
+        LettuceAssert.notNull(f, "CommandsFactory must not be null");
+        return store.compute(f.key(), () -> f.apply(this));
     }
 
     static class SentinelConnectionState extends ConnectionState {

--- a/src/main/java/io/lettuce/core/sentinel/api/StatefulRedisSentinelConnection.java
+++ b/src/main/java/io/lettuce/core/sentinel/api/StatefulRedisSentinelConnection.java
@@ -1,6 +1,8 @@
 package io.lettuce.core.sentinel.api;
 
+import io.lettuce.core.api.CommandsFactory;
 import io.lettuce.core.api.StatefulConnection;
+import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.protocol.ConnectionWatchdog;
 import io.lettuce.core.sentinel.api.async.RedisSentinelAsyncCommands;
 import io.lettuce.core.sentinel.api.reactive.RedisSentinelReactiveCommands;
@@ -21,6 +23,9 @@ public interface StatefulRedisSentinelConnection<K, V> extends StatefulConnectio
 
     /**
      * Returns the {@link RedisSentinelCommands} API for the current connection. Does not create a new connection.
+     * <p>
+     * Note: this accessor is scheduled for removal in a future major release; a {@code commands(...)}-based replacement is
+     * planned.
      *
      * @return the synchronous API for the underlying connection.
      */
@@ -28,6 +33,9 @@ public interface StatefulRedisSentinelConnection<K, V> extends StatefulConnectio
 
     /**
      * Returns the {@link RedisSentinelAsyncCommands} API for the current connection. Does not create a new connection.
+     * <p>
+     * Note: this accessor is scheduled for removal in a future major release; a {@code commands(...)}-based replacement is
+     * planned.
      *
      * @return the asynchronous API for the underlying connection.
      */
@@ -37,7 +45,23 @@ public interface StatefulRedisSentinelConnection<K, V> extends StatefulConnectio
      * Returns the {@link RedisSentinelReactiveCommands} API for the current connection. Does not create a new connection.
      *
      * @return the reactive API for the underlying connection.
+     * @deprecated since 7.7, use {@link #commands(CommandsFactory)} with {@link RedisSentinelReactiveCommands#factory()}
+     *             instead; scheduled for removal in Lettuce 8.0.
      */
+    @Deprecated
     RedisSentinelReactiveCommands<K, V> reactive();
+
+    /**
+     * Returns the command API created by {@code factory}, bound to this connection. Does not create a new connection.
+     * <p>
+     * The command API is created once per connection and cached; calling this method again with the same {@code factory}
+     * returns the same instance.
+     *
+     * @param factory the command API factory, must not be {@code null}
+     * @param <T> the command API type
+     * @return the command API bound to this connection
+     * @since 7.7
+     */
+    <T> T commands(CommandsFactory<StatefulRedisSentinelConnection<K, V>, T> factory);
 
 }

--- a/src/main/java/io/lettuce/core/sentinel/api/reactive/RedisSentinelReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/sentinel/api/reactive/RedisSentinelReactiveCommands.java
@@ -24,9 +24,11 @@ import java.util.Map;
 
 import io.lettuce.core.ClientListArgs;
 import io.lettuce.core.KillArgs;
+import io.lettuce.core.api.CommandsFactory;
 import io.lettuce.core.output.CommandOutput;
 import io.lettuce.core.protocol.CommandArgs;
 import io.lettuce.core.protocol.ProtocolKeyword;
+import io.lettuce.core.sentinel.RedisSentinelReactiveCommandsImpl;
 import io.lettuce.core.sentinel.api.StatefulRedisSentinelConnection;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -253,5 +255,43 @@ public interface RedisSentinelReactiveCommands<K, V> {
      * @return the underlying connection.
      */
     StatefulRedisSentinelConnection<K, V> getStatefulConnection();
+
+    /**
+     * Returns the {@link CommandsFactory} that creates {@link RedisSentinelReactiveCommands}, for use with
+     * {@link io.lettuce.core.sentinel.api.StatefulRedisSentinelConnection#commands(CommandsFactory)}:
+     *
+     * <pre>
+     * 
+     * {
+     *     &#64;code
+     *     RedisSentinelReactiveCommands<K, V> reactive = connection.commands(RedisSentinelReactiveCommands.factory());
+     * }
+     * </pre>
+     *
+     * @param <K> Key type
+     * @param <V> Value type
+     * @return the factory that creates {@link RedisSentinelReactiveCommands}
+     * @since 7.7
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    static <K, V> CommandsFactory<StatefulRedisSentinelConnection<K, V>, RedisSentinelReactiveCommands<K, V>> factory() {
+        return (CommandsFactory) FactoryHolder.INSTANCE;
+    }
+
+    /**
+     * Holds the singleton factory so {@link #factory()} returns one shared instance (no per-call allocation); {@code factory()}
+     * re-applies {@code <K, V>}.
+     */
+    final class FactoryHolder {
+
+        private FactoryHolder() {
+        }
+
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        private static final CommandsFactory INSTANCE = CommandsFactory.of(RedisSentinelReactiveCommands.class,
+                (StatefulRedisSentinelConnection c) -> new RedisSentinelReactiveCommandsImpl(c, c.getCodec(),
+                        () -> c.getOptions().getJsonParser().get()));
+
+    }
 
 }

--- a/src/test/java/io/lettuce/core/StatefulRedisConnectionImplUnitTests.java
+++ b/src/test/java/io/lettuce/core/StatefulRedisConnectionImplUnitTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026-Present, Redis Ltd. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+package io.lettuce.core;
+
+import static io.lettuce.TestTags.UNIT_TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
+import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.protocol.PushHandler;
+import io.lettuce.core.resource.ClientResources;
+import io.lettuce.core.tracing.Tracing;
+
+@Tag(UNIT_TEST)
+class StatefulRedisConnectionImplUnitTests {
+
+    private final RedisCodec<String, String> codec = StringCodec.UTF8;
+
+    private StatefulRedisConnection<String, String> connection;
+
+    @BeforeEach
+    void setup() {
+        RedisChannelWriter writer = mock(RedisChannelWriter.class);
+        ClientResources resources = mock(ClientResources.class);
+        Tracing tracing = mock(Tracing.class);
+        when(resources.tracing()).thenReturn(tracing);
+        when(tracing.isEnabled()).thenReturn(Boolean.FALSE);
+        when(writer.getClientResources()).thenReturn(resources);
+
+        connection = new StatefulRedisConnectionImpl<>(writer, mock(PushHandler.class), codec, Duration.ofSeconds(5));
+    }
+
+    @Test
+    void reactiveCommandsAreCached() {
+        RedisReactiveCommands<String, String> first = connection.commands(RedisReactiveCommands.factory());
+        RedisReactiveCommands<String, String> second = connection.commands(RedisReactiveCommands.factory());
+
+        assertThat(first).isNotNull();
+        assertThat(second).isSameAs(first);
+    }
+
+    @Test
+    void factoryIsSingleton() {
+        assertThat(RedisReactiveCommands.factory()).isSameAs(RedisReactiveCommands.factory());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void factoryProducesSameTypeAsReactive() {
+        assertThat(connection.commands(RedisReactiveCommands.factory()).getClass()).isSameAs(connection.reactive().getClass());
+    }
+
+}

--- a/src/test/java/io/lettuce/core/cluster/StatefulRedisClusterConnectionImplUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/StatefulRedisClusterConnectionImplUnitTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026-Present, Redis Ltd. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+package io.lettuce.core.cluster;
+
+import static io.lettuce.TestTags.UNIT_TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.lettuce.core.RedisChannelWriter;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
+import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.resource.ClientResources;
+import io.lettuce.core.tracing.Tracing;
+
+@Tag(UNIT_TEST)
+class StatefulRedisClusterConnectionImplUnitTests {
+
+    private final RedisCodec<String, String> codec = StringCodec.UTF8;
+
+    private StatefulRedisClusterConnection<String, String> connection;
+
+    @BeforeEach
+    void setup() {
+        RedisChannelWriter writer = mock(RedisChannelWriter.class);
+        ClientResources resources = mock(ClientResources.class);
+        Tracing tracing = mock(Tracing.class);
+        when(resources.tracing()).thenReturn(tracing);
+        when(tracing.isEnabled()).thenReturn(Boolean.FALSE);
+        when(writer.getClientResources()).thenReturn(resources);
+
+        connection = new StatefulRedisClusterConnectionImpl<>(writer, mock(ClusterPushHandler.class), codec,
+                Duration.ofSeconds(5));
+    }
+
+    @Test
+    void reactiveCommandsAreCached() {
+        RedisAdvancedClusterReactiveCommands<String, String> first = connection
+                .commands(RedisAdvancedClusterReactiveCommands.factory());
+        RedisAdvancedClusterReactiveCommands<String, String> second = connection
+                .commands(RedisAdvancedClusterReactiveCommands.factory());
+
+        assertThat(first).isNotNull();
+        assertThat(second).isSameAs(first);
+    }
+
+    @Test
+    void factoryIsSingleton() {
+        assertThat(RedisAdvancedClusterReactiveCommands.factory()).isSameAs(RedisAdvancedClusterReactiveCommands.factory());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void factoryProducesSameTypeAsReactive() {
+        assertThat(connection.commands(RedisAdvancedClusterReactiveCommands.factory()).getClass())
+                .isSameAs(connection.reactive().getClass());
+    }
+
+}

--- a/src/test/java/io/lettuce/core/cluster/StatefulRedisClusterPubSubConnectionImplUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/StatefulRedisClusterPubSubConnectionImplUnitTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026-Present, Redis Ltd. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+package io.lettuce.core.cluster;
+
+import static io.lettuce.TestTags.UNIT_TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.lettuce.core.RedisChannelWriter;
+import io.lettuce.core.cluster.pubsub.api.reactive.RedisClusterPubSubReactiveCommands;
+import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.resource.ClientResources;
+import io.lettuce.core.tracing.Tracing;
+
+@Tag(UNIT_TEST)
+class StatefulRedisClusterPubSubConnectionImplUnitTests {
+
+    private final RedisCodec<String, String> codec = StringCodec.UTF8;
+
+    private StatefulRedisClusterPubSubConnectionImpl<String, String> connection;
+
+    @BeforeEach
+    void setup() {
+        RedisChannelWriter writer = mock(RedisChannelWriter.class);
+        ClientResources resources = mock(ClientResources.class);
+        Tracing tracing = mock(Tracing.class);
+        when(resources.tracing()).thenReturn(tracing);
+        when(tracing.isEnabled()).thenReturn(Boolean.FALSE);
+        when(writer.getClientResources()).thenReturn(resources);
+
+        connection = new StatefulRedisClusterPubSubConnectionImpl<>(mock(PubSubClusterEndpoint.class),
+                mock(ClusterPushHandler.class), writer, codec, Duration.ofSeconds(5));
+    }
+
+    @Test
+    void reactiveCommandsAreCached() {
+        RedisClusterPubSubReactiveCommands<String, String> first = connection
+                .commands(RedisClusterPubSubReactiveCommands.factory());
+        RedisClusterPubSubReactiveCommands<String, String> second = connection
+                .commands(RedisClusterPubSubReactiveCommands.factory());
+
+        assertThat(first).isNotNull();
+        assertThat(second).isSameAs(first);
+    }
+
+    @Test
+    void factoryIsSingleton() {
+        assertThat(RedisClusterPubSubReactiveCommands.factory()).isSameAs(RedisClusterPubSubReactiveCommands.factory());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void factoryProducesSameTypeAsReactive() {
+        assertThat(connection.commands(RedisClusterPubSubReactiveCommands.factory()).getClass())
+                .isSameAs(connection.reactive().getClass());
+    }
+
+}

--- a/src/test/java/io/lettuce/core/failover/StatefulRedisMultiDbConnectionImplUnitTests.java
+++ b/src/test/java/io/lettuce/core/failover/StatefulRedisMultiDbConnectionImplUnitTests.java
@@ -31,6 +31,7 @@ import org.testcontainers.shaded.org.awaitility.Durations;
 import io.lettuce.core.RedisConnectionStateListener;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.api.push.PushListener;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.codec.StringCodec;
@@ -296,6 +297,16 @@ class StatefulRedisMultiDbConnectionImplUnitTests {
         @DisplayName("Should return resources")
         void shouldReturnResources() {
             assertThat(connection.getResources()).isEqualTo(clientResources);
+        }
+
+        @Test
+        @DisplayName("Should cache reactive commands")
+        void shouldCacheReactiveCommands() {
+            RedisReactiveCommands<String, String> first = connection.commands(RedisReactiveCommands.factory());
+            RedisReactiveCommands<String, String> second = connection.commands(RedisReactiveCommands.factory());
+
+            assertThat(first).isNotNull();
+            assertThat(second).isSameAs(first);
         }
 
         @Test

--- a/src/test/java/io/lettuce/core/masterslave/MasterSlaveConnectionWrapperUnitTests.java
+++ b/src/test/java/io/lettuce/core/masterslave/MasterSlaveConnectionWrapperUnitTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026-Present, Redis Ltd. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+package io.lettuce.core.masterslave;
+
+import static io.lettuce.TestTags.UNIT_TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
+import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection;
+
+@Tag(UNIT_TEST)
+class MasterSlaveConnectionWrapperUnitTests {
+
+    @SuppressWarnings("unchecked")
+    private final StatefulRedisMasterReplicaConnection<String, String> delegate = mock(
+            StatefulRedisMasterReplicaConnection.class);
+
+    private MasterSlaveConnectionWrapper<String, String> wrapper;
+
+    @BeforeEach
+    void setup() {
+        wrapper = new MasterSlaveConnectionWrapper<>(delegate);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void commandsDelegateToTheUnderlyingConnection() {
+        RedisReactiveCommands<String, String> expected = mock(RedisReactiveCommands.class);
+        when(delegate.commands(any())).thenReturn(expected);
+
+        RedisReactiveCommands<String, String> actual = wrapper.commands(RedisReactiveCommands.factory());
+
+        assertThat(actual).isSameAs(expected);
+    }
+
+}

--- a/src/test/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnectionImplUnitTests.java
+++ b/src/test/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnectionImplUnitTests.java
@@ -5,6 +5,7 @@ import io.lettuce.core.RedisFuture;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.codec.StringCodec;
 import io.lettuce.core.protocol.AsyncCommand;
+import io.lettuce.core.pubsub.api.reactive.RedisPubSubReactiveCommands;
 import io.lettuce.core.resource.ClientResources;
 import io.lettuce.core.tracing.Tracing;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static io.lettuce.TestTags.UNIT_TEST;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.*;
@@ -24,7 +26,7 @@ import java.util.List;
 @Tag(UNIT_TEST)
 class StatefulRedisPubSubConnectionImplUnitTests {
 
-    private StatefulRedisPubSubConnectionImpl connection;
+    private StatefulRedisPubSubConnectionImpl<String, String> connection;
 
     private final RedisCodec<String, String> codec = StringCodec.UTF8;
 
@@ -45,7 +47,28 @@ class StatefulRedisPubSubConnectionImplUnitTests {
         when(mockedTracing.isEnabled()).thenReturn(Boolean.FALSE);
         when(mockedWriter.getClientResources()).thenReturn(mockedReseources);
 
-        connection = new StatefulRedisPubSubConnectionImpl(mockedEndpoint, mockedWriter, codec, timeout);
+        connection = new StatefulRedisPubSubConnectionImpl<>(mockedEndpoint, mockedWriter, codec, timeout);
+    }
+
+    @Test
+    void reactiveCommandsAreCached() {
+        RedisPubSubReactiveCommands first = connection.commands(RedisPubSubReactiveCommands.factory());
+        RedisPubSubReactiveCommands second = connection.commands(RedisPubSubReactiveCommands.factory());
+
+        assertThat(first).isNotNull();
+        assertThat(second).isSameAs(first);
+    }
+
+    @Test
+    void factoryIsSingleton() {
+        assertThat(RedisPubSubReactiveCommands.factory()).isSameAs(RedisPubSubReactiveCommands.factory());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void factoryProducesSameTypeAsReactive() {
+        assertThat(connection.commands(RedisPubSubReactiveCommands.factory()).getClass())
+                .isSameAs(connection.reactive().getClass());
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/sentinel/StatefulRedisSentinelConnectionImplUnitTests.java
+++ b/src/test/java/io/lettuce/core/sentinel/StatefulRedisSentinelConnectionImplUnitTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026-Present, Redis Ltd. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+package io.lettuce.core.sentinel;
+
+import static io.lettuce.TestTags.UNIT_TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.lettuce.core.RedisChannelWriter;
+import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.resource.ClientResources;
+import io.lettuce.core.sentinel.api.StatefulRedisSentinelConnection;
+import io.lettuce.core.sentinel.api.reactive.RedisSentinelReactiveCommands;
+import io.lettuce.core.tracing.Tracing;
+
+@Tag(UNIT_TEST)
+class StatefulRedisSentinelConnectionImplUnitTests {
+
+    private final RedisCodec<String, String> codec = StringCodec.UTF8;
+
+    private StatefulRedisSentinelConnection<String, String> connection;
+
+    @BeforeEach
+    void setup() {
+        RedisChannelWriter writer = mock(RedisChannelWriter.class);
+        ClientResources resources = mock(ClientResources.class);
+        Tracing tracing = mock(Tracing.class);
+        when(resources.tracing()).thenReturn(tracing);
+        when(tracing.isEnabled()).thenReturn(Boolean.FALSE);
+        when(writer.getClientResources()).thenReturn(resources);
+
+        connection = new StatefulRedisSentinelConnectionImpl<>(writer, codec, Duration.ofSeconds(5));
+    }
+
+    @Test
+    void reactiveCommandsAreCached() {
+        RedisSentinelReactiveCommands<String, String> first = connection.commands(RedisSentinelReactiveCommands.factory());
+        RedisSentinelReactiveCommands<String, String> second = connection.commands(RedisSentinelReactiveCommands.factory());
+
+        assertThat(first).isNotNull();
+        assertThat(second).isSameAs(first);
+    }
+
+    @Test
+    void factoryIsSingleton() {
+        assertThat(RedisSentinelReactiveCommands.factory()).isSameAs(RedisSentinelReactiveCommands.factory());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void factoryProducesSameTypeAsReactive() {
+        assertThat(connection.commands(RedisSentinelReactiveCommands.factory()).getClass())
+                .isSameAs(connection.reactive().getClass());
+    }
+
+}


### PR DESCRIPTION
This PR introduces a new way to obtain command APIs from a `StatefulConnection`: The motivation and immediate benefit of it is related to #3614 and will allow us to decouple the connection interface from the reactive types.

```java
RedisReactiveCommands<String, String> reactive = connection.commands(RedisReactiveCommands.factory());
```

`commands(...)` builds the command API once per connection and caches it, without the connection interface
referencing Reactor. It replaces `reactive()`, which is now deprecated for removal in 8.0.

## What's included

- **`CommandsFactory<C, T>` SPI** — flavor-neutral factory (`key()` + `of(...)`) passed to `commands(...)`.
- **`factory()` on the five reactive command interfaces**, each a shared singleton (no per-call allocation).
- **Per-connection cache** — one command-API instance per factory key.
- **Compile-time family safety** — `PubSubCommandsFactory` / `ClusterPubSubCommandsFactory` give the
  standalone → pub/sub → cluster-pub/sub hierarchy distinct `commands(...)` overloads: a connection accepts its
  own and ancestor-family factories and rejects descendant-family factories at compile time. Cluster and Sentinel
  keep their own invariant bounds.

## Deprecations

- `reactive()` — deprecated on all connection interfaces and impls, pointing at
  `commands(XxxReactiveCommands.factory())`; removal in **8.0**.
- `sync()` / `async()` — not deprecated; carry an informational future-removal note only.

## Compatibility & testing

- Purely additive plus deprecations; no existing method removed or changed.
- Per-impl unit tests across all connection families
