### PR TITLE
[reactor-optional] Change reactive accessor

### DIFF
--- a/src/main/java/io/lettuce/core/StatefulRedisConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/StatefulRedisConnectionImpl.java
@@ -35,7 +35,6 @@ import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.internal.LettuceAssert;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.api.push.PushListener;
-import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
 import io.lettuce.core.codec.RedisCodec;

--- a/src/main/java/io/lettuce/core/StatefulRedisConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/StatefulRedisConnectionImpl.java
@@ -63,13 +63,6 @@ public class StatefulRedisConnectionImpl<K, V> extends RedisChannelHandler<K, V>
 
     protected final RedisAsyncCommandsImpl<K, V> async;
 
-    /**
-     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisReactiveCommands#factory()} instead; scheduled for
-     *             removal in Lettuce 8.0.
-     */
-    @Deprecated
-    protected final RedisReactiveCommandsImpl<K, V> reactive;
-
     private final ConnectionState state = new ConnectionState();
 
     private final PushHandler pushHandler;
@@ -112,7 +105,6 @@ public class StatefulRedisConnectionImpl<K, V> extends RedisChannelHandler<K, V>
         this.parser = parser;
         this.async = newRedisAsyncCommandsImpl();
         this.sync = newRedisSyncCommandsImpl();
-        this.reactive = newRedisReactiveCommandsImpl();
     }
 
     @Override
@@ -147,28 +139,6 @@ public class StatefulRedisConnectionImpl<K, V> extends RedisChannelHandler<K, V>
      */
     protected RedisAsyncCommandsImpl<K, V> newRedisAsyncCommandsImpl() {
         return new RedisAsyncCommandsImpl<>(this, codec, parser);
-    }
-
-    /**
-     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisReactiveCommands#factory()} instead; scheduled for
-     *             removal in Lettuce 8.0.
-     */
-    @Deprecated
-    @Override
-    public RedisReactiveCommands<K, V> reactive() {
-        return reactive;
-    }
-
-    /**
-     * Create a new instance of {@link RedisReactiveCommandsImpl}. Can be overriden to extend.
-     *
-     * @return a new instance
-     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisReactiveCommands#factory()} instead; scheduled for
-     *             removal in Lettuce 8.0.
-     */
-    @Deprecated
-    protected RedisReactiveCommandsImpl<K, V> newRedisReactiveCommandsImpl() {
-        return new RedisReactiveCommandsImpl<>(this, codec, parser);
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/api/StatefulRedisConnection.java
+++ b/src/main/java/io/lettuce/core/api/StatefulRedisConnection.java
@@ -69,12 +69,8 @@ public interface StatefulRedisConnection<K, V> extends StatefulConnection<K, V> 
      * @param factory the command API factory, must not be {@code null}
      * @param <T> the command API type
      * @return the command API bound to this connection
-     * @throws UnsupportedOperationException if the connection implementation does not override this method. The default is
-     *         provided only for source compatibility in Lettuce 7.x and becomes an abstract method in Lettuce 8.0.
      * @since 7.7
      */
-    default <T> T commands(CommandsFactory<StatefulRedisConnection<K, V>, T> factory) {
-        throw new UnsupportedOperationException("commands(CommandsFactory) is not implemented by this connection");
-    }
+    <T> T commands(CommandsFactory<StatefulRedisConnection<K, V>, T> factory);
 
 }

--- a/src/main/java/io/lettuce/core/api/StatefulRedisConnection.java
+++ b/src/main/java/io/lettuce/core/api/StatefulRedisConnection.java
@@ -2,7 +2,6 @@ package io.lettuce.core.api;
 
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.api.push.PushListener;
-import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.protocol.ConnectionWatchdog;
 
@@ -44,16 +43,6 @@ public interface StatefulRedisConnection<K, V> extends StatefulConnection<K, V> 
      * @return the asynchronous API for the underlying connection.
      */
     RedisAsyncCommands<K, V> async();
-
-    /**
-     * Returns the {@link RedisReactiveCommands} API for the current connection. Does not create a new connection.
-     *
-     * @return the reactive API for the underlying connection.
-     * @deprecated since 7.7, use {@link #commands(CommandsFactory)} with {@link RedisReactiveCommands#factory()} instead;
-     *             scheduled for removal in Lettuce 8.0.
-     */
-    @Deprecated
-    RedisReactiveCommands<K, V> reactive();
 
     /**
      * Add a new {@link PushListener listener} to consume push messages.

--- a/src/main/java/io/lettuce/core/cluster/NodeSelectionInvocationHandler.java
+++ b/src/main/java/io/lettuce/core/cluster/NodeSelectionInvocationHandler.java
@@ -23,6 +23,7 @@ import org.reactivestreams.Publisher;
 import io.lettuce.core.RedisCommandExecutionException;
 import io.lettuce.core.RedisCommandTimeoutException;
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.cluster.api.NodeSelectionSupport;
 import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
 import io.lettuce.core.internal.AbstractInvocationHandler;
@@ -169,7 +170,9 @@ class NodeSelectionInvocationHandler extends AbstractInvocationHandler {
             argsToUse[1] = ((Supplier) args[1]).get();
         }
 
-        return targetMethod.invoke(executionModel == ExecutionModel.REACTIVE ? it.reactive() : it.async(), argsToUse);
+        return targetMethod.invoke(
+                executionModel == ExecutionModel.REACTIVE ? it.commands(RedisReactiveCommands.factory()) : it.async(),
+                argsToUse);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/src/main/java/io/lettuce/core/cluster/NodeSelectionInvocationHandler.java
+++ b/src/main/java/io/lettuce/core/cluster/NodeSelectionInvocationHandler.java
@@ -22,8 +22,8 @@ import org.reactivestreams.Publisher;
 
 import io.lettuce.core.RedisCommandExecutionException;
 import io.lettuce.core.RedisCommandTimeoutException;
+import io.lettuce.core.api.CommandsFactory;
 import io.lettuce.core.api.StatefulRedisConnection;
-import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.cluster.api.NodeSelectionSupport;
 import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
 import io.lettuce.core.internal.AbstractInvocationHandler;
@@ -56,6 +56,8 @@ class NodeSelectionInvocationHandler extends AbstractInvocationHandler {
 
     private final TimeoutProvider timeoutProvider;
 
+    private final CommandsFactory<?, ?> reactiveCommandsFactory;
+
     static {
         try {
             NULL_MARKER_METHOD = NodeSelectionInvocationHandler.class.getDeclaredMethod("handleInvocation", Object.class,
@@ -67,16 +69,21 @@ class NodeSelectionInvocationHandler extends AbstractInvocationHandler {
 
     NodeSelectionInvocationHandler(AbstractNodeSelection<?, ?, ?, ?> selection, Class<?> commandsInterface,
             ExecutionModel executionModel) {
-        this(selection, commandsInterface, null, executionModel);
+        this(selection, commandsInterface, null, executionModel, null);
+    }
+
+    NodeSelectionInvocationHandler(AbstractNodeSelection<?, ?, ?, ?> selection, Class<?> commandsInterface,
+            ExecutionModel executionModel, CommandsFactory<?, ?> reactiveCommandsFactory) {
+        this(selection, commandsInterface, null, executionModel, reactiveCommandsFactory);
     }
 
     NodeSelectionInvocationHandler(AbstractNodeSelection<?, ?, ?, ?> selection, Class<?> commandsInterface,
             TimeoutProvider timeoutProvider) {
-        this(selection, commandsInterface, timeoutProvider, ExecutionModel.SYNC);
+        this(selection, commandsInterface, timeoutProvider, ExecutionModel.SYNC, null);
     }
 
     private NodeSelectionInvocationHandler(AbstractNodeSelection<?, ?, ?, ?> selection, Class<?> commandsInterface,
-            TimeoutProvider timeoutProvider, ExecutionModel executionModel) {
+            TimeoutProvider timeoutProvider, ExecutionModel executionModel, CommandsFactory<?, ?> reactiveCommandsFactory) {
 
         if (executionModel == ExecutionModel.SYNC) {
             LettuceAssert.notNull(timeoutProvider, "TimeoutProvider must not be null");
@@ -88,6 +95,7 @@ class NodeSelectionInvocationHandler extends AbstractInvocationHandler {
         this.commandsInterface = commandsInterface;
         this.timeoutProvider = timeoutProvider;
         this.executionModel = executionModel;
+        this.reactiveCommandsFactory = reactiveCommandsFactory;
     }
 
     @Override
@@ -157,6 +165,7 @@ class NodeSelectionInvocationHandler extends AbstractInvocationHandler {
         }
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     private Object doInvoke(Object[] args, Method targetMethod, StatefulRedisConnection<?, ?> it)
             throws IllegalAccessException, InvocationTargetException {
 
@@ -170,9 +179,13 @@ class NodeSelectionInvocationHandler extends AbstractInvocationHandler {
             argsToUse[1] = ((Supplier) args[1]).get();
         }
 
-        return targetMethod.invoke(
-                executionModel == ExecutionModel.REACTIVE ? it.commands(RedisReactiveCommands.factory()) : it.async(),
-                argsToUse);
+        // The reactive command API is supplied by the reactive impl that created this handler (which lives in a reactive
+        // package); the neutral cluster handler never names a reactive type. async() stays polymorphic on the connection.
+        Object commands = executionModel == ExecutionModel.REACTIVE
+                ? ((StatefulRedisConnection) it).commands(reactiveCommandsFactory)
+                : it.async();
+
+        return targetMethod.invoke(commands, argsToUse);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImpl.java
@@ -53,6 +53,7 @@ import org.reactivestreams.Publisher;
 import io.lettuce.core.*;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.reactive.RedisKeyReactiveCommands;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.api.reactive.RedisScriptingReactiveCommands;
 import io.lettuce.core.api.reactive.RedisServerReactiveCommands;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
@@ -171,7 +172,7 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
             publishers.add(byNodeId.flatMap(conn -> {
 
                 if (conn.isOpen()) {
-                    return conn.reactive().clientSetname(name);
+                    return conn.commands(RedisReactiveCommands.factory()).clientSetname(name);
                 }
                 return Mono.empty();
             }));
@@ -182,7 +183,7 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
             publishers.add(byHost.flatMap(conn -> {
 
                 if (conn.isOpen()) {
-                    return conn.reactive().clientSetname(name);
+                    return conn.commands(RedisReactiveCommands.factory()).clientSetname(name);
                 }
                 return Mono.empty();
             }));
@@ -506,7 +507,7 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
 
     @Override
     public RedisClusterReactiveCommands<K, V> getConnection(String nodeId) {
-        return getStatefulConnection().getConnection(nodeId).reactive();
+        return getStatefulConnection().getConnection(nodeId).commands(RedisReactiveCommands.factory());
     }
 
     private Mono<StatefulRedisConnection<K, V>> getStatefulConnection(String nodeId) {
@@ -515,17 +516,17 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
 
     private Mono<RedisClusterReactiveCommands<K, V>> getConnectionReactive(String nodeId) {
         return getMono(getConnectionProvider().<K, V> getConnectionAsync(ConnectionIntent.WRITE, nodeId))
-                .map(StatefulRedisConnection::reactive);
+                .map(c -> c.commands(RedisReactiveCommands.factory()));
     }
 
     @Override
     public RedisClusterReactiveCommands<K, V> getConnection(String host, int port) {
-        return getStatefulConnection().getConnection(host, port).reactive();
+        return getStatefulConnection().getConnection(host, port).commands(RedisReactiveCommands.factory());
     }
 
     private Mono<RedisClusterReactiveCommands<K, V>> getConnectionReactive(String host, int port) {
         return getMono(getConnectionProvider().<K, V> getConnectionAsync(ConnectionIntent.WRITE, host, port))
-                .map(StatefulRedisConnection::reactive);
+                .map(c -> c.commands(RedisReactiveCommands.factory()));
     }
 
     private Mono<StatefulRedisConnection<K, V>> getStatefulConnection(String host, int port) {
@@ -756,7 +757,7 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
         }
         String nodeId = nodeIdOpt.get();
         StatefulRedisConnection<K, V> byNode = getStatefulConnection().getConnection(nodeId, ConnectionIntent.WRITE);
-        return byNode.reactive().ftCursorread(index, cursor, count).map(reply -> {
+        return byNode.commands(RedisReactiveCommands.factory()).ftCursorread(index, cursor, count).map(reply -> {
             if (reply != null) {
                 reply.getCursor().ifPresent(c -> c.setNodeId(nodeId));
             }
@@ -784,7 +785,7 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
         }
         String nodeId = nodeIdOpt.get();
         StatefulRedisConnection<K, V> byNode = getStatefulConnection().getConnection(nodeId, ConnectionIntent.WRITE);
-        return byNode.reactive().ftCursordel(index, cursor);
+        return byNode.commands(RedisReactiveCommands.factory()).ftCursordel(index, cursor);
     }
 
     /**
@@ -797,10 +798,11 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
 
         ConnectionIntent intent = getConnectionIntent(commandType);
 
-        return getStatefulConnection(intent).map(StatefulRedisConnection::reactive).flatMap(routedCall).onErrorResume(err -> {
-            logger.error("Cluster routing failed for {} - falling back to superCall", commandType, err);
-            return superCall.get();
-        });
+        return getStatefulConnection(intent).map(c -> c.commands(RedisReactiveCommands.factory())).flatMap(routedCall)
+                .onErrorResume(err -> {
+                    logger.error("Cluster routing failed for {} - falling back to superCall", commandType, err);
+                    return superCall.get();
+                });
     }
 
     /**
@@ -813,7 +815,7 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
 
         ConnectionIntent intent = getConnectionIntent(commandType);
 
-        return getStatefulConnection(intent).map(StatefulRedisConnection::reactive).flatMapMany(routedCall)
+        return getStatefulConnection(intent).map(c -> c.commands(RedisReactiveCommands.factory())).flatMapMany(routedCall)
                 .onErrorResume(err -> {
                     logger.error("Cluster routing failed for {} - falling back to superCall", commandType, err);
                     return superCall.get();
@@ -830,7 +832,7 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
 
         ConnectionIntent intent = getConnectionIntent(commandType);
 
-        return getStatefulConnection(intent).map(StatefulRedisConnection::reactive)
+        return getStatefulConnection(intent).map(c -> c.commands(RedisReactiveCommands.factory()))
                 .flatMap(conn -> conn.clusterMyId().flatMap(nodeId -> routedCall.apply(nodeId, conn))).onErrorResume(err -> {
                     logger.error("Cluster routing failed for {} - falling back to superCall", commandType, err);
                     return superCall.get();
@@ -945,7 +947,7 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
         ScanCursor continuationCursor = ClusterScanSupport.getContinuationCursor(cursor);
 
         Mono<T> scanCursor = getMono(connectionProvider.<K, V> getConnectionAsync(ConnectionIntent.WRITE, currentNodeId))
-                .flatMap(conn -> scanFunction.apply(conn.reactive(), continuationCursor));
+                .flatMap(conn -> scanFunction.apply(conn.commands(RedisReactiveCommands.factory()), continuationCursor));
         return mapper.map(nodeIds, currentNodeId, scanCursor);
     }
 

--- a/src/main/java/io/lettuce/core/cluster/RedisClusterPubSubReactiveCommandsImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisClusterPubSubReactiveCommandsImpl.java
@@ -121,7 +121,7 @@ public class RedisClusterPubSubReactiveCommandsImpl<K, V> extends RedisPubSubRea
 
         @Override
         protected CompletableFuture<RedisPubSubReactiveCommands<K, V>> getApi(RedisClusterNode redisClusterNode) {
-            return getConnection(redisClusterNode).thenApply(StatefulRedisPubSubConnection::reactive);
+            return getConnection(redisClusterNode).thenApply(c -> c.commands(RedisPubSubReactiveCommands.factory()));
         }
 
         protected List<RedisClusterNode> nodes() {

--- a/src/main/java/io/lettuce/core/cluster/RedisClusterPubSubReactiveCommandsImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisClusterPubSubReactiveCommandsImpl.java
@@ -98,7 +98,7 @@ public class RedisClusterPubSubReactiveCommandsImpl<K, V> extends RedisPubSubRea
                 predicate);
 
         NodeSelectionInvocationHandler h = new NodeSelectionInvocationHandler((AbstractNodeSelection<?, ?, ?, ?>) selection,
-                RedisPubSubReactiveCommands.class, REACTIVE);
+                RedisPubSubReactiveCommands.class, REACTIVE, RedisPubSubReactiveCommands.factory());
         return (PubSubReactiveNodeSelection<K, V>) Proxy.newProxyInstance(NodeSelectionSupport.class.getClassLoader(),
                 new Class<?>[] { NodeSelectionPubSubReactiveCommands.class, PubSubReactiveNodeSelection.class }, h);
     }

--- a/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterConnectionImpl.java
@@ -47,7 +47,6 @@ import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.api.async.RedisAdvancedClusterAsyncCommands;
 import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
 import io.lettuce.core.cluster.api.push.RedisClusterPushListener;
-import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
 import io.lettuce.core.cluster.api.sync.NodeSelection;
 import io.lettuce.core.cluster.api.sync.NodeSelectionCommands;
 import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;

--- a/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterConnectionImpl.java
@@ -84,13 +84,6 @@ public class StatefulRedisClusterConnectionImpl<K, V> extends RedisChannelHandle
 
     protected final RedisAdvancedClusterAsyncCommandsImpl<K, V> async;
 
-    /**
-     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisAdvancedClusterReactiveCommands#factory()} instead;
-     *             scheduled for removal in Lettuce 8.0.
-     */
-    @Deprecated
-    protected final RedisAdvancedClusterReactiveCommandsImpl<K, V> reactive;
-
     private final ClusterConnectionState connectionState = new ClusterConnectionState();
 
     private volatile Partitions partitions;
@@ -128,7 +121,6 @@ public class StatefulRedisClusterConnectionImpl<K, V> extends RedisChannelHandle
 
         this.async = newRedisAdvancedClusterAsyncCommandsImpl();
         this.sync = newRedisAdvancedClusterCommandsImpl();
-        this.reactive = newRedisAdvancedClusterReactiveCommandsImpl();
     }
 
     @Override
@@ -140,10 +132,6 @@ public class StatefulRedisClusterConnectionImpl<K, V> extends RedisChannelHandle
     public <T> T commands(CommandsFactory<StatefulRedisClusterConnection<K, V>, T> f) {
         LettuceAssert.notNull(f, "CommandsFactory must not be null");
         return store.compute(f.key(), () -> f.apply(this));
-    }
-
-    protected RedisAdvancedClusterReactiveCommandsImpl<K, V> newRedisAdvancedClusterReactiveCommandsImpl() {
-        return new RedisAdvancedClusterReactiveCommandsImpl<>((StatefulRedisClusterConnection<K, V>) this, codec, parser);
     }
 
     protected RedisAdvancedClusterCommands<K, V> newRedisAdvancedClusterCommandsImpl() {
@@ -171,16 +159,6 @@ public class StatefulRedisClusterConnectionImpl<K, V> extends RedisChannelHandle
     @Override
     public RedisAdvancedClusterAsyncCommands<K, V> async() {
         return async;
-    }
-
-    /**
-     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisAdvancedClusterReactiveCommands#factory()} instead;
-     *             scheduled for removal in Lettuce 8.0.
-     */
-    @Deprecated
-    @Override
-    public RedisAdvancedClusterReactiveCommands<K, V> reactive() {
-        return reactive;
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterPubSubConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/StatefulRedisClusterPubSubConnectionImpl.java
@@ -111,26 +111,6 @@ class StatefulRedisClusterPubSubConnectionImpl<K, V> extends StatefulRedisPubSub
                 NodeSelectionPubSubCommands.class, async());
     }
 
-    /**
-     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisClusterPubSubReactiveCommands#factory()} instead;
-     *             scheduled for removal in Lettuce 8.0.
-     */
-    @Deprecated
-    @Override
-    public RedisClusterPubSubReactiveCommands<K, V> reactive() {
-        return (RedisClusterPubSubReactiveCommands<K, V>) super.reactive();
-    }
-
-    /**
-     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisClusterPubSubReactiveCommands#factory()} instead;
-     *             scheduled for removal in Lettuce 8.0.
-     */
-    @Deprecated
-    @Override
-    protected RedisPubSubReactiveCommandsImpl<K, V> newRedisReactiveCommandsImpl() {
-        return new RedisClusterPubSubReactiveCommandsImpl<K, V>(this, codec);
-    }
-
     @Override
     protected List<RedisFuture<Void>> resubscribe() {
 

--- a/src/main/java/io/lettuce/core/cluster/api/StatefulRedisClusterConnection.java
+++ b/src/main/java/io/lettuce/core/cluster/api/StatefulRedisClusterConnection.java
@@ -67,17 +67,6 @@ public interface StatefulRedisClusterConnection<K, V> extends StatefulConnection
     RedisAdvancedClusterAsyncCommands<K, V> async();
 
     /**
-     * Returns the {@link RedisAdvancedClusterReactiveCommands} API for the current connection. Does not create a new
-     * connection.
-     *
-     * @return the reactive API for the underlying connection.
-     * @deprecated since 7.7, use {@link #commands(CommandsFactory)} with {@link RedisAdvancedClusterReactiveCommands#factory()}
-     *             instead; scheduled for removal in Lettuce 8.0.
-     */
-    @Deprecated
-    RedisAdvancedClusterReactiveCommands<K, V> reactive();
-
-    /**
      * Retrieve a connection to the specified cluster node using the {@code nodeId} suitable for {@link ConnectionIntent#WRITE
      * write operations}. Host and port are looked up in the node list. This connection is bound to the node id. Once the
      * cluster topology view is updated, the connection will try to reconnect the to the node with the specified {@code nodeId},

--- a/src/main/java/io/lettuce/core/cluster/api/StatefulRedisClusterConnection.java
+++ b/src/main/java/io/lettuce/core/cluster/api/StatefulRedisClusterConnection.java
@@ -292,12 +292,8 @@ public interface StatefulRedisClusterConnection<K, V> extends StatefulConnection
      * @param factory the command API factory, must not be {@code null}
      * @param <T> the command API type
      * @return the command API bound to this connection
-     * @throws UnsupportedOperationException if the connection implementation does not override this method. The default is
-     *         provided only for source compatibility in Lettuce 7.x and becomes an abstract method in Lettuce 8.0.
      * @since 7.7
      */
-    default <T> T commands(CommandsFactory<StatefulRedisClusterConnection<K, V>, T> factory) {
-        throw new UnsupportedOperationException("commands(CommandsFactory) is not implemented by this connection");
-    }
+    <T> T commands(CommandsFactory<StatefulRedisClusterConnection<K, V>, T> factory);
 
 }

--- a/src/main/java/io/lettuce/core/cluster/api/StatefulRedisClusterConnection.java
+++ b/src/main/java/io/lettuce/core/cluster/api/StatefulRedisClusterConnection.java
@@ -30,7 +30,6 @@ import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.cluster.ClusterClientOptions;
 import io.lettuce.core.cluster.api.async.RedisAdvancedClusterAsyncCommands;
 import io.lettuce.core.cluster.api.push.RedisClusterPushListener;
-import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
 import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
 import io.lettuce.core.cluster.models.partitions.Partitions;
 import io.lettuce.core.protocol.ConnectionIntent;

--- a/src/main/java/io/lettuce/core/cluster/pubsub/StatefulRedisClusterPubSubConnection.java
+++ b/src/main/java/io/lettuce/core/cluster/pubsub/StatefulRedisClusterPubSubConnection.java
@@ -80,16 +80,6 @@ public interface StatefulRedisClusterPubSubConnection<K, V> extends StatefulRedi
     RedisClusterPubSubAsyncCommands<K, V> async();
 
     /**
-     * Returns the {@link RedisClusterPubSubReactiveCommands} API for the current connection. Does not create a new connection.
-     *
-     * @return the reactive API for the underlying connection.
-     * @deprecated since 7.7, use {@link #commands(ClusterPubSubCommandsFactory)} with
-     *             {@link RedisClusterPubSubReactiveCommands#factory()} instead; scheduled for removal in Lettuce 8.0.
-     */
-    @Deprecated
-    RedisClusterPubSubReactiveCommands<K, V> reactive();
-
-    /**
      * Retrieve a connection to the specified cluster node using the nodeId. Host and port are looked up in the node list. This
      * connection is bound to the node id. Once the cluster topology view is updated, the connection will try to reconnect the
      * to the node with the specified {@code nodeId}, that behavior can also lead to a closed connection once the node with the

--- a/src/main/java/io/lettuce/core/cluster/pubsub/StatefulRedisClusterPubSubConnection.java
+++ b/src/main/java/io/lettuce/core/cluster/pubsub/StatefulRedisClusterPubSubConnection.java
@@ -198,12 +198,8 @@ public interface StatefulRedisClusterPubSubConnection<K, V> extends StatefulRedi
      * @param factory the command API factory, must not be {@code null}
      * @param <T> the command API type
      * @return the command API bound to this connection
-     * @throws UnsupportedOperationException if the connection implementation does not override this method. The default is
-     *         provided only for source compatibility in Lettuce 7.x and becomes an abstract method in Lettuce 8.0.
      * @since 7.7
      */
-    default <T> T commands(ClusterPubSubCommandsFactory<StatefulRedisClusterPubSubConnection<K, V>, T> factory) {
-        throw new UnsupportedOperationException("commands(ClusterPubSubCommandsFactory) is not implemented by this connection");
-    }
+    <T> T commands(ClusterPubSubCommandsFactory<StatefulRedisClusterPubSubConnection<K, V>, T> factory);
 
 }

--- a/src/main/java/io/lettuce/core/dynamic/RedisCommandFactory.java
+++ b/src/main/java/io/lettuce/core/dynamic/RedisCommandFactory.java
@@ -10,7 +10,9 @@ import io.lettuce.core.AbstractRedisReactiveCommands;
 import io.lettuce.core.RedisCommandExecutionException;
 import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
 import io.lettuce.core.codec.ByteArrayCodec;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.codec.StringCodec;
@@ -260,11 +262,12 @@ public class RedisCommandFactory {
             Object reactive = null;
 
             if (connection instanceof StatefulRedisConnection) {
-                reactive = ((StatefulRedisConnection) connection).reactive();
+                reactive = ((StatefulRedisConnection) connection).commands(RedisReactiveCommands.factory());
             }
 
             if (connection instanceof StatefulRedisClusterConnection) {
-                reactive = ((StatefulRedisClusterConnection) connection).reactive();
+                reactive = ((StatefulRedisClusterConnection) connection)
+                        .commands(RedisAdvancedClusterReactiveCommands.factory());
             }
 
             if (reactive != null && Proxy.isProxyClass(reactive.getClass())) {

--- a/src/main/java/io/lettuce/core/failover/StatefulRedisMultiDbConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/failover/StatefulRedisMultiDbConnectionImpl.java
@@ -83,13 +83,6 @@ class StatefulRedisMultiDbConnectionImpl<C extends StatefulRedisConnection<K, V>
 
     protected final RedisAsyncCommandsImpl<K, V> async;
 
-    /**
-     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisReactiveCommands#factory()} instead; scheduled for
-     *             removal in Lettuce 8.0.
-     */
-    @Deprecated
-    protected final RedisReactiveCommandsImpl<K, V> reactive;
-
     protected final RedisCodec<K, V> codec;
 
     protected final Store store = new Store();
@@ -203,7 +196,6 @@ class StatefulRedisMultiDbConnectionImpl<C extends StatefulRedisConnection<K, V>
 
         this.async = newRedisAsyncCommandsImpl();
         this.sync = newRedisSyncCommandsImpl();
-        this.reactive = newRedisReactiveCommandsImpl();
         this.completion = completion;
         if (completion != null) {
             completion.whenComplete(this::onDatabaseCompletion);
@@ -469,31 +461,6 @@ class StatefulRedisMultiDbConnectionImpl<C extends StatefulRedisConnection<K, V>
      */
     protected RedisAsyncCommandsImpl<K, V> newRedisAsyncCommandsImpl() {
         return new RedisAsyncCommandsImpl<>(this, codec, () -> this.getOptions().getJsonParser().get());
-    }
-
-    /**
-     * Returns the reactive API. The API is a dynamic proxy that remains valid across database switches.
-     *
-     * @return the reactive commands API.
-     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisReactiveCommands#factory()} instead; scheduled for
-     *             removal in Lettuce 8.0.
-     */
-    @Deprecated
-    @Override
-    public RedisReactiveCommands<K, V> reactive() {
-        return reactive;
-    }
-
-    /**
-     * Create a new instance of {@link RedisReactiveCommandsImpl}. Can be overridden to extend.
-     *
-     * @return a new instance
-     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisReactiveCommands#factory()} instead; scheduled for
-     *             removal in Lettuce 8.0.
-     */
-    @Deprecated
-    protected RedisReactiveCommandsImpl<K, V> newRedisReactiveCommandsImpl() {
-        return new RedisReactiveCommandsImpl<>(this, codec, () -> this.getOptions().getJsonParser().get());
     }
 
     /**

--- a/src/main/java/io/lettuce/core/failover/StatefulRedisMultiDbPubSubConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/failover/StatefulRedisMultiDbPubSubConnectionImpl.java
@@ -106,27 +106,6 @@ class StatefulRedisMultiDbPubSubConnectionImpl<K, V>
     }
 
     /**
-     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisPubSubReactiveCommands#factory()} instead; scheduled
-     *             for removal in Lettuce 8.0.
-     */
-    @Deprecated
-    @Override
-    @SuppressWarnings("unchecked")
-    public RedisPubSubReactiveCommands<K, V> reactive() {
-        return (RedisPubSubReactiveCommands<K, V>) reactive;
-    }
-
-    /**
-     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisPubSubReactiveCommands#factory()} instead; scheduled
-     *             for removal in Lettuce 8.0.
-     */
-    @Deprecated
-    @Override
-    protected RedisPubSubReactiveCommandsImpl<K, V> newRedisReactiveCommandsImpl() {
-        return new RedisPubSubReactiveCommandsImpl<>(this, codec);
-    }
-
-    /**
      * In addition to the standard database switch behavior from the parent class, this method also:
      * <ul>
      * <li>Migrates all PubSub listeners from the old database connection to the new one</li>

--- a/src/main/java/io/lettuce/core/masterslave/MasterSlaveConnectionWrapper.java
+++ b/src/main/java/io/lettuce/core/masterslave/MasterSlaveConnectionWrapper.java
@@ -57,16 +57,6 @@ class MasterSlaveConnectionWrapper<K, V> implements StatefulRedisMasterSlaveConn
         return delegate.async();
     }
 
-    /**
-     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisReactiveCommands#factory()} instead; scheduled for
-     *             removal in Lettuce 8.0.
-     */
-    @Deprecated
-    @Override
-    public RedisReactiveCommands<K, V> reactive() {
-        return delegate.reactive();
-    }
-
     @Override
     public void addListener(RedisConnectionStateListener listener) {
         this.delegate.addListener(listener);

--- a/src/main/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnection.java
+++ b/src/main/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnection.java
@@ -44,16 +44,6 @@ public interface StatefulRedisPubSubConnection<K, V> extends StatefulRedisConnec
     RedisPubSubAsyncCommands<K, V> async();
 
     /**
-     * Returns the {@link RedisPubSubReactiveCommands} API for the current connection. Does not create a new connection.
-     *
-     * @return the reactive API for the underlying connection.
-     * @deprecated since 7.7, use {@link #commands(PubSubCommandsFactory)} with {@link RedisPubSubReactiveCommands#factory()}
-     *             instead; scheduled for removal in Lettuce 8.0.
-     */
-    @Deprecated
-    RedisPubSubReactiveCommands<K, V> reactive();
-
-    /**
      * Add a new {@link RedisPubSubListener listener}.
      *
      * @param listener the listener, must not be {@code null}.

--- a/src/main/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnection.java
+++ b/src/main/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnection.java
@@ -65,12 +65,8 @@ public interface StatefulRedisPubSubConnection<K, V> extends StatefulRedisConnec
      * @param factory the command API factory, must not be {@code null}
      * @param <T> the command API type
      * @return the command API bound to this connection
-     * @throws UnsupportedOperationException if the connection implementation does not override this method. The default is
-     *         provided only for source compatibility in Lettuce 7.x and becomes an abstract method in Lettuce 8.0.
      * @since 7.7
      */
-    default <T> T commands(PubSubCommandsFactory<StatefulRedisPubSubConnection<K, V>, T> factory) {
-        throw new UnsupportedOperationException("commands(PubSubCommandsFactory) is not implemented by this connection");
-    }
+    <T> T commands(PubSubCommandsFactory<StatefulRedisPubSubConnection<K, V>, T> factory);
 
 }

--- a/src/main/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnection.java
+++ b/src/main/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnection.java
@@ -3,7 +3,6 @@ package io.lettuce.core.pubsub;
 import io.lettuce.core.api.PubSubCommandsFactory;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.pubsub.api.async.RedisPubSubAsyncCommands;
-import io.lettuce.core.pubsub.api.reactive.RedisPubSubReactiveCommands;
 import io.lettuce.core.pubsub.api.sync.RedisPubSubCommands;
 
 /**

--- a/src/main/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnectionImpl.java
@@ -112,26 +112,6 @@ public class StatefulRedisPubSubConnectionImpl<K, V> extends StatefulRedisConnec
     }
 
     /**
-     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisPubSubReactiveCommands#factory()} instead; scheduled
-     *             for removal in Lettuce 8.0.
-     */
-    @Deprecated
-    @Override
-    public RedisPubSubReactiveCommands<K, V> reactive() {
-        return (RedisPubSubReactiveCommands<K, V>) reactive;
-    }
-
-    /**
-     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisPubSubReactiveCommands#factory()} instead; scheduled
-     *             for removal in Lettuce 8.0.
-     */
-    @Deprecated
-    @Override
-    protected RedisPubSubReactiveCommandsImpl<K, V> newRedisReactiveCommandsImpl() {
-        return new RedisPubSubReactiveCommandsImpl<>(this, codec);
-    }
-
-    /**
      * Re-subscribe to all previously subscribed channels and patterns.
      *
      * @return list of the futures of the {@literal subscribe} and {@literal psubscribe} commands.

--- a/src/main/java/io/lettuce/core/sentinel/StatefulRedisSentinelConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/sentinel/StatefulRedisSentinelConnectionImpl.java
@@ -52,13 +52,6 @@ public class StatefulRedisSentinelConnectionImpl<K, V> extends RedisChannelHandl
 
     protected final RedisSentinelAsyncCommands<K, V> async;
 
-    /**
-     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisSentinelReactiveCommands#factory()} instead; scheduled
-     *             for removal in Lettuce 8.0.
-     */
-    @Deprecated
-    protected final RedisSentinelReactiveCommands<K, V> reactive;
-
     private final SentinelConnectionState connectionState = new SentinelConnectionState();
 
     /**
@@ -88,7 +81,6 @@ public class StatefulRedisSentinelConnectionImpl<K, V> extends RedisChannelHandl
         this.codec = codec;
         this.async = new RedisSentinelAsyncCommandsImpl<>(this, codec);
         this.sync = syncHandler(async, RedisSentinelCommands.class);
-        this.reactive = new RedisSentinelReactiveCommandsImpl<>(this, codec, parser);
     }
 
     @Override
@@ -109,16 +101,6 @@ public class StatefulRedisSentinelConnectionImpl<K, V> extends RedisChannelHandl
     @Override
     public RedisSentinelAsyncCommands<K, V> async() {
         return async;
-    }
-
-    /**
-     * @deprecated since 7.7, use {@code commands(...)} with {@link RedisSentinelReactiveCommands#factory()} instead; scheduled
-     *             for removal in Lettuce 8.0.
-     */
-    @Deprecated
-    @Override
-    public RedisSentinelReactiveCommands<K, V> reactive() {
-        return reactive;
     }
 
     /**

--- a/src/main/java/io/lettuce/core/sentinel/StatefulRedisSentinelConnectionImpl.java
+++ b/src/main/java/io/lettuce/core/sentinel/StatefulRedisSentinelConnectionImpl.java
@@ -35,7 +35,6 @@ import io.lettuce.core.api.CommandsFactory;
 import io.lettuce.core.internal.LettuceAssert;
 import io.lettuce.core.sentinel.api.StatefulRedisSentinelConnection;
 import io.lettuce.core.sentinel.api.async.RedisSentinelAsyncCommands;
-import io.lettuce.core.sentinel.api.reactive.RedisSentinelReactiveCommands;
 import io.lettuce.core.sentinel.api.sync.RedisSentinelCommands;
 
 import static io.lettuce.core.ClientOptions.DEFAULT_JSON_PARSER;

--- a/src/main/java/io/lettuce/core/sentinel/api/StatefulRedisSentinelConnection.java
+++ b/src/main/java/io/lettuce/core/sentinel/api/StatefulRedisSentinelConnection.java
@@ -42,16 +42,6 @@ public interface StatefulRedisSentinelConnection<K, V> extends StatefulConnectio
     RedisSentinelAsyncCommands<K, V> async();
 
     /**
-     * Returns the {@link RedisSentinelReactiveCommands} API for the current connection. Does not create a new connection.
-     *
-     * @return the reactive API for the underlying connection.
-     * @deprecated since 7.7, use {@link #commands(CommandsFactory)} with {@link RedisSentinelReactiveCommands#factory()}
-     *             instead; scheduled for removal in Lettuce 8.0.
-     */
-    @Deprecated
-    RedisSentinelReactiveCommands<K, V> reactive();
-
-    /**
      * Returns the command API created by {@code factory}, bound to this connection. Does not create a new connection.
      * <p>
      * The command API is created once per connection and cached; calling this method again with the same {@code factory}

--- a/src/main/java/io/lettuce/core/sentinel/api/StatefulRedisSentinelConnection.java
+++ b/src/main/java/io/lettuce/core/sentinel/api/StatefulRedisSentinelConnection.java
@@ -49,12 +49,8 @@ public interface StatefulRedisSentinelConnection<K, V> extends StatefulConnectio
      * @param factory the command API factory, must not be {@code null}
      * @param <T> the command API type
      * @return the command API bound to this connection
-     * @throws UnsupportedOperationException if the connection implementation does not override this method. The default is
-     *         provided only for source compatibility in Lettuce 7.x and becomes an abstract method in Lettuce 8.0.
      * @since 7.7
      */
-    default <T> T commands(CommandsFactory<StatefulRedisSentinelConnection<K, V>, T> factory) {
-        throw new UnsupportedOperationException("commands(CommandsFactory) is not implemented by this connection");
-    }
+    <T> T commands(CommandsFactory<StatefulRedisSentinelConnection<K, V>, T> factory);
 
 }

--- a/src/main/java/io/lettuce/core/sentinel/api/StatefulRedisSentinelConnection.java
+++ b/src/main/java/io/lettuce/core/sentinel/api/StatefulRedisSentinelConnection.java
@@ -5,7 +5,6 @@ import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.protocol.ConnectionWatchdog;
 import io.lettuce.core.sentinel.api.async.RedisSentinelAsyncCommands;
-import io.lettuce.core.sentinel.api.reactive.RedisSentinelReactiveCommands;
 import io.lettuce.core.sentinel.api.sync.RedisSentinelCommands;
 
 /**

--- a/src/main/java/io/lettuce/core/support/ConnectionWrapping.java
+++ b/src/main/java/io/lettuce/core/support/ConnectionWrapping.java
@@ -123,8 +123,9 @@ public class ConnectionWrapping {
 
             try {
 
-                if (method.getName().equals("sync") || method.getName().equals("async")
-                        || method.getName().equals("reactive")) {
+                // TODO: when sync()/async() are removed, delete this branch and the connectionProxies map - the
+                // commands(...) branch below already wraps every command API generically (keyed by factory).
+                if (method.getName().equals("sync") || method.getName().equals("async")) {
                     return connectionProxies.computeIfAbsent(method, m -> getInnerProxy(method, args));
                 }
 

--- a/src/main/kotlin/io/lettuce/core/api/StatefulRedisConnectionExtensions.kt
+++ b/src/main/kotlin/io/lettuce/core/api/StatefulRedisConnectionExtensions.kt
@@ -3,6 +3,7 @@ package io.lettuce.core.api
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
 import io.lettuce.core.api.coroutines.RedisCoroutinesCommands
 import io.lettuce.core.api.coroutines.RedisCoroutinesCommandsImpl
+import io.lettuce.core.api.reactive.RedisReactiveCommands
 
 /**
  * Extension for [StatefulRedisConnection] to create [RedisCoroutinesCommands]
@@ -12,4 +13,4 @@ import io.lettuce.core.api.coroutines.RedisCoroutinesCommandsImpl
  * @since 6.0
  */
 @ExperimentalLettuceCoroutinesApi
-fun <K : Any, V : Any> StatefulRedisConnection<K, V>.coroutines(): RedisCoroutinesCommands<K, V> = RedisCoroutinesCommandsImpl(reactive())
+fun <K : Any, V : Any> StatefulRedisConnection<K, V>.coroutines(): RedisCoroutinesCommands<K, V> = RedisCoroutinesCommandsImpl(commands(RedisReactiveCommands.factory<K, V>()))

--- a/src/main/kotlin/io/lettuce/core/cluster/api/StatefulRedisClusterConnectionExtensions.kt
+++ b/src/main/kotlin/io/lettuce/core/cluster/api/StatefulRedisClusterConnectionExtensions.kt
@@ -3,6 +3,7 @@ package io.lettuce.core.cluster.api
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
 import io.lettuce.core.cluster.api.coroutines.RedisClusterCoroutinesCommands
 import io.lettuce.core.cluster.api.coroutines.RedisClusterCoroutinesCommandsImpl
+import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands
 
 /**
  * Extension for [StatefulRedisClusterConnection] to create [RedisClusterCoroutinesCommands]
@@ -12,4 +13,4 @@ import io.lettuce.core.cluster.api.coroutines.RedisClusterCoroutinesCommandsImpl
  * @since 6.0
  */
 @ExperimentalLettuceCoroutinesApi
-fun <K : Any, V : Any> StatefulRedisClusterConnection<K, V>.coroutines(): RedisClusterCoroutinesCommands<K, V> = RedisClusterCoroutinesCommandsImpl(reactive())
+fun <K : Any, V : Any> StatefulRedisClusterConnection<K, V>.coroutines(): RedisClusterCoroutinesCommands<K, V> = RedisClusterCoroutinesCommandsImpl(commands(RedisAdvancedClusterReactiveCommands.factory<K, V>()))

--- a/src/main/kotlin/io/lettuce/core/sentinel/api/StatefulRedisSentinelConnectionExtensions.kt
+++ b/src/main/kotlin/io/lettuce/core/sentinel/api/StatefulRedisSentinelConnectionExtensions.kt
@@ -3,6 +3,7 @@ package io.lettuce.core.sentinel.api
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
 import io.lettuce.core.sentinel.api.coroutines.RedisSentinelCoroutinesCommands
 import io.lettuce.core.sentinel.api.coroutines.RedisSentinelCoroutinesCommandsImpl
+import io.lettuce.core.sentinel.api.reactive.RedisSentinelReactiveCommands
 
 /**
  * Extension for [StatefulRedisSentinelConnection] to create [RedisSentinelCoroutinesCommands]
@@ -12,4 +13,4 @@ import io.lettuce.core.sentinel.api.coroutines.RedisSentinelCoroutinesCommandsIm
  * @since 6.0
  */
 @ExperimentalLettuceCoroutinesApi
-fun <K : Any, V : Any> StatefulRedisSentinelConnection<K, V>.coroutines(): RedisSentinelCoroutinesCommands<K, V> = RedisSentinelCoroutinesCommandsImpl(reactive())
+fun <K : Any, V : Any> StatefulRedisSentinelConnection<K, V>.coroutines(): RedisSentinelCoroutinesCommands<K, V> = RedisSentinelCoroutinesCommandsImpl(commands(RedisSentinelReactiveCommands.factory<K, V>()))

--- a/src/test/java/io/lettuce/authx/DefaultAzureCredentialsIntegrationTests.java
+++ b/src/test/java/io/lettuce/authx/DefaultAzureCredentialsIntegrationTests.java
@@ -9,6 +9,7 @@ import io.lettuce.core.RedisURI;
 import io.lettuce.core.SocketOptions;
 import io.lettuce.core.TimeoutOptions;
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.test.env.Endpoints;
 import io.lettuce.test.env.Endpoints.Endpoint;
@@ -88,7 +89,7 @@ public class DefaultAzureCredentialsIntegrationTests {
             sync.set(key, "value");
             assertThat(sync.get(key)).isEqualTo("value");
             assertThat(connection.async().get(key).get()).isEqualTo("value");
-            assertThat(connection.reactive().get(key).block()).isEqualTo("value");
+            assertThat(connection.commands(RedisReactiveCommands.factory()).get(key).block()).isEqualTo("value");
             sync.del(key);
         }
     }

--- a/src/test/java/io/lettuce/authx/EntraIdClusterIntegrationTests.java
+++ b/src/test/java/io/lettuce/authx/EntraIdClusterIntegrationTests.java
@@ -9,6 +9,7 @@ import io.lettuce.core.cluster.ClusterClientOptions;
 import io.lettuce.core.cluster.ClusterTopologyRefreshOptions;
 import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
 import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
 import io.lettuce.core.resource.ClientResources;
 import io.lettuce.core.resource.DnsResolver;
@@ -109,7 +110,8 @@ public class EntraIdClusterIntegrationTests {
             for (String mykey : mset.keySet()) {
                 assertThat(defaultConnection.sync().get(mykey)).isEqualTo("value-" + mykey);
                 assertThat(defaultConnection.async().get(mykey).get()).isEqualTo("value-" + mykey);
-                assertThat(defaultConnection.reactive().get(mykey).block()).isEqualTo("value-" + mykey);
+                assertThat(defaultConnection.commands(RedisAdvancedClusterReactiveCommands.factory()).get(mykey).block())
+                        .isEqualTo("value-" + mykey);
             }
             assertThat(sync.del(mset.keySet().toArray(new String[0]))).isEqualTo(mset.keySet().size());
 

--- a/src/test/java/io/lettuce/authx/EntraIdIntegrationTests.java
+++ b/src/test/java/io/lettuce/authx/EntraIdIntegrationTests.java
@@ -4,6 +4,7 @@ import io.lettuce.core.*;
 import io.lettuce.core.RedisCredentialsProvider.CredentialsSubscription;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 import io.lettuce.core.support.PubSubTestListener;
@@ -80,7 +81,7 @@ public class EntraIdIntegrationTests {
             sync.set(key, "value");
             assertThat(connection.sync().get(key)).isEqualTo("value");
             assertThat(connection.async().get(key).get()).isEqualTo("value");
-            assertThat(connection.reactive().get(key).block()).isEqualTo("value");
+            assertThat(connection.commands(RedisReactiveCommands.factory()).get(key).block()).isEqualTo("value");
             sync.del(key);
         }
     }

--- a/src/test/java/io/lettuce/authx/EntraIdManagedIdentityIntegrationTests.java
+++ b/src/test/java/io/lettuce/authx/EntraIdManagedIdentityIntegrationTests.java
@@ -4,6 +4,7 @@ import io.lettuce.core.ClientOptions;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.cluster.ClusterClientOptions;
 import io.lettuce.test.env.Endpoints;
@@ -67,7 +68,7 @@ public class EntraIdManagedIdentityIntegrationTests {
                 sync.set(key, "value");
                 assertThat(connection.sync().get(key)).isEqualTo("value");
                 assertThat(connection.async().get(key).get()).isEqualTo("value");
-                assertThat(connection.reactive().get(key).block()).isEqualTo("value");
+                assertThat(connection.commands(RedisReactiveCommands.factory()).get(key).block()).isEqualTo("value");
                 sync.del(key);
             }
         }
@@ -96,7 +97,7 @@ public class EntraIdManagedIdentityIntegrationTests {
                 sync.set(key, "value");
                 assertThat(connection.sync().get(key)).isEqualTo("value");
                 assertThat(connection.async().get(key).get()).isEqualTo("value");
-                assertThat(connection.reactive().get(key).block()).isEqualTo("value");
+                assertThat(connection.commands(RedisReactiveCommands.factory()).get(key).block()).isEqualTo("value");
                 sync.del(key);
             }
         }

--- a/src/test/java/io/lettuce/core/ClientOptionsIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/ClientOptionsIntegrationTests.java
@@ -46,6 +46,7 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.codec.StringCodec;
 import io.lettuce.core.output.StatusOutput;
@@ -427,7 +428,7 @@ class ClientOptionsIntegrationTests extends TestSupport {
 
             connection.async().clientPause(300);
 
-            Mono<String> mono = connection.reactive().ping();
+            Mono<String> mono = connection.commands(RedisReactiveCommands.factory()).ping();
 
             StepVerifier.create(mono).expectError(RedisCommandTimeoutException.class).verify();
         }

--- a/src/test/java/io/lettuce/core/ConnectMethodsIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/ConnectMethodsIntegrationTests.java
@@ -3,8 +3,12 @@ package io.lettuce.core;
 import javax.inject.Inject;
 
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
+import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
 import io.lettuce.core.cluster.pubsub.StatefulRedisClusterPubSubConnection;
+import io.lettuce.core.cluster.pubsub.api.reactive.RedisClusterPubSubReactiveCommands;
 import io.lettuce.core.sentinel.api.StatefulRedisSentinelConnection;
+import io.lettuce.core.sentinel.api.reactive.RedisSentinelReactiveCommands;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,7 +54,7 @@ class ConnectMethodsIntegrationTests {
     @Test
     void standaloneReactive() {
         try (StatefulRedisConnection<String, String> connection = redisClient.connect()) {
-            connection.reactive();
+            connection.commands(RedisReactiveCommands.factory());
         }
     }
 
@@ -98,7 +102,7 @@ class ConnectMethodsIntegrationTests {
     @Test
     void sentinelReactive() {
         try (StatefulRedisSentinelConnection<String, String> connection = redisClient.connectSentinel()) {
-            connection.reactive();
+            connection.commands(RedisSentinelReactiveCommands.factory());
         }
     }
 
@@ -125,7 +129,7 @@ class ConnectMethodsIntegrationTests {
     @Test
     void clusterReactive() {
         try (StatefulRedisClusterConnection<String, String> connection = clusterClient.connect()) {
-            connection.reactive();
+            connection.commands(RedisAdvancedClusterReactiveCommands.factory());
         }
     }
 
@@ -151,7 +155,7 @@ class ConnectMethodsIntegrationTests {
     @Test
     void clusterPubSubReactive() {
         try (StatefulRedisClusterPubSubConnection<String, String> connection = clusterClient.connectPubSub()) {
-            connection.reactive();
+            connection.commands(RedisClusterPubSubReactiveCommands.factory());
         }
     }
 
@@ -181,7 +185,7 @@ class ConnectMethodsIntegrationTests {
     void advancedClusterReactive() {
         try (StatefulRedisClusterConnection<String, String> statefulConnection = clusterClient.connect()) {
             RedisURI uri = clusterClient.getPartitions().getPartition(0).getUri();
-            statefulConnection.getConnection(uri.getHost(), uri.getPort()).reactive();
+            statefulConnection.getConnection(uri.getHost(), uri.getPort()).commands(RedisReactiveCommands.factory());
         }
     }
 

--- a/src/test/java/io/lettuce/core/CustomCodecIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/CustomCodecIntegrationTests.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import reactor.test.StepVerifier;
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.codec.*;
 import io.lettuce.test.LettuceExtension;
@@ -80,7 +81,8 @@ class CustomCodecIntegrationTests extends TestSupport {
         StatefulRedisConnection<String, Object> redisConnection = client.connect(new SerializedObjectCodec());
         List<String> list = list("one", "two");
 
-        StepVerifier.create(redisConnection.reactive().set(key, list, SetArgs.Builder.ex(1))).expectNext("OK").verifyComplete();
+        StepVerifier.create(redisConnection.commands(RedisReactiveCommands.factory()).set(key, list, SetArgs.Builder.ex(1)))
+                .expectNext("OK").verifyComplete();
         redisConnection.close();
     }
 

--- a/src/test/java/io/lettuce/core/ReactiveConnectionIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/ReactiveConnectionIntegrationTests.java
@@ -72,7 +72,7 @@ class ReactiveConnectionIntegrationTests extends TestSupport {
     ReactiveConnectionIntegrationTests(StatefulRedisConnection<String, String> connection) {
         this.connection = connection;
         this.redis = connection.sync();
-        this.reactive = connection.reactive();
+        this.reactive = connection.commands(RedisReactiveCommands.factory());
     }
 
     @BeforeEach
@@ -83,7 +83,7 @@ class ReactiveConnectionIntegrationTests extends TestSupport {
     @Test
     void doNotFireCommandUntilObservation() {
 
-        RedisReactiveCommands<String, String> reactive = connection.reactive();
+        RedisReactiveCommands<String, String> reactive = connection.commands(RedisReactiveCommands.factory());
         Mono<String> set = reactive.set(key, value);
         Delay.delay(Duration.ofMillis(50));
         assertThat(redis.get(key)).isNull();
@@ -132,7 +132,7 @@ class ReactiveConnectionIntegrationTests extends TestSupport {
 
         final CountDownLatch sync = new CountDownLatch(1);
         try (StatefulRedisConnection<String, String> statefulRedisConnection = client.connect()) {
-            RedisReactiveCommands<String, String> reactive = statefulRedisConnection.reactive();
+            RedisReactiveCommands<String, String> reactive = statefulRedisConnection.commands(RedisReactiveCommands.factory());
 
             reactive.multi().subscribe(multiResponse -> {
                 reactive.set(key, "1").subscribe();
@@ -199,9 +199,9 @@ class ReactiveConnectionIntegrationTests extends TestSupport {
         connection.async().quit();
         Wait.untilTrue(() -> !connection.isOpen()).waitOrTimeout();
 
-        StepVerifier
-                .create(connection.reactive().ping()).consumeErrorWith(throwable -> assertThat(throwable)
-                        .isInstanceOf(RedisException.class).hasMessageContaining("not connected. Commands are rejected"))
+        StepVerifier.create(connection.commands(RedisReactiveCommands.factory()).ping())
+                .consumeErrorWith(throwable -> assertThat(throwable).isInstanceOf(RedisException.class)
+                        .hasMessageContaining("not connected. Commands are rejected"))
                 .verify();
 
         connection.close();
@@ -213,7 +213,7 @@ class ReactiveConnectionIntegrationTests extends TestSupport {
 
         client.setOptions(ClientOptions.builder().publishOnScheduler(true).build());
         try (StatefulRedisConnection<String, String> statefulRedisConnection = client.connect()) {
-            RedisReactiveCommands<String, String> reactive = statefulRedisConnection.reactive();
+            RedisReactiveCommands<String, String> reactive = statefulRedisConnection.commands(RedisReactiveCommands.factory());
 
             int counter = 0;
             for (int i = 0; i < 1000; i++) {

--- a/src/test/java/io/lettuce/core/ReactiveStreamingOutputIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/ReactiveStreamingOutputIntegrationTests.java
@@ -38,7 +38,7 @@ class ReactiveStreamingOutputIntegrationTests extends TestSupport {
     @Inject
     ReactiveStreamingOutputIntegrationTests(StatefulRedisConnection<String, String> connection) {
         this.redis = connection.sync();
-        this.reactive = connection.reactive();
+        this.reactive = connection.commands(RedisReactiveCommands.factory());
     }
 
     @BeforeEach

--- a/src/test/java/io/lettuce/core/ScanStreamIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/ScanStreamIntegrationTests.java
@@ -74,7 +74,8 @@ class ScanStreamIntegrationTests extends TestSupport {
         ScanIterator<String> scan = ScanIterator.scan(redis);
         List<String> list = Flux.fromIterable(() -> scan).collectList().block();
 
-        RedisReactiveCommands<String, String> reactive = redis.getStatefulConnection().reactive();
+        RedisReactiveCommands<String, String> reactive = redis.getStatefulConnection()
+                .commands(RedisReactiveCommands.factory());
 
         StepVerifier.create(ScanStream.scan(reactive, ScanArgs.Builder.limit(200)).take(250)).expectNextCount(250)
                 .verifyComplete();
@@ -88,7 +89,8 @@ class ScanStreamIntegrationTests extends TestSupport {
             redis.hset(key, "field-" + i, "value-" + i);
         }
 
-        RedisReactiveCommands<String, String> reactive = redis.getStatefulConnection().reactive();
+        RedisReactiveCommands<String, String> reactive = redis.getStatefulConnection()
+                .commands(RedisReactiveCommands.factory());
 
         StepVerifier.create(ScanStream.hscan(reactive, key, ScanArgs.Builder.limit(200)).take(250)).expectNextCount(250)
                 .verifyComplete();
@@ -104,7 +106,8 @@ class ScanStreamIntegrationTests extends TestSupport {
             redis.hset(key, "field-" + i, "value-" + i);
         }
 
-        RedisReactiveCommands<String, String> reactive = redis.getStatefulConnection().reactive();
+        RedisReactiveCommands<String, String> reactive = redis.getStatefulConnection()
+                .commands(RedisReactiveCommands.factory());
 
         StepVerifier.create(ScanStream.hscanNovalues(reactive, key, ScanArgs.Builder.limit(200)).take(250)).expectNextCount(250)
                 .verifyComplete();
@@ -118,7 +121,8 @@ class ScanStreamIntegrationTests extends TestSupport {
             redis.sadd(key, "value-" + i);
         }
 
-        RedisReactiveCommands<String, String> reactive = redis.getStatefulConnection().reactive();
+        RedisReactiveCommands<String, String> reactive = redis.getStatefulConnection()
+                .commands(RedisReactiveCommands.factory());
 
         StepVerifier.create(ScanStream.sscan(reactive, key, ScanArgs.Builder.limit(200)), 0).thenRequest(250)
                 .expectNextCount(250).thenCancel().verify();
@@ -132,7 +136,8 @@ class ScanStreamIntegrationTests extends TestSupport {
             redis.zadd(key, (double) i, "value-" + i);
         }
 
-        RedisReactiveCommands<String, String> reactive = redis.getStatefulConnection().reactive();
+        RedisReactiveCommands<String, String> reactive = redis.getStatefulConnection()
+                .commands(RedisReactiveCommands.factory());
 
         StepVerifier.create(ScanStream.zscan(reactive, key, ScanArgs.Builder.limit(200)).take(250)).expectNextCount(250)
                 .verifyComplete();
@@ -142,7 +147,7 @@ class ScanStreamIntegrationTests extends TestSupport {
     @Test
     void shouldCorrectlyEmitItemsWithConcurrentPoll() {
 
-        RedisReactiveCommands<String, String> commands = connection.reactive();
+        RedisReactiveCommands<String, String> commands = connection.commands(RedisReactiveCommands.factory());
 
         String sourceKey = "source";
         String targetKey = "target";
@@ -167,7 +172,7 @@ class ScanStreamIntegrationTests extends TestSupport {
         // NOVALUES flag (since Redis 7.4)
         assumeTrue(RedisConditions.of(redis).hasVersionGreaterOrEqualsTo("7.4"));
 
-        RedisReactiveCommands<String, String> commands = connection.reactive();
+        RedisReactiveCommands<String, String> commands = connection.commands(RedisReactiveCommands.factory());
 
         String sourceKey = "source";
         String targetKey = "target";

--- a/src/test/java/io/lettuce/core/StatefulRedisConnectionImplUnitTests.java
+++ b/src/test/java/io/lettuce/core/StatefulRedisConnectionImplUnitTests.java
@@ -57,9 +57,8 @@ class StatefulRedisConnectionImplUnitTests {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
-    void factoryProducesSameTypeAsReactive() {
-        assertThat(connection.commands(RedisReactiveCommands.factory()).getClass()).isSameAs(connection.reactive().getClass());
+    void factoryProducesReactiveCommands() {
+        assertThat(connection.commands(RedisReactiveCommands.factory())).isInstanceOf(RedisReactiveCommandsImpl.class);
     }
 
 }

--- a/src/test/java/io/lettuce/core/array/RedisArrayReactiveIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/array/RedisArrayReactiveIntegrationTests.java
@@ -40,7 +40,7 @@ public class RedisArrayReactiveIntegrationTests extends RedisArrayIntegrationTes
     @Inject
     RedisArrayReactiveIntegrationTests(StatefulRedisConnection<String, String> connection) {
         super(ReactiveSyncInvocationHandler.sync(connection));
-        this.reactive = connection.reactive();
+        this.reactive = connection.commands(RedisReactiveCommands.factory());
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/cluster/AdvancedClusterClientIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/AdvancedClusterClientIntegrationTests.java
@@ -166,7 +166,8 @@ class AdvancedClusterClientIntegrationTests extends TestSupport {
             assertThat(nodeId).isNotSameAs(hostAndPort);
         }
 
-        RedisAdvancedClusterReactiveCommands<String, String> rx = clusterConnection.reactive();
+        RedisAdvancedClusterReactiveCommands<String, String> rx = clusterConnection
+                .commands(RedisAdvancedClusterReactiveCommands.factory());
         for (RedisClusterNode redisClusterNode : clusterClient.getPartitions()) {
 
             RedisClusterReactiveCommands<String, String> nodeId = rx.getConnection(redisClusterNode.getNodeId());

--- a/src/test/java/io/lettuce/core/cluster/AdvancedClusterReactiveIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/AdvancedClusterReactiveIntegrationTests.java
@@ -91,7 +91,7 @@ class AdvancedClusterReactiveIntegrationTests extends TestSupport {
     AdvancedClusterReactiveIntegrationTests(RedisClusterClient clusterClient,
             StatefulRedisClusterConnection<String, String> connection) {
         this.clusterClient = clusterClient;
-        this.commands = connection.reactive();
+        this.commands = connection.commands(RedisAdvancedClusterReactiveCommands.factory());
         this.syncCommands = connection.sync();
     }
 

--- a/src/test/java/io/lettuce/core/cluster/ClusterCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/ClusterCommandIntegrationTests.java
@@ -27,6 +27,7 @@ import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
 import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
 import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
 import io.lettuce.core.AclSetuserArgs;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.cluster.api.async.RedisAdvancedClusterAsyncCommands;
 import io.lettuce.core.cluster.models.partitions.ClusterPartitionParser;
 import io.lettuce.core.cluster.models.partitions.Partitions;
@@ -109,7 +110,7 @@ class ClusterCommandIntegrationTests extends TestSupport {
         List<Object> result = sync.clusterShards();
         assertThat(result).hasSize(2);
 
-        result = connection.reactive().clusterShards().block(Duration.ofSeconds(5));
+        result = connection.commands(RedisReactiveCommands.factory()).clusterShards().block(Duration.ofSeconds(5));
         assertThat(result).hasSize(2);
     }
 

--- a/src/test/java/io/lettuce/core/cluster/ClusterReactiveCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/ClusterReactiveCommandIntegrationTests.java
@@ -51,7 +51,7 @@ class ClusterReactiveCommandIntegrationTests {
         this.clusterClient = clusterClient;
         this.connection = connection;
 
-        this.reactive = connection.reactive();
+        this.reactive = connection.commands(RedisAdvancedClusterReactiveCommands.factory());
         this.sync = connection.sync();
     }
 
@@ -166,7 +166,8 @@ class ClusterReactiveCommandIntegrationTests {
             try (RedisClusterClient restrictedClient = RedisClusterClient.create(restrictedUri);
                     StatefulRedisClusterConnection<String, String> restrictedConnection = restrictedClient.connect()) {
 
-                RedisAdvancedClusterReactiveCommands<String, String> restrictedReactive = restrictedConnection.reactive();
+                RedisAdvancedClusterReactiveCommands<String, String> restrictedReactive = restrictedConnection
+                        .commands(RedisAdvancedClusterReactiveCommands.factory());
 
                 // This should trigger the fallback to CLUSTER NODES parsing
                 StepVerifier.create(restrictedReactive.clusterMyId().zipWith(restrictedReactive.clusterNodes()))

--- a/src/test/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImplTest.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImplTest.java
@@ -79,7 +79,7 @@ class RedisAdvancedClusterReactiveCommandsImplTest {
         partitions.addPartition(node);
         partitions.updateCache();
 
-        when(nodeConn.reactive()).thenReturn(nodeReactive);
+        when(nodeConn.commands(RedisReactiveCommands.factory())).thenReturn(nodeReactive);
         when(nodeReactive.clusterMyId()).thenReturn(Mono.just("node-1"));
 
         when(clusterConn.getChannelWriter()).thenReturn(writer);

--- a/src/test/java/io/lettuce/core/cluster/RedisReactiveClusterClientIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisReactiveClusterClientIntegrationTests.java
@@ -33,7 +33,7 @@ class RedisReactiveClusterClientIntegrationTests extends TestSupport {
     @Inject
     RedisReactiveClusterClientIntegrationTests(StatefulRedisClusterConnection<String, String> connection) {
         this.sync = connection.sync();
-        this.reactive = connection.reactive();
+        this.reactive = connection.commands(RedisAdvancedClusterReactiveCommands.factory());
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/cluster/ScanStreamIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/ScanStreamIntegrationTests.java
@@ -42,7 +42,8 @@ class ScanStreamIntegrationTests extends TestSupport {
             redis.set("key-" + i, value);
         }
 
-        RedisAdvancedClusterReactiveCommands<String, String> reactive = connection.reactive();
+        RedisAdvancedClusterReactiveCommands<String, String> reactive = connection
+                .commands(RedisAdvancedClusterReactiveCommands.factory());
 
         StepVerifier.create(ScanStream.scan(reactive, ScanArgs.Builder.limit(200)).take(250)).expectNextCount(250)
                 .verifyComplete();

--- a/src/test/java/io/lettuce/core/cluster/SingleThreadedReactiveClusterClientIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/SingleThreadedReactiveClusterClientIntegrationTests.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
 import io.lettuce.core.metrics.DefaultCommandLatencyCollectorOptions;
 import io.lettuce.core.resource.DefaultClientResources;
 import io.lettuce.core.resource.DefaultEventLoopGroupProvider;
@@ -50,8 +51,9 @@ class SingleThreadedReactiveClusterClientIntegrationTests {
         StatefulRedisClusterConnection<String, String> connect = client.connect();
         connect.sync().flushall();
 
-        List<String> keys = connect.reactive().set("key", "value").flatMap(s -> connect.reactive().set("foo", "bar"))
-                .flatMapMany(s -> connect.reactive().keys("*")) //
+        List<String> keys = connect.commands(RedisAdvancedClusterReactiveCommands.factory()).set("key", "value")
+                .flatMap(s -> connect.commands(RedisAdvancedClusterReactiveCommands.factory()).set("foo", "bar"))
+                .flatMapMany(s -> connect.commands(RedisAdvancedClusterReactiveCommands.factory()).keys("*")) //
                 .doOnError(Throwable::printStackTrace) //
                 .collectList() //
                 .block();

--- a/src/test/java/io/lettuce/core/cluster/StatefulRedisClusterConnectionImplUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/StatefulRedisClusterConnectionImplUnitTests.java
@@ -60,10 +60,9 @@ class StatefulRedisClusterConnectionImplUnitTests {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
-    void factoryProducesSameTypeAsReactive() {
-        assertThat(connection.commands(RedisAdvancedClusterReactiveCommands.factory()).getClass())
-                .isSameAs(connection.reactive().getClass());
+    void factoryProducesReactiveCommands() {
+        assertThat(connection.commands(RedisAdvancedClusterReactiveCommands.factory()))
+                .isInstanceOf(RedisAdvancedClusterReactiveCommandsImpl.class);
     }
 
 }

--- a/src/test/java/io/lettuce/core/cluster/StatefulRedisClusterPubSubConnectionImplUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/StatefulRedisClusterPubSubConnectionImplUnitTests.java
@@ -59,10 +59,9 @@ class StatefulRedisClusterPubSubConnectionImplUnitTests {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
-    void factoryProducesSameTypeAsReactive() {
-        assertThat(connection.commands(RedisClusterPubSubReactiveCommands.factory()).getClass())
-                .isSameAs(connection.reactive().getClass());
+    void factoryProducesReactiveCommands() {
+        assertThat(connection.commands(RedisClusterPubSubReactiveCommands.factory()))
+                .isInstanceOf(RedisClusterPubSubReactiveCommandsImpl.class);
     }
 
 }

--- a/src/test/java/io/lettuce/core/cluster/commands/reactive/StringClusterReactiveCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/commands/reactive/StringClusterReactiveCommandIntegrationTests.java
@@ -57,7 +57,8 @@ class StringClusterReactiveCommandIntegrationTests extends StringCommandIntegrat
         redis.set("key1", value);
         redis.set("key2", value);
 
-        RedisAdvancedClusterReactiveCommands<String, String> reactive = connection.reactive();
+        RedisAdvancedClusterReactiveCommands<String, String> reactive = connection
+                .commands(RedisAdvancedClusterReactiveCommands.factory());
 
         Flux<KeyValue<String, String>> mget = reactive.mget(key, "key1", "key2");
         StepVerifier.create(mget.next()).expectNext(KeyValue.just(key, value)).verifyComplete();

--- a/src/test/java/io/lettuce/core/cluster/pubsub/RedisClusterPubSubConnectionIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/pubsub/RedisClusterPubSubConnectionIntegrationTests.java
@@ -28,6 +28,7 @@ import io.lettuce.core.cluster.pubsub.api.async.PubSubAsyncNodeSelection;
 import io.lettuce.core.cluster.pubsub.api.async.RedisClusterPubSubAsyncCommands;
 import io.lettuce.core.cluster.pubsub.api.reactive.NodeSelectionPubSubReactiveCommands;
 import io.lettuce.core.cluster.pubsub.api.reactive.PubSubReactiveNodeSelection;
+import io.lettuce.core.cluster.pubsub.api.reactive.RedisClusterPubSubReactiveCommands;
 import io.lettuce.core.cluster.pubsub.api.sync.NodeSelectionPubSubCommands;
 import io.lettuce.core.cluster.pubsub.api.sync.PubSubNodeSelection;
 import io.lettuce.core.event.command.CommandFailedEvent;
@@ -407,7 +408,8 @@ class RedisClusterPubSubConnectionIntegrationTests extends TestSupport {
 
         pubSubConnection.setNodeMessagePropagation(true);
 
-        PubSubReactiveNodeSelection<String, String> masters = pubSubConnection.reactive().masters();
+        PubSubReactiveNodeSelection<String, String> masters = pubSubConnection
+                .commands(RedisClusterPubSubReactiveCommands.factory()).masters();
         NodeSelectionPubSubReactiveCommands<String, String> commands = masters.commands();
 
         commands.psubscribe("chann*").flux().then().block();

--- a/src/test/java/io/lettuce/core/cluster/topology/TopologyRefreshIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/topology/TopologyRefreshIntegrationTests.java
@@ -30,6 +30,7 @@ import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.api.async.RedisAdvancedClusterAsyncCommands;
 import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
+import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
 import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
 import io.lettuce.core.cluster.models.partitions.Partitions;
 import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
@@ -262,7 +263,7 @@ class TopologyRefreshIntegrationTests extends TestSupport {
         assertThat(clusterClient.getPartitions().getPartitionByNodeId(node1.getNodeId()).getSlots()).hasSize(0);
         assertThat(clusterClient.getPartitions().getPartitionByNodeId(node2.getNodeId()).getSlots()).hasSize(16384);
 
-        connection.reactive().set("b", value).toFuture();// slot 3300
+        connection.commands(RedisAdvancedClusterReactiveCommands.factory()).set("b", value).toFuture();// slot 3300
 
         Wait.untilEquals(12000, () -> clusterClient.getPartitions().getPartitionByNodeId(node1.getNodeId()).getSlots().size())
                 .waitOrTimeout();

--- a/src/test/java/io/lettuce/core/commands/reactive/BitReactiveCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/reactive/BitReactiveCommandIntegrationTests.java
@@ -17,6 +17,7 @@ import io.lettuce.core.BitFieldArgs;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.Value;
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.api.reactive.RedisStringReactiveCommands;
 import io.lettuce.core.commands.BitCommandIntegrationTests;
 import io.lettuce.test.ReactiveSyncInvocationHandler;
@@ -32,7 +33,7 @@ class BitReactiveCommandIntegrationTests extends BitCommandIntegrationTests {
     @Inject
     BitReactiveCommandIntegrationTests(RedisClient client, StatefulRedisConnection<String, String> connection) {
         super(client, ReactiveSyncInvocationHandler.sync(connection));
-        this.reactive = connection.reactive();
+        this.reactive = connection.commands(RedisReactiveCommands.factory());
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/commands/reactive/CustomReactiveCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/reactive/CustomReactiveCommandIntegrationTests.java
@@ -40,7 +40,8 @@ class CustomReactiveCommandIntegrationTests extends TestSupport {
     void dispatchGetAndSet() {
 
         redis.set(key, value);
-        RedisReactiveCommands<String, String> reactive = redis.getStatefulConnection().reactive();
+        RedisReactiveCommands<String, String> reactive = redis.getStatefulConnection()
+                .commands(RedisReactiveCommands.factory());
 
         Flux<String> flux = reactive.dispatch(CommandType.GET, new ValueOutput<>(StringCodec.UTF8),
                 new CommandArgs<>(StringCodec.UTF8).addKey(key));
@@ -52,7 +53,8 @@ class CustomReactiveCommandIntegrationTests extends TestSupport {
     void dispatchList() {
 
         redis.rpush(key, "a", "b", "c");
-        RedisReactiveCommands<String, String> reactive = redis.getStatefulConnection().reactive();
+        RedisReactiveCommands<String, String> reactive = redis.getStatefulConnection()
+                .commands(RedisReactiveCommands.factory());
 
         Flux<String> flux = reactive.dispatch(CommandType.LRANGE, new ValueListOutput<>(StringCodec.UTF8),
                 new CommandArgs<>(StringCodec.UTF8).addKey(key).add(0).add(-1));

--- a/src/test/java/io/lettuce/core/commands/reactive/GeoReactiveCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/reactive/GeoReactiveCommandIntegrationTests.java
@@ -34,7 +34,7 @@ class GeoReactiveCommandIntegrationTests extends GeoCommandIntegrationTests {
     @Override
     public void geopos() {
 
-        RedisReactiveCommands<String, String> reactive = connection.reactive();
+        RedisReactiveCommands<String, String> reactive = connection.commands(RedisReactiveCommands.factory());
 
         prepareGeo();
 

--- a/src/test/java/io/lettuce/core/commands/reactive/HashReactiveCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/reactive/HashReactiveCommandIntegrationTests.java
@@ -15,6 +15,7 @@ import reactor.test.StepVerifier;
 import io.lettuce.core.KeyValue;
 import io.lettuce.core.Value;
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.commands.HashCommandIntegrationTests;
 import io.lettuce.test.ReactiveSyncInvocationHandler;
 
@@ -39,8 +40,8 @@ class HashReactiveCommandIntegrationTests extends HashCommandIntegrationTests {
         connection.sync().hset(key, "one", "1");
         connection.sync().hset(key, "two", "2");
 
-        connection.reactive().hgetall(key).collect(Collectors.toMap(KeyValue::getKey, Value::getValue)).as(StepVerifier::create)
-                .assertNext(actual -> {
+        connection.commands(RedisReactiveCommands.factory()).hgetall(key)
+                .collect(Collectors.toMap(KeyValue::getKey, Value::getValue)).as(StepVerifier::create).assertNext(actual -> {
 
                     assertThat(actual).containsEntry("zero", "0").containsEntry("one", "1").containsEntry("two", "2");
                 }).verifyComplete();

--- a/src/test/java/io/lettuce/core/commands/reactive/ServerReactiveCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/reactive/ServerReactiveCommandIntegrationTests.java
@@ -32,7 +32,7 @@ class ServerReactiveCommandIntegrationTests extends ServerCommandIntegrationTest
     @Inject
     ServerReactiveCommandIntegrationTests(RedisClient client, StatefulRedisConnection<String, String> connection) {
         super(client, ReactiveSyncInvocationHandler.sync(connection));
-        this.reactive = connection.reactive();
+        this.reactive = connection.commands(RedisReactiveCommands.factory());
     }
 
     /**

--- a/src/test/java/io/lettuce/core/commands/reactive/SortedSetReactiveCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/reactive/SortedSetReactiveCommandIntegrationTests.java
@@ -30,7 +30,7 @@ class SortedSetReactiveCommandIntegrationTests extends SortedSetCommandIntegrati
     @Inject
     SortedSetReactiveCommandIntegrationTests(StatefulRedisConnection<String, String> connection) {
         super(ReactiveSyncInvocationHandler.sync(connection));
-        this.reactive = connection.reactive();
+        this.reactive = connection.commands(RedisReactiveCommands.factory());
         this.connection = connection;
     }
 

--- a/src/test/java/io/lettuce/core/commands/reactive/StringReactiveCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/reactive/StringReactiveCommandIntegrationTests.java
@@ -30,7 +30,7 @@ class StringReactiveCommandIntegrationTests extends StringCommandIntegrationTest
     StringReactiveCommandIntegrationTests(StatefulRedisConnection<String, String> connection) {
         super(ReactiveSyncInvocationHandler.sync(connection));
         this.redis = connection.sync();
-        this.reactive = connection.reactive();
+        this.reactive = connection.commands(RedisReactiveCommands.factory());
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/commands/reactive/TransactionReactiveCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/reactive/TransactionReactiveCommandIntegrationTests.java
@@ -33,7 +33,7 @@ public class TransactionReactiveCommandIntegrationTests extends TransactionComma
     public TransactionReactiveCommandIntegrationTests(RedisClient client, StatefulRedisConnection<String, String> connection) {
         super(client, ReactiveSyncInvocationHandler.sync(connection));
         this.client = client;
-        this.commands = connection.reactive();
+        this.commands = connection.commands(RedisReactiveCommands.factory());
         this.connection = connection;
     }
 

--- a/src/test/java/io/lettuce/core/failover/CircuitBreakerFailoverIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/failover/CircuitBreakerFailoverIntegrationTests.java
@@ -38,6 +38,7 @@ import io.lettuce.core.failover.api.CircuitBreakerConfig;
 import io.lettuce.core.failover.api.CircuitBreakerStateChangeEvent;
 import io.lettuce.core.failover.api.CircuitBreakerStateListener;
 import io.lettuce.core.failover.api.StatefulRedisMultiDbConnection;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.test.WithPassword;
 import io.lettuce.test.settings.TestSettings;
 
@@ -428,7 +429,7 @@ class CircuitBreakerFailoverIntegrationTests extends AbstractRedisClientTest {
 
         // Execute commands that will fail using REACTIVE API
         for (int i = 0; i < 20; i++) {
-            connection.reactive().get("key" + i).subscribe();
+            connection.commands(RedisReactiveCommands.factory()).get("key" + i).subscribe();
         }
 
         // Then: Should receive state change event
@@ -464,7 +465,8 @@ class CircuitBreakerFailoverIntegrationTests extends AbstractRedisClientTest {
 
         // Write a test key to endpoint2 (so we can verify failover)
         connection.switchTo(endpoint2);
-        connection.reactive().set("failover-test-key-reactive", "endpoint2-value").block(Duration.ofSeconds(1));
+        connection.commands(RedisReactiveCommands.factory()).set("failover-test-key-reactive", "endpoint2-value")
+                .block(Duration.ofSeconds(1));
         connection.switchTo(endpoint1);
 
         // Track state changes
@@ -485,7 +487,7 @@ class CircuitBreakerFailoverIntegrationTests extends AbstractRedisClientTest {
         int aimedFailureCount = cbConfig.getMinimumNumberOfFailures();
         // Execute commands that will fail on endpoint1 using REACTIVE API
         for (int i = 0; i < aimedFailureCount; i++) {
-            connection.reactive().get("key" + i).subscribe();
+            connection.commands(RedisReactiveCommands.factory()).get("key" + i).subscribe();
         }
 
         // Then: Should automatically failover to endpoint2
@@ -494,7 +496,8 @@ class CircuitBreakerFailoverIntegrationTests extends AbstractRedisClientTest {
         await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(endpoint2, connection.getCurrentEndpoint()));
 
         // Verify we can read from endpoint2
-        String value = connection.reactive().get("failover-test-key-reactive").block(Duration.ofSeconds(1));
+        String value = connection.commands(RedisReactiveCommands.factory()).get("failover-test-key-reactive")
+                .block(Duration.ofSeconds(1));
         assertThat(value).isEqualTo("endpoint2-value");
 
         // Cleanup
@@ -516,7 +519,8 @@ class CircuitBreakerFailoverIntegrationTests extends AbstractRedisClientTest {
         AtomicInteger failureCounter = new AtomicInteger();
         int aimedFailureCount = cbConfig.getMinimumNumberOfFailures() - 1;
         for (int i = 0; i < aimedFailureCount; i++) {
-            connection.reactive().get("key" + i).doOnError(e -> failureCounter.incrementAndGet()).subscribe();
+            connection.commands(RedisReactiveCommands.factory()).get("key" + i).doOnError(e -> failureCounter.incrementAndGet())
+                    .subscribe();
         }
 
         // Then: Metrics should track failures
@@ -537,7 +541,7 @@ class CircuitBreakerFailoverIntegrationTests extends AbstractRedisClientTest {
         shutdownRedisInstance(currentEndpoint);
 
         for (int i = 0; i < 20; i++) {
-            connection.reactive().get("key" + i).subscribe();
+            connection.commands(RedisReactiveCommands.factory()).get("key" + i).subscribe();
         }
 
         // Then: Circuit breaker should open
@@ -576,7 +580,7 @@ class CircuitBreakerFailoverIntegrationTests extends AbstractRedisClientTest {
         shutdownRedisInstance(currentEndpoint);
 
         for (int i = 0; i < 20; i++) {
-            connection.reactive().get("key" + i).subscribe();
+            connection.commands(RedisReactiveCommands.factory()).get("key" + i).subscribe();
         }
 
         // Then: Both listeners should be notified

--- a/src/test/java/io/lettuce/core/failover/MultiDbClientConnectAsyncIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/failover/MultiDbClientConnectAsyncIntegrationTests.java
@@ -34,6 +34,7 @@ import io.lettuce.core.failover.api.InitializationPolicy;
 import io.lettuce.core.failover.api.MultiDbConnectionFuture;
 import io.lettuce.core.failover.api.MultiDbOptions;
 import io.lettuce.core.failover.api.StatefulRedisMultiDbConnection;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.test.LettuceExtension;
 import io.lettuce.test.NoFailback;
 import io.lettuce.test.TestFutures;
@@ -273,10 +274,11 @@ class MultiDbClientConnectAsyncIntegrationTests extends MultiDbTestSupport {
         StatefulRedisMultiDbConnection<String, String> connection = future.get(10, TimeUnit.SECONDS);
 
         // Use reactive API
-        String result = connection.reactive().set("reactiveKey", "reactiveValue").block(Duration.ofSeconds(5));
+        String result = connection.commands(RedisReactiveCommands.factory()).set("reactiveKey", "reactiveValue")
+                .block(Duration.ofSeconds(5));
         assertThat(result).isEqualTo("OK");
 
-        String value = connection.reactive().get("reactiveKey").block(Duration.ofSeconds(5));
+        String value = connection.commands(RedisReactiveCommands.factory()).get("reactiveKey").block(Duration.ofSeconds(5));
         assertThat(value).isEqualTo("reactiveValue");
     }
 

--- a/src/test/java/io/lettuce/core/failover/NoHealthyDatabaseBehaviorIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/failover/NoHealthyDatabaseBehaviorIntegrationTests.java
@@ -397,7 +397,7 @@ class NoHealthyDatabaseBehaviorIntegrationTests extends AbstractRedisClientTest 
             triggerCircuitBreakerAndWaitForState(CircuitBreaker.State.OPEN, redis1ProxyUri, redis2ProxyUri);
 
             // When/Then: Reactive commands should emit error
-            RedisReactiveCommands<String, String> reactive = connection.reactive();
+            RedisReactiveCommands<String, String> reactive = connection.commands(RedisReactiveCommands.factory());
 
             StepVerifier.create(reactive.set("key", "value")).expectError(RedisNoHealthyDatabaseException.class).verify();
 
@@ -419,7 +419,7 @@ class NoHealthyDatabaseBehaviorIntegrationTests extends AbstractRedisClientTest 
             });
 
             // When/Then: Reactive commands should emit timeout error
-            RedisReactiveCommands<String, String> reactive = connection.reactive();
+            RedisReactiveCommands<String, String> reactive = connection.commands(RedisReactiveCommands.factory());
 
             StepVerifier.create(reactive.set("key", "value")).expectError(RedisNoHealthyDatabaseException.class).verify();
 
@@ -433,7 +433,7 @@ class NoHealthyDatabaseBehaviorIntegrationTests extends AbstractRedisClientTest 
             triggerCircuitBreakerAndWaitForState(CircuitBreaker.State.OPEN, redis1ProxyUri, redis2ProxyUri);
 
             // When/Then: Reactive command stream should emit errors
-            RedisReactiveCommands<String, String> reactive = connection.reactive();
+            RedisReactiveCommands<String, String> reactive = connection.commands(RedisReactiveCommands.factory());
 
             Mono<String> command1 = reactive.set("key1", "value1");
             Mono<String> command2 = reactive.set("key2", "value2");
@@ -453,7 +453,7 @@ class NoHealthyDatabaseBehaviorIntegrationTests extends AbstractRedisClientTest 
             triggerCircuitBreakerAndWaitForState(CircuitBreaker.State.OPEN, redis1ProxyUri, redis2ProxyUri);
 
             // When: Use onErrorResume to handle errors
-            RedisReactiveCommands<String, String> reactive = connection.reactive();
+            RedisReactiveCommands<String, String> reactive = connection.commands(RedisReactiveCommands.factory());
 
             Mono<String> commandWithFallback = reactive.set("key", "value").onErrorResume(RedisNoHealthyDatabaseException.class,
                     e -> Mono.just("FALLBACK"));
@@ -486,7 +486,7 @@ class NoHealthyDatabaseBehaviorIntegrationTests extends AbstractRedisClientTest 
                     .hasCauseInstanceOf(RedisNoHealthyDatabaseException.class);
 
             // Reactive API
-            StepVerifier.create(connection.reactive().set("reactiveKey", "reactiveValue"))
+            StepVerifier.create(connection.commands(RedisReactiveCommands.factory()).set("reactiveKey", "reactiveValue"))
                     .expectError(RedisNoHealthyDatabaseException.class).verify();
         }
 
@@ -509,8 +509,8 @@ class NoHealthyDatabaseBehaviorIntegrationTests extends AbstractRedisClientTest 
                         .hasCauseInstanceOf(RedisNoHealthyDatabaseException.class);
 
                 // Try reactive
-                StepVerifier.create(connection.reactive().get("key" + index)).expectError(RedisNoHealthyDatabaseException.class)
-                        .verify();
+                StepVerifier.create(connection.commands(RedisReactiveCommands.factory()).get("key" + index))
+                        .expectError(RedisNoHealthyDatabaseException.class).verify();
             }
         }
 
@@ -579,8 +579,8 @@ class NoHealthyDatabaseBehaviorIntegrationTests extends AbstractRedisClientTest 
             triggerCircuitBreakerAndWaitForState(CircuitBreaker.State.OPEN, redis1ProxyUri, redis2ProxyUri);
 
             // Verify commands fail
-            StepVerifier.create(connection.reactive().set("key", "value")).expectError(RedisNoHealthyDatabaseException.class)
-                    .verify();
+            StepVerifier.create(connection.commands(RedisReactiveCommands.factory()).set("key", "value"))
+                    .expectError(RedisNoHealthyDatabaseException.class).verify();
 
             // When: Re-enable proxies
             enableAllToxiproxy();
@@ -591,9 +591,11 @@ class NoHealthyDatabaseBehaviorIntegrationTests extends AbstractRedisClientTest 
             });
 
             // Then: Commands should succeed
-            StepVerifier.create(connection.reactive().set("recoveryKey", "recoveryValue")).expectNext("OK").verifyComplete();
+            StepVerifier.create(connection.commands(RedisReactiveCommands.factory()).set("recoveryKey", "recoveryValue"))
+                    .expectNext("OK").verifyComplete();
 
-            StepVerifier.create(connection.reactive().get("recoveryKey")).expectNext("recoveryValue").verifyComplete();
+            StepVerifier.create(connection.commands(RedisReactiveCommands.factory()).get("recoveryKey"))
+                    .expectNext("recoveryValue").verifyComplete();
         }
 
     }

--- a/src/test/java/io/lettuce/core/failover/StatefulRedisMultiDbConnectionImplUnitTests.java
+++ b/src/test/java/io/lettuce/core/failover/StatefulRedisMultiDbConnectionImplUnitTests.java
@@ -987,7 +987,7 @@ class StatefulRedisMultiDbConnectionImplUnitTests {
         @Test
         @DisplayName("Should provide reactive commands")
         void shouldProvideReactiveCommands() {
-            assertThat(connection.reactive()).isNotNull();
+            assertThat(connection.commands(RedisReactiveCommands.factory())).isNotNull();
         }
 
     }

--- a/src/test/java/io/lettuce/core/json/RedisJsonClusterIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/json/RedisJsonClusterIntegrationTests.java
@@ -10,6 +10,7 @@ package io.lettuce.core.json;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
+import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
 import io.lettuce.core.cluster.api.reactive.RedisClusterReactiveCommands;
 import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
 import io.lettuce.core.json.arguments.JsonGetArgs;
@@ -120,7 +121,8 @@ public class RedisJsonClusterIntegrationTests {
     @Test
     void jsonArrLenAsyncAndReactive() throws ExecutionException, InterruptedException {
         RedisClusterAsyncCommands<String, String> asyncCommands = client.connect().async();
-        RedisClusterReactiveCommands<String, String> reactiveCommands = client.connect().reactive();
+        RedisClusterReactiveCommands<String, String> reactiveCommands = client.connect()
+                .commands(RedisAdvancedClusterReactiveCommands.factory());
 
         JsonPath myPath = JsonPath.of(MOUNTAIN_BIKES_V1);
 

--- a/src/test/java/io/lettuce/core/json/RedisJsonIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/json/RedisJsonIntegrationTests.java
@@ -168,7 +168,7 @@ public class RedisJsonIntegrationTests {
     @Test
     void jsonArrLenAsyncAndReactive() throws ExecutionException, InterruptedException {
         RedisAsyncCommands<String, String> asyncCommands = client.connect().async();
-        RedisReactiveCommands<String, String> reactiveCommands = client.connect().reactive();
+        RedisReactiveCommands<String, String> reactiveCommands = client.connect().commands(RedisReactiveCommands.factory());
 
         JsonPath myPath = JsonPath.of(MOUNTAIN_BIKES_V1);
 

--- a/src/test/java/io/lettuce/core/probabilistic/RedisBloomFilterReactiveIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/probabilistic/RedisBloomFilterReactiveIntegrationTests.java
@@ -38,7 +38,7 @@ public class RedisBloomFilterReactiveIntegrationTests extends RedisBloomFilterIn
     @Inject
     public RedisBloomFilterReactiveIntegrationTests(StatefulRedisConnection<String, String> connection) {
         super(ReactiveSyncInvocationHandler.sync(connection));
-        this.reactive = connection.reactive();
+        this.reactive = connection.commands(RedisReactiveCommands.factory());
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/probabilistic/RedisCuckooFilterReactiveIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/probabilistic/RedisCuckooFilterReactiveIntegrationTests.java
@@ -45,7 +45,7 @@ public class RedisCuckooFilterReactiveIntegrationTests extends RedisCuckooFilter
     @Inject
     public RedisCuckooFilterReactiveIntegrationTests(StatefulRedisConnection<String, String> connection) {
         super(ReactiveSyncInvocationHandler.sync(connection));
-        this.reactive = connection.reactive();
+        this.reactive = connection.commands(RedisReactiveCommands.factory());
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/probabilistic/topk/RedisTopKReactiveIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/probabilistic/topk/RedisTopKReactiveIntegrationTests.java
@@ -37,7 +37,7 @@ public class RedisTopKReactiveIntegrationTests extends RedisTopKIntegrationTests
     @Inject
     public RedisTopKReactiveIntegrationTests(StatefulRedisConnection<String, String> connection) {
         super(ReactiveSyncInvocationHandler.sync(connection));
-        this.reactive = connection.reactive();
+        this.reactive = connection.commands(RedisReactiveCommands.factory());
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/protocol/ReactiveStreamErrorIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/protocol/ReactiveStreamErrorIntegrationTests.java
@@ -65,7 +65,7 @@ class ReactiveStreamErrorIntegrationTests extends TestSupport {
         ExecutorService executorService = Executors.newCachedThreadPool();
         AtomicInteger messageOutOfOrder = new AtomicInteger(0);
 
-        RedisReactiveCommands<String, String> reactive = connection.reactive();
+        RedisReactiveCommands<String, String> reactive = connection.commands(RedisReactiveCommands.factory());
 
         Runnable readTask = () -> IntStream.range(0, 100).forEach(i -> {
             reactive.get(KEY_TO_WORK_ON).doOnNext(result -> {

--- a/src/test/java/io/lettuce/core/pubsub/PubSubReactiveIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/pubsub/PubSubReactiveIntegrationTests.java
@@ -44,6 +44,7 @@ import io.lettuce.core.internal.LettuceFactories;
 import io.lettuce.core.pubsub.api.reactive.ChannelMessage;
 import io.lettuce.core.pubsub.api.reactive.PatternMessage;
 import io.lettuce.core.pubsub.api.reactive.RedisPubSubReactiveCommands;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.test.Delay;
 import io.lettuce.test.Wait;
 import io.lettuce.test.condition.EnabledOnCommand;
@@ -88,8 +89,8 @@ class PubSubReactiveIntegrationTests extends AbstractRedisClientTest implements 
     void openPubSubConnection() {
         pubSubConnection = client.connectPubSub();
         pubSubConnection2 = client.connectPubSub();
-        pubsub = pubSubConnection.reactive();
-        pubsub2 = pubSubConnection2.reactive();
+        pubsub = pubSubConnection.commands(RedisPubSubReactiveCommands.factory());
+        pubsub2 = pubSubConnection2.commands(RedisPubSubReactiveCommands.factory());
         pubSubConnection.addListener(this);
         channels = LettuceFactories.newBlockingQueue();
         shardChannels = LettuceFactories.newBlockingQueue();
@@ -139,8 +140,8 @@ class PubSubReactiveIntegrationTests extends AbstractRedisClientTest implements 
 
         pubsub.observeChannels().doOnNext(channelMessages::add).subscribe().dispose();
 
-        block(statefulRedisConnection.reactive().publish(channel, message));
-        block(statefulRedisConnection.reactive().publish(channel, message));
+        block(statefulRedisConnection.commands(RedisReactiveCommands.factory()).publish(channel, message));
+        block(statefulRedisConnection.commands(RedisReactiveCommands.factory()).publish(channel, message));
 
         Delay.delay(Duration.ofMillis(500));
         assertThat(channelMessages).isEmpty();

--- a/src/test/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnectionImplUnitTests.java
+++ b/src/test/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnectionImplUnitTests.java
@@ -65,10 +65,9 @@ class StatefulRedisPubSubConnectionImplUnitTests {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
-    void factoryProducesSameTypeAsReactive() {
-        assertThat(connection.commands(RedisPubSubReactiveCommands.factory()).getClass())
-                .isSameAs(connection.reactive().getClass());
+    void factoryProducesReactiveCommands() {
+        assertThat(connection.commands(RedisPubSubReactiveCommands.factory()))
+                .isInstanceOf(RedisPubSubReactiveCommandsImpl.class);
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/pubsub/SubkeyNotificationsReactiveIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/pubsub/SubkeyNotificationsReactiveIntegrationTests.java
@@ -48,7 +48,7 @@ class SubkeyNotificationsReactiveIntegrationTests extends AbstractRedisClientTes
     @BeforeEach
     void openPubSubConnection() {
         pubSubConnection = client.connectPubSub();
-        pubsub = pubSubConnection.reactive();
+        pubsub = pubSubConnection.commands(RedisPubSubReactiveCommands.factory());
 
         RedisCommands<String, String> sync = redis;
         originalNotifyConfig = sync.configGet("notify-keyspace-events").getOrDefault("notify-keyspace-events", "");

--- a/src/test/java/io/lettuce/core/reactive/ScanStreamVerification.java
+++ b/src/test/java/io/lettuce/core/reactive/ScanStreamVerification.java
@@ -13,6 +13,7 @@ import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.ScanStream;
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.test.resource.FastShutdown;
 import io.lettuce.test.resource.TestClientResources;
@@ -76,7 +77,7 @@ public class ScanStreamVerification extends PublisherVerification<String> {
             map.clear();
         }
 
-        return ScanStream.scan(connection.reactive());
+        return ScanStream.scan(connection.commands(RedisReactiveCommands.factory()));
     }
 
     @Override

--- a/src/test/java/io/lettuce/core/search/RediSearchClusterCursorIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/search/RediSearchClusterCursorIntegrationTests.java
@@ -68,7 +68,7 @@ public class RediSearchClusterCursorIntegrationTests extends TestSupport {
         connection = clusterClient.connect();
         sync = connection.sync();
         async = connection.async();
-        reactive = connection.reactive();
+        reactive = connection.commands(RedisAdvancedClusterReactiveCommands.factory());
     }
 
     @AfterEach

--- a/src/test/java/io/lettuce/core/sentinel/StatefulRedisSentinelConnectionImplUnitTests.java
+++ b/src/test/java/io/lettuce/core/sentinel/StatefulRedisSentinelConnectionImplUnitTests.java
@@ -57,10 +57,9 @@ class StatefulRedisSentinelConnectionImplUnitTests {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
-    void factoryProducesSameTypeAsReactive() {
-        assertThat(connection.commands(RedisSentinelReactiveCommands.factory()).getClass())
-                .isSameAs(connection.reactive().getClass());
+    void factoryProducesReactiveCommands() {
+        assertThat(connection.commands(RedisSentinelReactiveCommands.factory()))
+                .isInstanceOf(RedisSentinelReactiveCommandsImpl.class);
     }
 
 }

--- a/src/test/java/io/lettuce/core/support/AsyncConnectionPoolSupportIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/support/AsyncConnectionPoolSupportIntegrationTests.java
@@ -175,7 +175,7 @@ class AsyncConnectionPoolSupportIntegrationTests extends TestSupport {
 
         assertThat(sync).isInstanceOf(RedisCommands.class);
         assertThat(connection.async()).isInstanceOf(RedisAsyncCommands.class).isNotInstanceOf(RedisAsyncCommandsImpl.class);
-        assertThat(connection.reactive()).isInstanceOf(RedisReactiveCommands.class)
+        assertThat(connection.commands(RedisReactiveCommands.factory())).isInstanceOf(RedisReactiveCommands.class)
                 .isNotInstanceOf(RedisReactiveCommandsImpl.class);
         assertThat(sync.getStatefulConnection()).isInstanceOf(StatefulRedisConnection.class)
                 .isNotInstanceOf(StatefulRedisConnectionImpl.class).isSameAs(connection);

--- a/src/test/java/io/lettuce/core/support/ConnectionPoolSupportIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/support/ConnectionPoolSupportIntegrationTests.java
@@ -227,7 +227,7 @@ class ConnectionPoolSupportIntegrationTests extends TestSupport {
 
         assertThat(sync).isInstanceOf(RedisCommands.class);
         assertThat(connection.async()).isInstanceOf(RedisAsyncCommands.class).isNotInstanceOf(RedisAsyncCommandsImpl.class);
-        assertThat(connection.reactive()).isInstanceOf(RedisReactiveCommands.class)
+        assertThat(connection.commands(RedisReactiveCommands.factory())).isInstanceOf(RedisReactiveCommands.class)
                 .isNotInstanceOf(RedisReactiveCommandsImpl.class);
         assertThat(connection.commands(RedisReactiveCommands.factory())).isInstanceOf(RedisReactiveCommands.class)
                 .isNotInstanceOf(RedisReactiveCommandsImpl.class);
@@ -253,7 +253,7 @@ class ConnectionPoolSupportIntegrationTests extends TestSupport {
 
         assertThat(sync).isInstanceOf(RedisCommands.class);
         assertThat(connection.async()).isInstanceOf(RedisAsyncCommands.class).isNotInstanceOf(RedisAsyncCommandsImpl.class);
-        assertThat(connection.reactive()).isInstanceOf(RedisReactiveCommands.class)
+        assertThat(connection.commands(RedisReactiveCommands.factory())).isInstanceOf(RedisReactiveCommands.class)
                 .isNotInstanceOf(RedisReactiveCommandsImpl.class);
         assertThat(sync.getStatefulConnection()).isInstanceOf(StatefulRedisConnection.class)
                 .isNotInstanceOf(StatefulRedisConnectionImpl.class).isSameAs(connection);
@@ -281,7 +281,8 @@ class ConnectionPoolSupportIntegrationTests extends TestSupport {
         assertThat(sync).isInstanceOf(RedisAdvancedClusterCommands.class);
         assertThat(connection.async()).isInstanceOf(RedisAdvancedClusterAsyncCommands.class)
                 .isNotInstanceOf(RedisAdvancedClusterAsyncCommandsImpl.class);
-        assertThat(connection.reactive()).isInstanceOf(RedisAdvancedClusterReactiveCommands.class)
+        assertThat(connection.commands(RedisAdvancedClusterReactiveCommands.factory()))
+                .isInstanceOf(RedisAdvancedClusterReactiveCommands.class)
                 .isNotInstanceOf(RedisAdvancedClusterReactiveCommandsImpl.class);
         assertThat(connection.commands(RedisAdvancedClusterReactiveCommands.factory()))
                 .isInstanceOf(RedisAdvancedClusterReactiveCommands.class)
@@ -310,7 +311,7 @@ class ConnectionPoolSupportIntegrationTests extends TestSupport {
 
         assertThat(sync).isInstanceOf(RedisCommands.class);
         assertThat(connection.async()).isInstanceOf(RedisAsyncCommands.class).isInstanceOf(RedisAsyncCommandsImpl.class);
-        assertThat(connection.reactive()).isInstanceOf(RedisReactiveCommands.class)
+        assertThat(connection.commands(RedisReactiveCommands.factory())).isInstanceOf(RedisReactiveCommands.class)
                 .isInstanceOf(RedisReactiveCommandsImpl.class);
         assertThat(sync.getStatefulConnection()).isInstanceOf(StatefulRedisConnection.class)
                 .isInstanceOf(StatefulRedisConnectionImpl.class);

--- a/src/test/java/io/lettuce/core/tracing/BraveTracingIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/tracing/BraveTracingIntegrationTests.java
@@ -47,6 +47,7 @@ import io.lettuce.core.TestSupport;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.resource.ClientResources;
 import io.lettuce.core.resource.DefaultClientResources;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.test.Wait;
 import io.lettuce.test.condition.EnabledOnCommand;
 import io.lettuce.test.resource.FastShutdown;
@@ -184,7 +185,7 @@ class BraveTracingIntegrationTests extends TestSupport {
     void reactivePing() {
 
         StatefulRedisConnection<String, String> connect = client.connect();
-        connect.reactive().ping().as(StepVerifier::create).expectNext("PONG").verifyComplete();
+        connect.commands(RedisReactiveCommands.factory()).ping().as(StepVerifier::create).expectNext("PONG").verifyComplete();
 
         Wait.untilNotEquals(true, spans::isEmpty).waitOrTimeout();
         assertThat(spans).isNotEmpty();
@@ -196,7 +197,7 @@ class BraveTracingIntegrationTests extends TestSupport {
         ScopedSpan trace = clientTracing.tracer().startScopedSpan("foo");
 
         StatefulRedisConnection<String, String> connect = client.connect();
-        connect.reactive().ping() //
+        connect.commands(RedisReactiveCommands.factory()).ping() //
                 .contextWrite(it -> it.put(TraceContext.class, trace.context())) //
                 .as(StepVerifier::create) //
                 .expectNext("PONG").verifyComplete();
@@ -217,8 +218,8 @@ class BraveTracingIntegrationTests extends TestSupport {
         ScopedSpan trace = clientTracing.tracer().startScopedSpan("foo");
 
         StatefulRedisConnection<String, String> connect = client.connect();
-        connect.reactive().set("foo", "bar") //
-                .then(connect.reactive().get("foo")) //
+        connect.commands(RedisReactiveCommands.factory()).set("foo", "bar") //
+                .then(connect.commands(RedisReactiveCommands.factory()).get("foo")) //
                 .contextWrite(it -> it.put(TraceContext.class, trace.context())) //
                 .as(StepVerifier::create) //
                 .expectNext("bar").verifyComplete();
@@ -242,7 +243,8 @@ class BraveTracingIntegrationTests extends TestSupport {
         brave.Span trace = clientTracing.tracer().newTrace();
 
         StatefulRedisConnection<String, String> connect = client.connect();
-        connect.reactive().set("foo", "bar").then(connect.reactive().get("foo"))
+        connect.commands(RedisReactiveCommands.factory()).set("foo", "bar")
+                .then(connect.commands(RedisReactiveCommands.factory()).get("foo"))
                 .contextWrite(io.lettuce.core.tracing.Tracing
                         .withTraceContextProvider(() -> BraveTracing.BraveTraceContext.create(trace.context()))) //
                 .as(StepVerifier::create) //

--- a/src/test/java/io/lettuce/core/tracing/ReactiveIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/tracing/ReactiveIntegrationTests.java
@@ -12,6 +12,7 @@ import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.protocol.CommandType;
 import io.lettuce.core.protocol.RedisCommand;
 import io.lettuce.core.resource.ClientResources;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.test.resource.FastShutdown;
 import io.lettuce.test.settings.TestSettings;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -92,7 +93,7 @@ public class ReactiveIntegrationTests extends SampleTestRunner {
 
             // Propagate the Observation via the Observation.class key.
             // This exercises the Observation.class branch in getTraceContextAsync.
-            connection.reactive().ping()
+            connection.commands(RedisReactiveCommands.factory()).ping()
                     .contextWrite(ctx -> ctx.put(Observation.class, observationRegistry.getCurrentObservation()))
                     .as(StepVerifier::create).expectNext("PONG").verifyComplete();
 

--- a/src/test/java/io/lettuce/core/vector/RedisVectorSetIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/vector/RedisVectorSetIntegrationTests.java
@@ -75,7 +75,7 @@ public class RedisVectorSetIntegrationTests {
         StatefulRedisConnection<String, String> connection = client.connect();
         redis = connection.sync();
         asyncRedis = connection.async();
-        reactiveRedis = connection.reactive();
+        reactiveRedis = connection.commands(RedisReactiveCommands.factory());
     }
 
     @BeforeEach

--- a/src/test/java/io/lettuce/examples/AutomaticFailover.java
+++ b/src/test/java/io/lettuce/examples/AutomaticFailover.java
@@ -82,7 +82,7 @@ public class AutomaticFailover {
         log.info("Available Endpoints: {}", connection.getEndpoints());
 
         // Get reactive commands interface
-        RedisReactiveCommands<String, String> reactive = connection.reactive();
+        RedisReactiveCommands<String, String> reactive = connection.commands(RedisReactiveCommands.factory());
 
         String keyName = "multidb-counter";
 

--- a/src/test/java/io/lettuce/examples/TokenBasedAuthExample.java
+++ b/src/test/java/io/lettuce/examples/TokenBasedAuthExample.java
@@ -7,6 +7,7 @@ import io.lettuce.core.RedisURI;
 import io.lettuce.core.SocketOptions;
 import io.lettuce.core.TimeoutOptions;
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.cluster.ClusterClientOptions;
 import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
@@ -82,12 +83,12 @@ public class TokenBasedAuthExample {
             // create connection using default URI (authorised as user1)
             try (StatefulRedisConnection<String, String> user1 = redisClient.connect(StringCodec.UTF8)) {
 
-                user1.reactive().aclWhoami().doOnNext(System.out::println).block();
+                user1.commands(RedisReactiveCommands.factory()).aclWhoami().doOnNext(System.out::println).block();
             }
 
             // another connection using different authorizations (user2 credentials provider)
             try (StatefulRedisConnection<String, String> user2 = redisClient.connect(StringCodec.UTF8, redisURI2);) {
-                user2.reactive().aclWhoami().doOnNext(System.out::println).block();
+                user2.commands(RedisReactiveCommands.factory()).aclWhoami().doOnNext(System.out::println).block();
             }
 
             // Shutdown Redis client and close connections

--- a/src/test/java/io/lettuce/scenario/ConnectionInterruptionReactiveTest.java
+++ b/src/test/java/io/lettuce/scenario/ConnectionInterruptionReactiveTest.java
@@ -77,7 +77,7 @@ public class ConnectionInterruptionReactiveTest {
         // Also track with state listener for comparison
         tracker.trackWithStateListener(connection);
 
-        RedisReactiveCommands<String, String> reactive = connection.reactive();
+        RedisReactiveCommands<String, String> reactive = connection.commands(RedisReactiveCommands.factory());
 
         String keyName = "counter";
 
@@ -145,7 +145,7 @@ public class ConnectionInterruptionReactiveTest {
         publisherClient.setOptions(RecommendedSettingsProvider.forConnectionInterruption());
 
         StatefulRedisConnection<String, String> publisherConnection = publisherClient.connect();
-        RedisReactiveCommands<String, String> publisherReactive = publisherConnection.reactive();
+        RedisReactiveCommands<String, String> publisherReactive = publisherConnection.commands(RedisReactiveCommands.factory());
 
         AtomicLong messagesSent = new AtomicLong();
         AtomicLong messagesReceived = new AtomicLong();
@@ -160,7 +160,8 @@ public class ConnectionInterruptionReactiveTest {
         // Also track with state listener for comparison
         tracker.trackWithStateListener(pubSubConnection);
 
-        RedisPubSubReactiveCommands<String, String> pubSubReactive = pubSubConnection.reactive();
+        RedisPubSubReactiveCommands<String, String> pubSubReactive = pubSubConnection
+                .commands(RedisPubSubReactiveCommands.factory());
         pubSubConnection.addListener(new RedisPubSubAdapter<String, String>() {
 
             @Override

--- a/src/test/java/io/lettuce/test/ReactiveSyncInvocationHandler.java
+++ b/src/test/java/io/lettuce/test/ReactiveSyncInvocationHandler.java
@@ -10,10 +10,13 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
 import io.lettuce.core.internal.LettuceSets;
 import io.lettuce.core.sentinel.api.StatefulRedisSentinelConnection;
+import io.lettuce.core.sentinel.api.reactive.RedisSentinelReactiveCommands;
 import io.lettuce.core.sentinel.api.sync.RedisSentinelCommands;
 
 /**
@@ -95,21 +98,24 @@ public class ReactiveSyncInvocationHandler<K, V> extends ConnectionDecoratingInv
 
     public static <K, V> RedisCommands<K, V> sync(StatefulRedisConnection<K, V> connection) {
 
-        ReactiveSyncInvocationHandler<K, V> handler = new ReactiveSyncInvocationHandler<>(connection, connection.reactive());
+        ReactiveSyncInvocationHandler<K, V> handler = new ReactiveSyncInvocationHandler<>(connection,
+                connection.commands(RedisReactiveCommands.factory()));
         return (RedisCommands<K, V>) Proxy.newProxyInstance(handler.getClass().getClassLoader(),
                 new Class<?>[] { RedisCommands.class }, handler);
     }
 
     public static <K, V> RedisCommands<K, V> sync(StatefulRedisClusterConnection<K, V> connection) {
 
-        ReactiveSyncInvocationHandler<K, V> handler = new ReactiveSyncInvocationHandler<>(connection, connection.reactive());
+        ReactiveSyncInvocationHandler<K, V> handler = new ReactiveSyncInvocationHandler<>(connection,
+                connection.commands(RedisAdvancedClusterReactiveCommands.factory()));
         return (RedisCommands<K, V>) Proxy.newProxyInstance(handler.getClass().getClassLoader(),
                 new Class<?>[] { RedisCommands.class }, handler);
     }
 
     public static <K, V> RedisSentinelCommands<K, V> sync(StatefulRedisSentinelConnection<K, V> connection) {
 
-        ReactiveSyncInvocationHandler<K, V> handler = new ReactiveSyncInvocationHandler<>(connection, connection.reactive());
+        ReactiveSyncInvocationHandler<K, V> handler = new ReactiveSyncInvocationHandler<>(connection,
+                connection.commands(RedisSentinelReactiveCommands.factory()));
         return (RedisSentinelCommands<K, V>) Proxy.newProxyInstance(handler.getClass().getClassLoader(),
                 new Class<?>[] { RedisSentinelCommands.class }, handler);
     }

--- a/src/test/java/io/redis/examples/reactive/CmdsListExample.java
+++ b/src/test/java/io/redis/examples/reactive/CmdsListExample.java
@@ -21,7 +21,7 @@ public class CmdsListExample {
         RedisClient redisClient = RedisClient.create("redis://localhost:6379");
 
         try (StatefulRedisConnection<String, String> connection = redisClient.connect()) {
-            RedisReactiveCommands<String, String> reactiveCommands = connection.reactive();
+            RedisReactiveCommands<String, String> reactiveCommands = connection.commands(RedisReactiveCommands.factory());
             // REMOVE_START
             reactiveCommands.del("mylist").block();
             // REMOVE_END

--- a/src/test/java/io/redis/examples/reactive/CmdsSetExample.java
+++ b/src/test/java/io/redis/examples/reactive/CmdsSetExample.java
@@ -18,7 +18,7 @@ public class CmdsSetExample {
         RedisClient redisClient = RedisClient.create("redis://localhost:6379");
 
         try (StatefulRedisConnection<String, String> connection = redisClient.connect()) {
-            RedisReactiveCommands<String, String> reactiveCommands = connection.reactive();
+            RedisReactiveCommands<String, String> reactiveCommands = connection.commands(RedisReactiveCommands.factory());
             // REMOVE_START
             // Clean up any existing data
             Mono<Void> cleanup = reactiveCommands.del("myset").then();

--- a/src/test/java/io/redis/examples/reactive/HashExample.java
+++ b/src/test/java/io/redis/examples/reactive/HashExample.java
@@ -22,7 +22,7 @@ public class HashExample {
         RedisClient redisClient = RedisClient.create("redis://localhost:6379");
 
         try (StatefulRedisConnection<String, String> connection = redisClient.connect()) {
-            RedisReactiveCommands<String, String> reactiveCommands = connection.reactive();
+            RedisReactiveCommands<String, String> reactiveCommands = connection.commands(RedisReactiveCommands.factory());
             // REMOVE_START
             // Clean up any existing data
             Mono<Void> cleanup = reactiveCommands.del("bike:1", "bike:1:stats").then();

--- a/src/test/java/io/redis/examples/reactive/SetExample.java
+++ b/src/test/java/io/redis/examples/reactive/SetExample.java
@@ -22,7 +22,7 @@ public class SetExample {
         RedisClient redisClient = RedisClient.create("redis://localhost:6379");
 
         try (StatefulRedisConnection<String, String> connection = redisClient.connect()) {
-            RedisReactiveCommands<String, String> reactiveCommands = connection.reactive();
+            RedisReactiveCommands<String, String> reactiveCommands = connection.commands(RedisReactiveCommands.factory());
             // REMOVE_START
             // Clean up any existing data
             Mono<Void> cleanup = reactiveCommands.del("bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy").then();

--- a/src/test/java/io/redis/examples/reactive/StringExample.java
+++ b/src/test/java/io/redis/examples/reactive/StringExample.java
@@ -24,7 +24,7 @@ public class StringExample {
         RedisClient redisClient = RedisClient.create("redis://localhost:6379");
 
         try (StatefulRedisConnection<String, String> connection = redisClient.connect()) {
-            RedisReactiveCommands<String, String> reactiveCommands = connection.reactive();
+            RedisReactiveCommands<String, String> reactiveCommands = connection.commands(RedisReactiveCommands.factory());
 
             // STEP_START set_get
             Mono<Void> setAndGet = reactiveCommands.set("bike:1", "Deimos").doOnNext(v -> {

--- a/src/test/java/io/redis/examples/reactive/VectorSetExample.java
+++ b/src/test/java/io/redis/examples/reactive/VectorSetExample.java
@@ -22,7 +22,7 @@ public class VectorSetExample {
         RedisClient redisClient = RedisClient.create("redis://localhost:6379");
 
         try (StatefulRedisConnection<String, String> connection = redisClient.connect()) {
-            RedisReactiveCommands<String, String> reactiveCommands = connection.reactive();
+            RedisReactiveCommands<String, String> reactiveCommands = connection.commands(RedisReactiveCommands.factory());
 
             // REMOVE_START
             // Clean up any existing data

--- a/src/test/jmh/io/lettuce/core/EmptyStatefulRedisConnection.java
+++ b/src/test/jmh/io/lettuce/core/EmptyStatefulRedisConnection.java
@@ -7,7 +7,6 @@ import io.lettuce.core.api.CommandsFactory;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.api.push.PushListener;
-import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.protocol.ConnectionFacade;
 import io.lettuce.core.protocol.RedisCommand;
@@ -41,7 +40,7 @@ public class EmptyStatefulRedisConnection extends RedisChannelHandler implements
     }
 
     @Override
-    public RedisReactiveCommands reactive() {
+    public Object commands(CommandsFactory factory) {
         return null;
     }
 

--- a/src/test/jmh/io/lettuce/core/EmptyStatefulRedisConnection.java
+++ b/src/test/jmh/io/lettuce/core/EmptyStatefulRedisConnection.java
@@ -45,11 +45,6 @@ public class EmptyStatefulRedisConnection extends RedisChannelHandler implements
     }
 
     @Override
-    public Object commands(CommandsFactory factory) {
-        return null;
-    }
-
-    @Override
     public void close() {
     }
 

--- a/src/test/jmh/io/lettuce/core/RedisClientBenchmark.java
+++ b/src/test/jmh/io/lettuce/core/RedisClientBenchmark.java
@@ -8,6 +8,7 @@ import org.openjdk.jmh.annotations.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.codec.ByteArrayCodec;
 import io.lettuce.test.Delay;
 import io.lettuce.test.settings.TestSettings;
@@ -109,7 +110,7 @@ public class RedisClientBenchmark {
 
     @Benchmark
     public void reactiveSet() {
-        connection.reactive().set(KEY, KEY).block();
+        connection.commands(RedisReactiveCommands.factory()).set(KEY, KEY).block();
     }
 
     @Benchmark
@@ -117,7 +118,7 @@ public class RedisClientBenchmark {
     public void reactiveSetBatch() {
 
         for (int i = 0; i < BATCH_SIZE; i++) {
-            monos[i] = connection.reactive().set(KEY, KEY);
+            monos[i] = connection.commands(RedisReactiveCommands.factory()).set(KEY, KEY);
         }
 
         Flux.merge(monos).blockLast();
@@ -130,7 +131,7 @@ public class RedisClientBenchmark {
         connection.setAutoFlushCommands(false);
 
         for (int i = 0; i < BATCH_SIZE; i++) {
-            monos[i] = connection.reactive().set(KEY, KEY);
+            monos[i] = connection.commands(RedisReactiveCommands.factory()).set(KEY, KEY);
         }
 
         Flux.merge(monos).doOnSubscribe(subscription -> {

--- a/src/test/jmh/io/lettuce/core/cluster/RedisClusterClientBenchmark.java
+++ b/src/test/jmh/io/lettuce/core/cluster/RedisClusterClientBenchmark.java
@@ -7,6 +7,7 @@ import reactor.core.publisher.Mono;
 import io.lettuce.core.RedisFuture;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
 import io.lettuce.core.codec.ByteArrayCodec;
 import io.lettuce.test.settings.TestSettings;
 
@@ -94,7 +95,7 @@ public class RedisClusterClientBenchmark {
 
     @Benchmark
     public void reactiveSet() {
-        connection.reactive().set(KEY, KEY).block();
+        connection.commands(RedisAdvancedClusterReactiveCommands.factory()).set(KEY, KEY).block();
     }
 
     @Benchmark
@@ -102,7 +103,7 @@ public class RedisClusterClientBenchmark {
     public void reactiveSetBatch() {
 
         for (int i = 0; i < BATCH_SIZE; i++) {
-            monos[i] = connection.reactive().set(KEY, KEY);
+            monos[i] = connection.commands(RedisAdvancedClusterReactiveCommands.factory()).set(KEY, KEY);
         }
 
         Flux.merge(monos).blockLast();
@@ -115,7 +116,7 @@ public class RedisClusterClientBenchmark {
         connection.setAutoFlushCommands(false);
 
         for (int i = 0; i < BATCH_SIZE; i++) {
-            monos[i] = connection.reactive().set(KEY, KEY);
+            monos[i] = connection.commands(RedisAdvancedClusterReactiveCommands.factory()).set(KEY, KEY);
         }
 
         Flux.merge(monos).doOnSubscribe(subscription -> {

--- a/src/test/jmh/io/lettuce/core/dynamic/RedisCommandFactoryBenchmark.java
+++ b/src/test/jmh/io/lettuce/core/dynamic/RedisCommandFactoryBenchmark.java
@@ -8,6 +8,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 
 import io.lettuce.core.*;
+import io.lettuce.core.api.CommandsFactory;
 import io.lettuce.core.api.reactive.RedisReactiveCommands;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.codec.StringCodec;
@@ -86,7 +87,7 @@ public class RedisCommandFactoryBenchmark {
         }
 
         @Override
-        public RedisReactiveCommands reactive() {
+        public Object commands(CommandsFactory factory) {
             return reactive;
         }
     }


### PR DESCRIPTION
Remove deprecated `connection.reactive()` accessor in favor of `connection.commands(CommandsFactory)`.
Follow up of #3781 
Relates to #3614 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a public API break affecting every caller of `connection.reactive()` across connection types; migration to `commands(factory())` is required and any external code or wrappers still using `reactive()` will fail to compile.
> 
> **Overview**
> **Breaking change:** `reactive()` is removed from standalone, cluster, pub/sub, sentinel, multi-DB, and master/slave connection APIs. Reactive access is only via `connection.commands(RedisReactiveCommands.factory())` (or the matching cluster/pub/sub/sentinel factory types).
> 
> Connection implementations no longer keep a dedicated reactive command instance field; reactive APIs are created and cached through the existing `commands(CommandsFactory)` store. On connection interfaces, `commands(...)` is no longer a default that throws `UnsupportedOperationException`—implementations must provide it.
> 
> Internal cluster **node selection** for reactive mode now resolves commands through an injected `CommandsFactory` instead of calling `reactive()` on each node connection. `RedisCommandFactory`, Kotlin `coroutines()` extensions, and connection pool wrapping are updated accordingly (pool proxies no longer treat `reactive` like `sync`/`async`).
> 
> Tests, examples, benchmarks, and docs are migrated to the factory pattern; unit tests now assert factory output type instead of comparing to `reactive()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d806114e0f8580c79d5f59ff52b1f151e31ae757. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->