### PR TITLE
Upgrade GitHub Actions versions (#3773) - part 2

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,18 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
-      - name: Checkout project
-        uses: actions/checkout@v6
-      - name: Set Java up in the runner
-        uses: actions/setup-java@v5
-        with:
-          java-version: '8'
-          distribution: 'temurin'
-          cache: 'maven'
       - name: Setup Maven
         uses: s4u/setup-maven-action@v1.19.0
         with:
           java-version: 8
+          java-distribution: temurin
       - name: Install missing dependencies to container
         run: |
           sudo apt update


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
The https://github.com/redis/lettuce/actions/workflows/benchmarks.yml seems to be failing since the 4th of June
Quite likely this is related to the #3773 bump of the dependencies.

Seems that the `actions/checkout@v6` moved its credential persistence out of http.https://github.com/.extraheader and this causes other actions (in this case `s4u/setup-maven-action@v1.19.0`, which internally uses the v5 version of the checkout action) to fail.

Since we need neither the `actions/checkout@v6` (nor the `actions/setup-java@v5` for that matter) removing them both should do the trick.

Make sure that:

- [ ] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to one workflow; no application or library code is affected.
> 
> **Overview**
> Fixes the failing **Benchmarks** workflow by dropping the separate `actions/checkout@v6` and `actions/setup-java@v5` steps and relying only on `s4u/setup-maven-action@v1.19.0` for checkout, Java 8, and Maven setup.
> 
> The workflow now passes **`java-distribution: temurin`** into that action so Temurin is still used. This avoids a conflict where checkout v6’s credential handling breaks the action’s internal checkout (often cited as the cause of failures since the earlier Actions version bump).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6a99d49b3945ee2ffdcfa001a980d7c05ae8e46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->