### PR TITLE
[reactor-optional] Deprecate reactor based EventBus in favor of callback based Subscription

### DIFF
--- a/src/main/java/io/lettuce/core/Subscription.java
+++ b/src/main/java/io/lettuce/core/Subscription.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026-Present, Redis Ltd. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+package io.lettuce.core;
+
+import java.io.Closeable;
+
+/**
+ * Handle to a callback subscription on a Lettuce streaming SPI, such as
+ * {@link io.lettuce.core.event.EventBus#subscribe(java.util.function.Consumer)}. Closing the subscription stops delivery of
+ * further values to the registered callback.
+ * <p>
+ * This is not related to {@code org.reactivestreams.Subscription} or to Redis Pub/Sub channel subscriptions.
+ *
+ * @author Aleksandar Todorov
+ * @since 7.7
+ */
+public interface Subscription extends Closeable {
+
+    /**
+     * Stop delivering to the registered callback. Idempotent; calling it more than once has no further effect and never throws.
+     */
+    @Override
+    void close();
+
+}

--- a/src/main/java/io/lettuce/core/Subscription.java
+++ b/src/main/java/io/lettuce/core/Subscription.java
@@ -19,7 +19,8 @@ import java.io.Closeable;
 public interface Subscription extends Closeable {
 
     /**
-     * Stop delivering to the registered callback. Idempotent; calling it more than once has no further effect and never throws.
+     * Stops delivering to the registered callback. Idempotent; calling it more than once has no further effect and never
+     * throws.
      */
     @Override
     void close();

--- a/src/main/java/io/lettuce/core/event/EventBus.java
+++ b/src/main/java/io/lettuce/core/event/EventBus.java
@@ -1,5 +1,9 @@
 package io.lettuce.core.event;
 
+import java.util.function.Consumer;
+
+import io.lettuce.core.Subscription;
+import io.lettuce.core.internal.LettuceAssert;
 import reactor.core.publisher.Flux;
 
 /**
@@ -14,7 +18,18 @@ public interface EventBus {
      * Subscribe to the event bus and {@link Event}s. The {@link Flux} drops events on backpressure to avoid contention.
      *
      * @return the observable to obtain events.
+     * @deprecated since 7.7, use {@link #subscribe(Consumer)} or {@link #subscribe(Class, Consumer)} instead; scheduled for
+     *             removal in Lettuce 8.0 (when {@code reactor-core} becomes optional). To obtain a {@link Flux} from the
+     *             callback API, bridge it yourself:
+     *
+     *             <pre class="code">
+     *             Flux.create(sink -&gt; {
+     *             Subscription s = eventBus.subscribe(sink::next);
+     *             sink.onDispose(s::close);
+     *             }, FluxSink.OverflowStrategy.DROP);
+     *             </pre>
      */
+    @Deprecated
     Flux<Event> get();
 
     /**
@@ -23,5 +38,39 @@ public interface EventBus {
      * @param event the event to publish
      */
     void publish(Event event);
+
+    /**
+     * Subscribe to all {@link Event}s published to the bus. The {@code listener} is invoked for every event until the returned
+     * {@link Subscription} is {@link Subscription#close() closed}. Events are dropped on backpressure to avoid contention.
+     *
+     * @param listener callback invoked with each published event, must not be {@code null}.
+     * @return a {@link Subscription} that stops delivery when closed.
+     * @since 7.7
+     */
+    default Subscription subscribe(Consumer<Event> listener) {
+        LettuceAssert.notNull(listener, "Listener must not be null");
+        reactor.core.Disposable disposable = get().subscribe(listener);
+        return disposable::dispose;
+    }
+
+    /**
+     * Subscribe to {@link Event}s of a given {@code type} published to the bus. The {@code listener} is invoked for every event
+     * assignable to {@code type} until the returned {@link Subscription} is {@link Subscription#close() closed}.
+     *
+     * @param type the event type to receive, must not be {@code null}.
+     * @param listener callback invoked with each matching event, must not be {@code null}.
+     * @param <T> the event type.
+     * @return a {@link Subscription} that stops delivery when closed.
+     * @since 7.7
+     */
+    default <T extends Event> Subscription subscribe(Class<T> type, Consumer<T> listener) {
+        LettuceAssert.notNull(type, "Event type must not be null");
+        LettuceAssert.notNull(listener, "Listener must not be null");
+        return subscribe(event -> {
+            if (type.isInstance(event)) {
+                listener.accept(type.cast(event));
+            }
+        });
+    }
 
 }

--- a/src/main/java/io/lettuce/core/event/EventBus.java
+++ b/src/main/java/io/lettuce/core/event/EventBus.java
@@ -15,17 +15,16 @@ import reactor.core.publisher.Flux;
 public interface EventBus {
 
     /**
-     * Subscribe to the event bus and {@link Event}s. The {@link Flux} drops events on backpressure to avoid contention.
+     * Subscribes to the event bus and its {@link Event}s. The {@link Flux} drops events on backpressure to avoid contention.
      *
      * @return the observable to obtain events.
      * @deprecated since 7.7, use {@link #subscribe(Consumer)} or {@link #subscribe(Class, Consumer)} instead; scheduled for
-     *             removal in Lettuce 8.0 (when {@code reactor-core} becomes optional). To obtain a {@link Flux} from the
-     *             callback API, bridge it yourself:
+     *             removal in Lettuce 8.0. To obtain a {@link Flux} from the callback API, bridge it yourself:
      *
      *             <pre class="code">
      *             Flux.create(sink -&gt; {
-     *             Subscription s = eventBus.subscribe(sink::next);
-     *             sink.onDispose(s::close);
+     *                 Subscription s = eventBus.subscribe(sink::next);
+     *                 sink.onDispose(s::close);
      *             }, FluxSink.OverflowStrategy.DROP);
      *             </pre>
      */
@@ -40,7 +39,7 @@ public interface EventBus {
     void publish(Event event);
 
     /**
-     * Subscribe to all {@link Event}s published to the bus. The {@code listener} is invoked for every event until the returned
+     * Subscribes to all {@link Event}s published to the bus. The {@code listener} is invoked for every event until the returned
      * {@link Subscription} is {@link Subscription#close() closed}. Events are dropped on backpressure to avoid contention.
      *
      * @param listener callback invoked with each published event, must not be {@code null}.
@@ -54,8 +53,8 @@ public interface EventBus {
     }
 
     /**
-     * Subscribe to {@link Event}s of a given {@code type} published to the bus. The {@code listener} is invoked for every event
-     * assignable to {@code type} until the returned {@link Subscription} is {@link Subscription#close() closed}.
+     * Subscribes to {@link Event}s of a given {@code type} published to the bus. The {@code listener} is invoked for every
+     * event assignable to {@code type} until the returned {@link Subscription} is {@link Subscription#close() closed}.
      *
      * @param type the event type to receive, must not be {@code null}.
      * @param listener callback invoked with each matching event, must not be {@code null}.

--- a/src/test/java/io/lettuce/core/event/DefaultEventBusUnitTests.java
+++ b/src/test/java/io/lettuce/core/event/DefaultEventBusUnitTests.java
@@ -4,6 +4,7 @@ import static io.lettuce.TestTags.UNIT_TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import io.lettuce.core.Subscription;
 import reactor.core.Disposable;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
@@ -47,6 +49,54 @@ class DefaultEventBusUnitTests {
         assertThat(arrayQueue.take()).isEqualTo(event);
         assertThat(arrayQueue.take()).isEqualTo(event);
         disposable1.dispose();
+    }
+
+    @Test
+    void subscribeCallbackReceivesEvent() throws Exception {
+
+        EventBus sut = new DefaultEventBus(Schedulers.immediate());
+        ArrayBlockingQueue<Event> received = new ArrayBlockingQueue<>(5);
+
+        Subscription subscription = sut.subscribe(received::add);
+        sut.publish(event);
+
+        assertThat(received.poll(1, TimeUnit.SECONDS)).isEqualTo(event);
+        subscription.close();
+    }
+
+    @Test
+    void subscribeByTypeFiltersEvents() throws Exception {
+
+        EventBus sut = new DefaultEventBus(Schedulers.immediate());
+        ArrayBlockingQueue<EventA> received = new ArrayBlockingQueue<>(5);
+
+        Subscription subscription = sut.subscribe(EventA.class, received::add);
+        sut.publish(new EventB());
+        EventA expected = new EventA();
+        sut.publish(expected);
+
+        assertThat(received.poll(1, TimeUnit.SECONDS)).isSameAs(expected);
+        assertThat(received).isEmpty();
+        subscription.close();
+    }
+
+    @Test
+    void closeStopsDelivery() throws Exception {
+
+        EventBus sut = new DefaultEventBus(Schedulers.immediate());
+        ArrayBlockingQueue<Event> received = new ArrayBlockingQueue<>(5);
+
+        Subscription subscription = sut.subscribe(received::add);
+        subscription.close();
+        sut.publish(event);
+
+        assertThat(received.poll(200, TimeUnit.MILLISECONDS)).isNull();
+    }
+
+    static class EventA implements Event {
+    }
+
+    static class EventB implements Event {
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API deprecation affects callers of EventBus.get(), though defaults preserve current behavior until 8.0.
> 
> **Overview**
> Introduces **`Subscription`**, a closeable handle for Lettuce streaming callbacks (distinct from Reactive Streams and Redis Pub/Sub), and adds **`EventBus.subscribe(Consumer)`** and **`subscribe(Class, Consumer)`** as the preferred way to receive events.
> 
> **`EventBus.get()`** is **deprecated** (removal in 8.0) with Javadoc showing how to bridge back to a **`Flux`** if needed. New subscribe methods are default implementations on top of the existing Flux pipeline, so behavior (including drop-on-backpressure) stays aligned with today.
> 
> Unit tests cover callback delivery, type filtering, and that **`close()`** stops further events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc13132f5935765a40e29969509befbd31d2266b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->