### PR TITLE
Fix connection pool support for new accessor

### DIFF
--- a/src/main/java/io/lettuce/core/support/ConnectionWrapping.java
+++ b/src/main/java/io/lettuce/core/support/ConnectionWrapping.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import io.lettuce.core.RedisException;
 import io.lettuce.core.api.AsyncCloseable;
+import io.lettuce.core.api.CommandsFactory;
 import io.lettuce.core.api.StatefulConnection;
 import io.lettuce.core.internal.AbstractInvocationHandler;
 
@@ -74,6 +75,8 @@ public class ConnectionWrapping {
 
         private Map<Method, Object> connectionProxies = new ConcurrentHashMap<>(5, 1);
 
+        private final Map<Object, Object> commandsProxies = new ConcurrentHashMap<>(5, 1);
+
         private final Origin<T> pool;
 
         ReturnObjectOnCloseInvocationHandler(T connection, Origin<T> pool) {
@@ -105,6 +108,7 @@ public class ConnectionWrapping {
                 connection = null;
                 proxiedConnection = null;
                 connectionProxies.clear();
+                commandsProxies.clear();
                 return null;
             }
 
@@ -113,6 +117,7 @@ public class ConnectionWrapping {
                 connection = null;
                 proxiedConnection = null;
                 connectionProxies.clear();
+                commandsProxies.clear();
                 return future;
             }
 
@@ -121,6 +126,11 @@ public class ConnectionWrapping {
                 if (method.getName().equals("sync") || method.getName().equals("async")
                         || method.getName().equals("reactive")) {
                     return connectionProxies.computeIfAbsent(method, m -> getInnerProxy(method, args));
+                }
+
+                if (method.getName().equals("commands")) {
+                    Object key = ((CommandsFactory<?, ?>) args[0]).key();
+                    return commandsProxies.computeIfAbsent(key, k -> getInnerProxy(method, args));
                 }
 
                 return method.invoke(connection, args);

--- a/src/test/java/io/lettuce/core/support/ConnectionPoolSupportIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/support/ConnectionPoolSupportIntegrationTests.java
@@ -229,6 +229,8 @@ class ConnectionPoolSupportIntegrationTests extends TestSupport {
         assertThat(connection.async()).isInstanceOf(RedisAsyncCommands.class).isNotInstanceOf(RedisAsyncCommandsImpl.class);
         assertThat(connection.reactive()).isInstanceOf(RedisReactiveCommands.class)
                 .isNotInstanceOf(RedisReactiveCommandsImpl.class);
+        assertThat(connection.commands(RedisReactiveCommands.factory())).isInstanceOf(RedisReactiveCommands.class)
+                .isNotInstanceOf(RedisReactiveCommandsImpl.class);
         assertThat(sync.getStatefulConnection()).isInstanceOf(StatefulRedisConnection.class)
                 .isNotInstanceOf(StatefulRedisConnectionImpl.class).isSameAs(connection);
 
@@ -280,6 +282,9 @@ class ConnectionPoolSupportIntegrationTests extends TestSupport {
         assertThat(connection.async()).isInstanceOf(RedisAdvancedClusterAsyncCommands.class)
                 .isNotInstanceOf(RedisAdvancedClusterAsyncCommandsImpl.class);
         assertThat(connection.reactive()).isInstanceOf(RedisAdvancedClusterReactiveCommands.class)
+                .isNotInstanceOf(RedisAdvancedClusterReactiveCommandsImpl.class);
+        assertThat(connection.commands(RedisAdvancedClusterReactiveCommands.factory()))
+                .isInstanceOf(RedisAdvancedClusterReactiveCommands.class)
                 .isNotInstanceOf(RedisAdvancedClusterReactiveCommandsImpl.class);
         assertThat(sync.getStatefulConnection()).isInstanceOf(StatefulRedisClusterConnection.class)
                 .isNotInstanceOf(StatefulRedisClusterConnectionImpl.class).isSameAs(connection);


### PR DESCRIPTION
Fixes connection pool support for new commands() accessor after #3781 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to existing pool proxy logic with matching integration tests; no auth or data-path changes.
> 
> **Overview**
> Pooled connections now wrap **`connection.commands(CommandsFactory)`** the same way as `sync()`, `async()`, and `reactive()`, so command APIs obtained via factories are proxied and closing them still returns the connection to the pool.
> 
> `ConnectionWrapping` caches those command APIs by the factory’s **`key()`**, clears that cache on **`close`** / **`closeAsync`**, and integration tests assert standalone and cluster pooled connections no longer expose raw command implementations from **`commands(...)`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2e36120cab1ca34b8971bd9f48ba84075731a6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->