### PR TITLE
[reactor-optional] Replace reactor event bus impl with callback based

### DIFF
--- a/src/main/java/io/lettuce/core/event/DefaultEventBus.java
+++ b/src/main/java/io/lettuce/core/event/DefaultEventBus.java
@@ -1,33 +1,51 @@
 package io.lettuce.core.event;
 
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Sinks;
-import reactor.core.scheduler.Scheduler;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import io.lettuce.core.Subscription;
 import io.lettuce.core.event.jfr.EventRecorder;
+import io.lettuce.core.internal.LettuceAssert;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.EventExecutorGroup;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 /**
- * Default implementation for an {@link EventBus}. Events are published using a {@link Scheduler} and events are recorded
- * through {@link EventRecorder#record(Event) EventRecorder}.
+ * Default implementation for an {@link EventBus}. Events are recorded through {@link EventRecorder#record(Event) EventRecorder}
+ * and dispatched to subscribers on an {@link EventExecutorGroup}. Each subscription is pinned to a single {@link EventExecutor}
+ * so its events are delivered in order; a subscriber that cannot keep up drops events (bounded by
+ * {@code maxInFlightPerSubscription}) rather than applying back-pressure to the publishing thread.
  *
  * @author Mark Paluch
  * @since 3.4
  */
 public class DefaultEventBus implements EventBus {
 
-    private final Sinks.Many<Event> bus;
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(DefaultEventBus.class);
 
-    private final Scheduler scheduler;
+    static final int DEFAULT_MAX_IN_FLIGHT = 1024;
+
+    private final EventExecutorGroup eventExecutorGroup;
+
+    private final int maxInFlightPerSubscription;
 
     private final EventRecorder recorder = EventRecorder.getInstance();
 
-    public DefaultEventBus(Scheduler scheduler) {
-        this.bus = Sinks.many().multicast().directBestEffort();
-        this.scheduler = scheduler;
+    private final CopyOnWriteArrayList<EventSubscription> subscriptions = new CopyOnWriteArrayList<>();
+
+    public DefaultEventBus(EventExecutorGroup eventExecutorGroup) {
+        this(eventExecutorGroup, DEFAULT_MAX_IN_FLIGHT);
     }
 
-    @Override
-    public Flux<Event> get() {
-        return bus.asFlux().onBackpressureDrop().publishOn(scheduler);
+    public DefaultEventBus(EventExecutorGroup eventExecutorGroup, int maxInFlightPerSubscription) {
+        LettuceAssert.notNull(eventExecutorGroup, "EventExecutorGroup must not be null");
+        LettuceAssert.isTrue(maxInFlightPerSubscription > 0, "maxInFlightPerSubscription must be greater than 0");
+        this.eventExecutorGroup = eventExecutorGroup;
+        this.maxInFlightPerSubscription = maxInFlightPerSubscription;
     }
 
     @Override
@@ -35,15 +53,76 @@ public class DefaultEventBus implements EventBus {
 
         recorder.record(event);
 
-        Sinks.EmitResult emitResult;
+        for (EventSubscription subscription : subscriptions) {
+            subscription.dispatch(event);
+        }
+    }
 
-        while ((emitResult = bus.tryEmitNext(event)) == Sinks.EmitResult.FAIL_NON_SERIALIZED) {
-            // busy-loop
+    @Override
+    public Subscription subscribe(Consumer<Event> listener) {
+
+        LettuceAssert.notNull(listener, "Listener must not be null");
+
+        EventSubscription subscription = new EventSubscription(listener, eventExecutorGroup.next());
+        subscriptions.add(subscription);
+        return subscription;
+    }
+
+    /**
+     * A single subscription, pinned to one {@link EventExecutor} for in-order delivery and bounded by an in-flight counter.
+     */
+    private class EventSubscription implements Subscription {
+
+        private final Consumer<Event> listener;
+
+        private final EventExecutor executor;
+
+        private final AtomicInteger inFlight = new AtomicInteger();
+
+        private final AtomicBoolean closed = new AtomicBoolean();
+
+        EventSubscription(Consumer<Event> listener, EventExecutor executor) {
+            this.listener = listener;
+            this.executor = executor;
         }
 
-        if (emitResult != Sinks.EmitResult.FAIL_ZERO_SUBSCRIBER) {
-            emitResult.orThrow();
+        void dispatch(Event event) {
+
+            if (closed.get()) {
+                return;
+            }
+
+            if (inFlight.incrementAndGet() > maxInFlightPerSubscription) {
+                inFlight.decrementAndGet();
+                logger.warn("Dropping event {} for a slow event bus subscriber ({} in-flight events exceeded)",
+                        event.getClass().getName(), maxInFlightPerSubscription);
+                return;
+            }
+
+            try {
+                executor.execute(() -> {
+                    try {
+                        if (!closed.get()) {
+                            listener.accept(event);
+                        }
+                    } catch (Throwable t) {
+                        logger.warn("Event bus listener threw while handling {}", event.getClass().getName(), t);
+                    } finally {
+                        inFlight.decrementAndGet();
+                    }
+                });
+            } catch (RejectedExecutionException e) {
+                inFlight.decrementAndGet();
+            }
         }
+
+        @Override
+        public void close() {
+            if (closed.compareAndSet(false, true)) {
+                subscriptions.remove(this);
+            }
+        }
+
     }
 
 }

--- a/src/main/java/io/lettuce/core/event/DefaultEventBus.java
+++ b/src/main/java/io/lettuce/core/event/DefaultEventBus.java
@@ -2,7 +2,6 @@ package io.lettuce.core.event;
 
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -79,7 +78,7 @@ public class DefaultEventBus implements EventBus {
 
         private final AtomicInteger inFlight = new AtomicInteger();
 
-        private final AtomicBoolean closed = new AtomicBoolean();
+        private volatile boolean closed;
 
         EventSubscription(Consumer<Event> listener, EventExecutor executor) {
             this.listener = listener;
@@ -88,7 +87,7 @@ public class DefaultEventBus implements EventBus {
 
         void dispatch(Event event) {
 
-            if (closed.get()) {
+            if (closed) {
                 return;
             }
 
@@ -102,7 +101,7 @@ public class DefaultEventBus implements EventBus {
             try {
                 executor.execute(() -> {
                     try {
-                        if (!closed.get()) {
+                        if (!closed) {
                             listener.accept(event);
                         }
                     } catch (Throwable t) {
@@ -118,9 +117,11 @@ public class DefaultEventBus implements EventBus {
 
         @Override
         public void close() {
-            if (closed.compareAndSet(false, true)) {
-                subscriptions.remove(this);
+            if (closed) {
+                return;
             }
+            closed = true;
+            subscriptions.remove(this);
         }
 
     }

--- a/src/main/java/io/lettuce/core/event/DefaultEventBus.java
+++ b/src/main/java/io/lettuce/core/event/DefaultEventBus.java
@@ -38,10 +38,24 @@ public class DefaultEventBus implements EventBus {
 
     private final CopyOnWriteArrayList<EventSubscription> subscriptions = new CopyOnWriteArrayList<>();
 
+    /**
+     * Creates a new {@link DefaultEventBus} that dispatches events on the given {@link EventExecutorGroup}, using the default
+     * per-subscription in-flight bound.
+     *
+     * @param eventExecutorGroup the executor group on which events are dispatched to subscribers, must not be {@code null}.
+     */
     public DefaultEventBus(EventExecutorGroup eventExecutorGroup) {
         this(eventExecutorGroup, DEFAULT_MAX_IN_FLIGHT);
     }
 
+    /**
+     * Creates a new {@link DefaultEventBus} that dispatches events on the given {@link EventExecutorGroup}, dropping events for
+     * a subscriber once more than {@code maxInFlightPerSubscription} of its events are awaiting delivery.
+     *
+     * @param eventExecutorGroup the executor group on which events are dispatched to subscribers, must not be {@code null}.
+     * @param maxInFlightPerSubscription the number of events that may await delivery per subscriber before further events are
+     *        dropped, must be greater than {@code 0}.
+     */
     public DefaultEventBus(EventExecutorGroup eventExecutorGroup, int maxInFlightPerSubscription) {
         LettuceAssert.notNull(eventExecutorGroup, "EventExecutorGroup must not be null");
         LettuceAssert.isTrue(maxInFlightPerSubscription > 0, "maxInFlightPerSubscription must be greater than 0");

--- a/src/main/java/io/lettuce/core/event/DefaultEventBus.java
+++ b/src/main/java/io/lettuce/core/event/DefaultEventBus.java
@@ -15,9 +15,11 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 /**
  * Default implementation for an {@link EventBus}. Events are recorded through {@link EventRecorder#record(Event) EventRecorder}
- * and dispatched to subscribers on an {@link EventExecutorGroup}. Each subscription is pinned to a single {@link EventExecutor}
- * so its events are delivered in order; a subscriber that cannot keep up drops events (bounded by
- * {@code maxInFlightPerSubscription}) rather than applying back-pressure to the publishing thread.
+ * and dispatched to subscribers on an {@link EventExecutorGroup}. Each subscription is pinned to a single
+ * {@link EventExecutor}, so events published from a single thread are delivered to that subscriber in publication order;
+ * ordering across concurrent publishers, and relative to {@link EventRecorder}, is not guaranteed. A subscriber that cannot
+ * keep up drops events (bounded by {@code maxInFlightPerSubscription}) rather than applying back-pressure to the publishing
+ * thread.
  *
  * @author Mark Paluch
  * @since 3.4
@@ -62,7 +64,21 @@ public class DefaultEventBus implements EventBus {
 
         LettuceAssert.notNull(listener, "Listener must not be null");
 
-        EventSubscription subscription = new EventSubscription(listener, eventExecutorGroup.next());
+        return register(null, listener);
+    }
+
+    @Override
+    public <T extends Event> Subscription subscribe(Class<T> type, Consumer<T> listener) {
+
+        LettuceAssert.notNull(type, "Event type must not be null");
+        LettuceAssert.notNull(listener, "Listener must not be null");
+
+        return register(type, event -> listener.accept(type.cast(event)));
+    }
+
+    private Subscription register(Class<? extends Event> type, Consumer<Event> listener) {
+
+        EventSubscription subscription = new EventSubscription(type, listener, eventExecutorGroup.next());
         subscriptions.add(subscription);
         return subscription;
     }
@@ -72,6 +88,8 @@ public class DefaultEventBus implements EventBus {
      */
     private class EventSubscription implements Subscription {
 
+        private final Class<? extends Event> type;
+
         private final Consumer<Event> listener;
 
         private final EventExecutor executor;
@@ -80,7 +98,8 @@ public class DefaultEventBus implements EventBus {
 
         private volatile boolean closed;
 
-        EventSubscription(Consumer<Event> listener, EventExecutor executor) {
+        EventSubscription(Class<? extends Event> type, Consumer<Event> listener, EventExecutor executor) {
+            this.type = type;
             this.listener = listener;
             this.executor = executor;
         }
@@ -88,6 +107,10 @@ public class DefaultEventBus implements EventBus {
         void dispatch(Event event) {
 
             if (closed) {
+                return;
+            }
+
+            if (type != null && !type.isInstance(event)) {
                 return;
             }
 

--- a/src/main/java/io/lettuce/core/event/EventBus.java
+++ b/src/main/java/io/lettuce/core/event/EventBus.java
@@ -14,14 +14,14 @@ import io.lettuce.core.internal.LettuceAssert;
 public interface EventBus {
 
     /**
-     * Publish a {@link Event} to the bus.
+     * Publishes an {@link Event} to the bus.
      *
      * @param event the event to publish
      */
     void publish(Event event);
 
     /**
-     * Subscribe to all {@link Event}s published to the bus. The {@code listener} is invoked for every event until the returned
+     * Subscribes to all {@link Event}s published to the bus. The {@code listener} is invoked for every event until the returned
      * {@link Subscription} is {@link Subscription#close() closed}. Events are dropped for a subscriber that cannot keep up, to
      * avoid contention.
      *
@@ -32,8 +32,11 @@ public interface EventBus {
     Subscription subscribe(Consumer<Event> listener);
 
     /**
-     * Subscribe to {@link Event}s of a given {@code type} published to the bus. The {@code listener} is invoked for every event
-     * assignable to {@code type} until the returned {@link Subscription} is {@link Subscription#close() closed}.
+     * Subscribes to {@link Event}s of a given {@code type} published to the bus. The {@code listener} is invoked for every
+     * event assignable to {@code type} until the returned {@link Subscription} is {@link Subscription#close() closed}.
+     * <p>
+     * Implementations that bound or drop events per subscriber should override this method to filter by {@code type} before
+     * admission, so that non-matching events do not consume a subscriber's delivery capacity.
      *
      * @param type the event type to receive, must not be {@code null}.
      * @param listener callback invoked with each matching event, must not be {@code null}.

--- a/src/main/java/io/lettuce/core/event/EventBus.java
+++ b/src/main/java/io/lettuce/core/event/EventBus.java
@@ -4,7 +4,6 @@ import java.util.function.Consumer;
 
 import io.lettuce.core.Subscription;
 import io.lettuce.core.internal.LettuceAssert;
-import reactor.core.publisher.Flux;
 
 /**
  * Interface for an EventBus. Events can be published over the bus that are delivered to the subscribers.
@@ -15,23 +14,6 @@ import reactor.core.publisher.Flux;
 public interface EventBus {
 
     /**
-     * Subscribes to the event bus and its {@link Event}s. The {@link Flux} drops events on backpressure to avoid contention.
-     *
-     * @return the observable to obtain events.
-     * @deprecated since 7.7, use {@link #subscribe(Consumer)} or {@link #subscribe(Class, Consumer)} instead; scheduled for
-     *             removal in Lettuce 8.0. To obtain a {@link Flux} from the callback API, bridge it yourself:
-     *
-     *             <pre class="code">
-     *             Flux.create(sink -&gt; {
-     *                 Subscription s = eventBus.subscribe(sink::next);
-     *                 sink.onDispose(s::close);
-     *             }, FluxSink.OverflowStrategy.DROP);
-     *             </pre>
-     */
-    @Deprecated
-    Flux<Event> get();
-
-    /**
      * Publish a {@link Event} to the bus.
      *
      * @param event the event to publish
@@ -39,28 +21,25 @@ public interface EventBus {
     void publish(Event event);
 
     /**
-     * Subscribes to all {@link Event}s published to the bus. The {@code listener} is invoked for every event until the returned
-     * {@link Subscription} is {@link Subscription#close() closed}. Events are dropped on backpressure to avoid contention.
+     * Subscribe to all {@link Event}s published to the bus. The {@code listener} is invoked for every event until the returned
+     * {@link Subscription} is {@link Subscription#close() closed}. Events are dropped for a subscriber that cannot keep up, to
+     * avoid contention.
      *
      * @param listener callback invoked with each published event, must not be {@code null}.
      * @return a {@link Subscription} that stops delivery when closed.
-     * @since 7.7
+     * @since 8.0
      */
-    default Subscription subscribe(Consumer<Event> listener) {
-        LettuceAssert.notNull(listener, "Listener must not be null");
-        reactor.core.Disposable disposable = get().subscribe(listener);
-        return disposable::dispose;
-    }
+    Subscription subscribe(Consumer<Event> listener);
 
     /**
-     * Subscribes to {@link Event}s of a given {@code type} published to the bus. The {@code listener} is invoked for every
-     * event assignable to {@code type} until the returned {@link Subscription} is {@link Subscription#close() closed}.
+     * Subscribe to {@link Event}s of a given {@code type} published to the bus. The {@code listener} is invoked for every event
+     * assignable to {@code type} until the returned {@link Subscription} is {@link Subscription#close() closed}.
      *
      * @param type the event type to receive, must not be {@code null}.
      * @param listener callback invoked with each matching event, must not be {@code null}.
      * @param <T> the event type.
      * @return a {@link Subscription} that stops delivery when closed.
-     * @since 7.7
+     * @since 8.0
      */
     default <T extends Event> Subscription subscribe(Class<T> type, Consumer<T> listener) {
         LettuceAssert.notNull(type, "Event type must not be null");

--- a/src/main/java/io/lettuce/core/resource/DefaultClientResources.java
+++ b/src/main/java/io/lettuce/core/resource/DefaultClientResources.java
@@ -55,7 +55,6 @@ import io.netty.util.concurrent.PromiseCombiner;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import reactor.core.scheduler.Schedulers;
 
 /**
  * Default instance of the client resources.
@@ -222,7 +221,7 @@ public class DefaultClientResources implements ClientResources {
         }
 
         if (builder.eventBus == null) {
-            eventBus = new DefaultEventBus(Schedulers.fromExecutorService(eventExecutorGroup, "lettuce-event-bus"));
+            eventBus = new DefaultEventBus(eventExecutorGroup);
         } else {
             eventBus = builder.eventBus;
         }

--- a/src/test/java/io/lettuce/core/ClientMetricsIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/ClientMetricsIntegrationTests.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import io.lettuce.test.ReflectionTestUtils;
 
-import reactor.core.Disposable;
+import io.lettuce.core.Subscription;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.event.EventBus;
@@ -39,8 +39,7 @@ class ClientMetricsIntegrationTests extends TestSupport {
                 "metricEventPublisher");
         publisher.emitMetricsEvent();
 
-        Disposable disposable = eventBus.get().filter(redisEvent -> redisEvent instanceof CommandLatencyEvent)
-                .cast(CommandLatencyEvent.class).doOnNext(events::add).subscribe();
+        Subscription subscription = eventBus.subscribe(CommandLatencyEvent.class, events::add);
 
         generateTestData(connection.sync());
         publisher.emitMetricsEvent();
@@ -49,7 +48,7 @@ class ClientMetricsIntegrationTests extends TestSupport {
 
         assertThat(events).isNotEmpty();
 
-        disposable.dispose();
+        subscription.close();
     }
 
     private void generateTestData(RedisCommands<String, String> redis) {

--- a/src/test/java/io/lettuce/core/RedisAuthenticationHandlerUnitTests.java
+++ b/src/test/java/io/lettuce/core/RedisAuthenticationHandlerUnitTests.java
@@ -1,7 +1,9 @@
 package io.lettuce.core;
 
+import io.lettuce.core.Subscription;
 import io.lettuce.core.codec.StringCodec;
 import io.lettuce.core.event.DefaultEventBus;
+import io.lettuce.core.event.Event;
 import io.lettuce.core.event.EventBus;
 import io.lettuce.core.event.connection.ReauthenticationFailedEvent;
 import io.lettuce.core.protocol.AsyncCommand;
@@ -14,10 +16,10 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
-import reactor.core.scheduler.Schedulers;
-import reactor.test.StepVerifier;
+import io.netty.util.concurrent.ImmediateEventExecutor;
 
-import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static io.lettuce.TestTags.UNIT_TEST;
 import static io.lettuce.core.protocol.CommandType.AUTH;
@@ -48,7 +50,7 @@ public class RedisAuthenticationHandlerUnitTests {
 
     @BeforeEach
     void setUp() {
-        eventBus = new DefaultEventBus(Schedulers.immediate());
+        eventBus = new DefaultEventBus(ImmediateEventExecutor.INSTANCE);
         writer = mock(RedisChannelWriter.class);
         connection = mock(StatefulRedisConnectionImpl.class);
         resources = mock(ClientResources.class);
@@ -92,12 +94,17 @@ public class RedisAuthenticationHandlerUnitTests {
 
         verify(connection, times(0)).dispatch(any(RedisCommand.class)); // No command should be sent
 
-        // Verify the event was published
-        StepVerifier.create(eventBus.get()).then(() -> {
-            handler.subscribe();
-            credentialsProvider.tryEmitError(new RuntimeException("Test error"));
-        }).expectNextMatches(event -> event instanceof ReauthenticationFailedEvent).thenCancel().verify(Duration.ofSeconds(1));
+        // Verify the event was published. ImmediateEventExecutor delivers synchronously, so the event is present once
+        // the error has been emitted.
+        List<Event> events = new CopyOnWriteArrayList<>();
+        Subscription subscription = eventBus.subscribe(events::add);
 
+        handler.subscribe();
+        credentialsProvider.tryEmitError(new RuntimeException("Test error"));
+
+        assertThat(events).anyMatch(event -> event instanceof ReauthenticationFailedEvent);
+
+        subscription.close();
         credentialsProvider.shutdown();
     }
 

--- a/src/test/java/io/lettuce/core/cluster/RedisClusterClientTopologyRefreshUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisClusterClientTopologyRefreshUnitTests.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.AfterEach;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.lettuce.core.RedisURI;
+import io.lettuce.core.Subscription;
 import io.lettuce.core.cluster.event.ClusterTopologyChangedEvent;
 import io.lettuce.core.cluster.models.partitions.Partitions;
 import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
@@ -25,7 +27,6 @@ import io.lettuce.core.event.Event;
 import io.lettuce.core.event.EventBus;
 import io.lettuce.core.resource.ClientResources;
 import io.lettuce.test.resource.FastShutdown;
-import reactor.core.publisher.Flux;
 
 /**
  * Unit tests for {@link RedisClusterClient} topology refresh.
@@ -75,8 +76,9 @@ class RedisClusterClientTopologyRefreshUnitTests {
         final AtomicReference<List<RedisClusterNode>> partitionsWhenPublished = new AtomicReference<>();
 
         @Override
-        public Flux<Event> get() {
-            return Flux.empty();
+        public Subscription subscribe(Consumer<Event> listener) {
+            return () -> {
+            };
         }
 
         @Override

--- a/src/test/java/io/lettuce/core/event/ConnectionEventsTriggeredIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/event/ConnectionEventsTriggeredIntegrationTests.java
@@ -3,11 +3,13 @@ package io.lettuce.core.event;
 import static io.lettuce.TestTags.INTEGRATION_TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.MyStreamingRedisCredentialsProvider;
+import io.lettuce.core.Subscription;
 import io.lettuce.core.event.connection.AuthenticationEvent;
 import io.lettuce.core.event.connection.ReauthenticationEvent;
 import io.lettuce.core.event.connection.ReauthenticationFailedEvent;
@@ -19,8 +21,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import org.junit.jupiter.api.extension.ExtendWith;
-import reactor.core.publisher.Flux;
-import reactor.test.StepVerifier;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.TestSupport;
@@ -37,19 +37,27 @@ import io.lettuce.test.resource.TestClientResources;
 class ConnectionEventsTriggeredIntegrationTests extends TestSupport {
 
     @Test
-    void testConnectionEvents() {
+    void testConnectionEvents() throws InterruptedException {
 
         RedisClient client = RedisClient.create(TestClientResources.get(), RedisURI.Builder.redis(host, port).build());
 
-        Flux<ConnectionEvent> publisher = client.getResources().eventBus().get()
-                .filter(event -> event instanceof ConnectionEvent).cast(ConnectionEvent.class);
+        BlockingQueue<ConnectionEvent> events = new LinkedBlockingQueue<>();
+        Subscription subscription = client.getResources().eventBus().subscribe(ConnectionEvent.class, events::add);
 
-        StepVerifier.create(publisher).then(() -> client.connect().close()).assertNext(event -> {
-            assertThat(event.remoteAddress()).isNotNull();
-            assertThat(event.localAddress()).isNotNull();
-            assertThat(event.toString()).contains("->");
-        }).expectNextCount(3).thenCancel().verify(Duration.of(5, ChronoUnit.SECONDS));
+        client.connect().close();
 
+        ConnectionEvent first = events.poll(5, TimeUnit.SECONDS);
+        assertThat(first).isNotNull();
+        assertThat(first.remoteAddress()).isNotNull();
+        assertThat(first.localAddress()).isNotNull();
+        assertThat(first.toString()).contains("->");
+
+        // expect at least three more connection events (connected/activated/disconnected/deactivated)
+        for (int i = 0; i < 3; i++) {
+            assertThat(events.poll(5, TimeUnit.SECONDS)).isNotNull();
+        }
+
+        subscription.close();
         FastShutdown.shutdown(client);
     }
 
@@ -64,17 +72,22 @@ class ConnectionEventsTriggeredIntegrationTests extends TestSupport {
                 .reauthenticateBehavior(ClientOptions.ReauthenticateBehavior.ON_NEW_CREDENTIALS).build());
         RedisURI uri = RedisURI.Builder.redis(host, port).withAuthentication(credentialsProvider).build();
 
-        Flux<AuthenticationEvent> publisher = client.getResources().eventBus().get()
-                .filter(event -> event instanceof AuthenticationEvent).cast(AuthenticationEvent.class);
+        WithPassword.run(client, () -> {
+            BlockingQueue<AuthenticationEvent> events = new LinkedBlockingQueue<>();
+            Subscription subscription = client.getResources().eventBus().subscribe(AuthenticationEvent.class, events::add);
 
-        WithPassword.run(client, () -> StepVerifier.create(publisher).then(() -> client.connect(uri))
-                .assertNext(event -> assertThat(event).asInstanceOf(InstanceOfAssertFactories.type(ReauthenticationEvent.class))
-                        .extracting(ReauthenticationEvent::getEpId).isNotNull())
-                .then(() -> credentialsProvider.emitCredentials(TestSettings.username(), "invalid".toCharArray()))
-                .assertNext(event -> assertThat(event)
-                        .asInstanceOf(InstanceOfAssertFactories.type(ReauthenticationFailedEvent.class))
-                        .extracting(ReauthenticationFailedEvent::getEpId).isNotNull())
-                .thenCancel().verify(Duration.of(1, ChronoUnit.SECONDS)));
+            client.connect(uri);
+            AuthenticationEvent first = events.poll(1, TimeUnit.SECONDS);
+            assertThat(first).asInstanceOf(InstanceOfAssertFactories.type(ReauthenticationEvent.class))
+                    .extracting(ReauthenticationEvent::getEpId).isNotNull();
+
+            credentialsProvider.emitCredentials(TestSettings.username(), "invalid".toCharArray());
+            AuthenticationEvent second = events.poll(1, TimeUnit.SECONDS);
+            assertThat(second).asInstanceOf(InstanceOfAssertFactories.type(ReauthenticationFailedEvent.class))
+                    .extracting(ReauthenticationFailedEvent::getEpId).isNotNull();
+
+            subscription.close();
+        });
 
         FastShutdown.shutdown(client);
     }

--- a/src/test/java/io/lettuce/core/event/DefaultEventBusUnitTests.java
+++ b/src/test/java/io/lettuce/core/event/DefaultEventBusUnitTests.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterEach;
@@ -179,6 +181,59 @@ class DefaultEventBusUnitTests {
 
         assertThat(received.poll(1, TimeUnit.SECONDS)).isSameAs(first);
         assertThat(received.poll(200, TimeUnit.MILLISECONDS)).isNull();
+    }
+
+    @Test
+    void concurrentPublishersDeliverWithoutError() throws Exception {
+
+        DefaultEventBus sut = new DefaultEventBus(group, 100_000); // generous bound so nothing is dropped
+        int threads = 8;
+        int perThread = 500;
+        int total = threads * perThread;
+        CountDownLatch delivered = new CountDownLatch(total);
+        List<Throwable> publishErrors = new CopyOnWriteArrayList<>();
+
+        sut.subscribe(event -> delivered.countDown());
+
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            for (int t = 0; t < threads; t++) {
+                pool.submit(() -> {
+                    try {
+                        for (int i = 0; i < perThread; i++) {
+                            sut.publish(new TestEvent());
+                        }
+                    } catch (Throwable th) {
+                        publishErrors.add(th);
+                    }
+                });
+            }
+
+            assertThat(delivered.await(5, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertThat(publishErrors).isEmpty();
+    }
+
+    @Test
+    void typedSubscriberNotStarvedByOtherEventTypes() throws Exception {
+
+        // Tiny bound: matching events would be dropped if non-matching events consumed in-flight capacity.
+        DefaultEventBus sut = new DefaultEventBus(group, 1);
+        ArrayBlockingQueue<EventA> received = new ArrayBlockingQueue<>(8);
+
+        sut.subscribe(EventA.class, received::add);
+
+        // A burst of non-matching events must be filtered before in-flight admission and never starve the typed subscriber.
+        for (int i = 0; i < 1000; i++) {
+            sut.publish(new EventB());
+        }
+        EventA expected = new EventA();
+        sut.publish(expected);
+
+        assertThat(received.poll(1, TimeUnit.SECONDS)).isSameAs(expected);
     }
 
     static class TestEvent implements Event {

--- a/src/test/java/io/lettuce/core/event/DefaultEventBusUnitTests.java
+++ b/src/test/java/io/lettuce/core/event/DefaultEventBusUnitTests.java
@@ -3,100 +3,201 @@ package io.lettuce.core.event;
 import static io.lettuce.TestTags.UNIT_TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.lettuce.core.Subscription;
-import reactor.core.Disposable;
-import reactor.core.scheduler.Schedulers;
-import reactor.test.StepVerifier;
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import io.netty.util.concurrent.EventExecutorGroup;
 
 /**
  * @author Mark Paluch
  */
 @Tag(UNIT_TEST)
-@ExtendWith(MockitoExtension.class)
 class DefaultEventBusUnitTests {
 
-    @Mock
-    private Event event;
+    private final EventExecutorGroup group = new DefaultEventExecutorGroup(1);
+
+    @AfterEach
+    void tearDown() {
+        group.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
+    }
 
     @Test
-    void publishToSubscriber() {
+    void publishToSingleSubscriber() throws Exception {
 
-        EventBus sut = new DefaultEventBus(Schedulers.immediate());
+        DefaultEventBus sut = new DefaultEventBus(group);
+        ArrayBlockingQueue<Event> received = new ArrayBlockingQueue<>(8);
 
-        StepVerifier.create(sut.get()).then(() -> sut.publish(event)).expectNext(event).thenCancel().verify();
+        Subscription subscription = sut.subscribe(received::add);
+        Event event = new TestEvent();
+        sut.publish(event);
+
+        assertThat(received.poll(1, TimeUnit.SECONDS)).isSameAs(event);
+        subscription.close();
     }
 
     @Test
     void publishToMultipleSubscribers() throws Exception {
 
-        EventBus sut = new DefaultEventBus(Schedulers.parallel());
+        DefaultEventBus sut = new DefaultEventBus(group);
+        ArrayBlockingQueue<Event> first = new ArrayBlockingQueue<>(8);
+        ArrayBlockingQueue<Event> second = new ArrayBlockingQueue<>(8);
 
-        ArrayBlockingQueue<Event> arrayQueue = new ArrayBlockingQueue<>(5);
-
-        Disposable disposable1 = sut.get().doOnNext(arrayQueue::add).subscribe();
-        StepVerifier.create(sut.get().doOnNext(arrayQueue::add)).then(() -> sut.publish(event)).expectNext(event).thenCancel()
-                .verify();
-
-        assertThat(arrayQueue.take()).isEqualTo(event);
-        assertThat(arrayQueue.take()).isEqualTo(event);
-        disposable1.dispose();
-    }
-
-    @Test
-    void subscribeCallbackReceivesEvent() throws Exception {
-
-        EventBus sut = new DefaultEventBus(Schedulers.immediate());
-        ArrayBlockingQueue<Event> received = new ArrayBlockingQueue<>(5);
-
-        Subscription subscription = sut.subscribe(received::add);
+        sut.subscribe(first::add);
+        sut.subscribe(second::add);
+        Event event = new TestEvent();
         sut.publish(event);
 
-        assertThat(received.poll(1, TimeUnit.SECONDS)).isEqualTo(event);
-        subscription.close();
+        assertThat(first.poll(1, TimeUnit.SECONDS)).isSameAs(event);
+        assertThat(second.poll(1, TimeUnit.SECONDS)).isSameAs(event);
     }
 
     @Test
     void subscribeByTypeFiltersEvents() throws Exception {
 
-        EventBus sut = new DefaultEventBus(Schedulers.immediate());
-        ArrayBlockingQueue<EventA> received = new ArrayBlockingQueue<>(5);
+        DefaultEventBus sut = new DefaultEventBus(group);
+        ArrayBlockingQueue<EventA> received = new ArrayBlockingQueue<>(8);
 
-        Subscription subscription = sut.subscribe(EventA.class, received::add);
+        sut.subscribe(EventA.class, received::add);
         sut.publish(new EventB());
         EventA expected = new EventA();
         sut.publish(expected);
 
         assertThat(received.poll(1, TimeUnit.SECONDS)).isSameAs(expected);
         assertThat(received).isEmpty();
+    }
+
+    @Test
+    void unsubscribeStopsDelivery() throws Exception {
+
+        DefaultEventBus sut = new DefaultEventBus(group);
+        ArrayBlockingQueue<Event> received = new ArrayBlockingQueue<>(8);
+
+        Subscription subscription = sut.subscribe(received::add);
+        subscription.close();
+        sut.publish(new TestEvent());
+
+        assertThat(received.poll(200, TimeUnit.MILLISECONDS)).isNull();
+    }
+
+    @Test
+    void closeIsIdempotent() {
+
+        DefaultEventBus sut = new DefaultEventBus(group);
+
+        Subscription subscription = sut.subscribe(event -> {
+        });
+        subscription.close();
         subscription.close();
     }
 
     @Test
-    void closeStopsDelivery() throws Exception {
+    void perSubscriberOrdering() throws Exception {
 
-        EventBus sut = new DefaultEventBus(Schedulers.immediate());
-        ArrayBlockingQueue<Event> received = new ArrayBlockingQueue<>(5);
+        DefaultEventBus sut = new DefaultEventBus(group);
+        int count = 100;
+        CountDownLatch latch = new CountDownLatch(count);
+        List<Integer> seen = new CopyOnWriteArrayList<>();
 
-        Subscription subscription = sut.subscribe(received::add);
-        subscription.close();
-        sut.publish(event);
+        sut.subscribe(event -> {
+            seen.add(((IndexedEvent) event).index);
+            latch.countDown();
+        });
+        for (int i = 0; i < count; i++) {
+            sut.publish(new IndexedEvent(i));
+        }
 
+        assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
+        List<Integer> expected = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            expected.add(i);
+        }
+        assertThat(seen).containsExactlyElementsOf(expected);
+    }
+
+    @Test
+    void exceptionInListenerIsIsolated() throws Exception {
+
+        DefaultEventBus sut = new DefaultEventBus(group);
+        ArrayBlockingQueue<Event> received = new ArrayBlockingQueue<>(8);
+        boolean[] threwOnce = { false };
+
+        sut.subscribe(event -> {
+            if (!threwOnce[0]) {
+                threwOnce[0] = true;
+                throw new RuntimeException("boom");
+            }
+            received.add(event);
+        });
+        sut.publish(new TestEvent());
+        Event second = new TestEvent();
+        sut.publish(second);
+
+        assertThat(received.poll(1, TimeUnit.SECONDS)).isSameAs(second);
+    }
+
+    @Test
+    void noSubscriberIsNoOp() {
+
+        DefaultEventBus sut = new DefaultEventBus(group);
+        sut.publish(new TestEvent());
+    }
+
+    @Test
+    void dropsEventsForSlowSubscriberBeyondBound() throws Exception {
+
+        DefaultEventBus sut = new DefaultEventBus(group, 1);
+        ArrayBlockingQueue<Event> received = new ArrayBlockingQueue<>(8);
+        CountDownLatch gate = new CountDownLatch(1);
+        CountDownLatch firstRunning = new CountDownLatch(1);
+
+        sut.subscribe(event -> {
+            received.add(event);
+            firstRunning.countDown();
+            try {
+                gate.await(2, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        Event first = new TestEvent();
+        sut.publish(first); // picked up, blocks the single executor thread; in-flight == 1
+        assertThat(firstRunning.await(1, TimeUnit.SECONDS)).isTrue();
+        sut.publish(new TestEvent()); // in-flight would be 2 > 1 -> dropped
+        sut.publish(new TestEvent()); // dropped
+        gate.countDown();
+
+        assertThat(received.poll(1, TimeUnit.SECONDS)).isSameAs(first);
         assertThat(received.poll(200, TimeUnit.MILLISECONDS)).isNull();
+    }
+
+    static class TestEvent implements Event {
     }
 
     static class EventA implements Event {
     }
 
     static class EventB implements Event {
+    }
+
+    static class IndexedEvent implements Event {
+
+        final int index;
+
+        IndexedEvent(int index) {
+            this.index = index;
+        }
+
     }
 
 }

--- a/src/test/java/io/lettuce/core/protocol/CodecFailureIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/protocol/CodecFailureIntegrationTests.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
-import reactor.core.Disposable;
+import io.lettuce.core.Subscription;
 
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.test.LettuceExtension;
@@ -71,7 +71,7 @@ class CodecFailureIntegrationTests extends TestSupport {
             // from other connections sharing the same EventBus (the RedisClient is a JVM-wide singleton).
             final String epId = unwrapEndpoint(customConnection).getId();
             final Integer[] reconnects = { 0 };
-            Disposable subscription = client.getResources().eventBus().get().subscribe(event -> {
+            Subscription subscription = client.getResources().eventBus().subscribe(event -> {
                 if (event instanceof ReconnectAttemptEvent
                         && epId.equals(ReflectionTestUtils.<String> getField(event, "epId"))) {
                     reconnects[0]++;
@@ -106,7 +106,7 @@ class CodecFailureIntegrationTests extends TestSupport {
                 // on the same endpoint while still requiring a reconnect originating from this connection.
                 Wait.untilTrue(() -> reconnects[0] >= 1).waitOrTimeout();
             } finally {
-                subscription.dispose();
+                subscription.close();
             }
         }
     }

--- a/src/test/java/io/lettuce/core/protocol/ConnectionFailureIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/protocol/ConnectionFailureIntegrationTests.java
@@ -187,7 +187,7 @@ class ConnectionFailureIntegrationTests extends TestSupport {
 
             redisUri.setPort(TestSettings.nonexistentPort());
 
-            client.getResources().eventBus().get().subscribe(queue::add);
+            client.getResources().eventBus().subscribe(queue::add);
 
             commands.quit();
             Wait.untilTrue(() -> !connection.isOpen()).waitOrTimeout();

--- a/src/test/java/io/lettuce/core/resource/DefaultClientResourcesUnitTests.java
+++ b/src/test/java/io/lettuce/core/resource/DefaultClientResourcesUnitTests.java
@@ -31,7 +31,8 @@ import io.netty.resolver.dns.DnsAddressResolverGroup;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import reactor.test.StepVerifier;
+import io.lettuce.core.Subscription;
+import java.util.concurrent.ArrayBlockingQueue;
 import io.lettuce.core.event.Event;
 import io.lettuce.core.event.EventBus;
 import io.lettuce.core.metrics.CommandLatencyCollector;
@@ -199,14 +200,19 @@ class DefaultClientResourcesUnitTests {
     }
 
     @Test
-    void testEventBus() {
+    void testEventBus() throws Exception {
 
         DefaultClientResources sut = DefaultClientResources.create();
 
         EventBus eventBus = sut.eventBus();
         Event event = mock(Event.class);
+        ArrayBlockingQueue<Event> received = new ArrayBlockingQueue<>(8);
 
-        StepVerifier.create(eventBus.get()).then(() -> eventBus.publish(event)).expectNext(event).thenCancel().verify();
+        Subscription subscription = eventBus.subscribe(received::add);
+        eventBus.publish(event);
+
+        assertThat(received.poll(1, TimeUnit.SECONDS)).isSameAs(event);
+        subscription.close();
 
         assertThat(TestFutures.getOrTimeout(sut.shutdown(0, 0, TimeUnit.MILLISECONDS))).isTrue();
     }

--- a/src/test/java/io/lettuce/examples/AutomaticFailover.java
+++ b/src/test/java/io/lettuce/examples/AutomaticFailover.java
@@ -61,7 +61,7 @@ public class AutomaticFailover {
         // Automatic failback are not supported in the current Beta release.
 
         // Listen to database switch events
-        multiDbClient.getResources().eventBus().get().subscribe(event -> {
+        multiDbClient.getResources().eventBus().subscribe(event -> {
             if (event instanceof DatabaseSwitchEvent) {
                 DatabaseSwitchEvent switchEvent = (DatabaseSwitchEvent) event;
                 log.info("Database switch from {} to {} (reason: {})", switchEvent.getFromDb(), switchEvent.getToDb(),

--- a/src/test/java/io/lettuce/scenario/ActiveActiveFailoverScenarioTest.java
+++ b/src/test/java/io/lettuce/scenario/ActiveActiveFailoverScenarioTest.java
@@ -47,7 +47,7 @@ import io.lettuce.core.failover.health.ProbingPolicy;
 import io.lettuce.core.pubsub.RedisPubSubAdapter;
 import io.lettuce.test.env.Endpoints;
 import io.lettuce.test.env.Endpoints.Endpoint;
-import reactor.core.Disposable;
+import io.lettuce.core.Subscription;
 
 @Tag(SCENARIO_TEST)
 @DisplayName("Active-Active Failover Scenario Tests")
@@ -115,7 +115,7 @@ public class ActiveActiveFailoverScenarioTest {
 
     private StatefulRedisMultiDbConnection<String, String> connection;
 
-    private Disposable eventSubscription;
+    private Subscription eventSubscription;
 
     private RedisURI primaryUri;
 
@@ -145,7 +145,7 @@ public class ActiveActiveFailoverScenarioTest {
     @AfterEach
     public void tearDown() {
         if (eventSubscription != null) {
-            eventSubscription.dispose();
+            eventSubscription.close();
         }
         if (connection != null && connection.isOpen()) {
             connection.close();
@@ -446,7 +446,7 @@ public class ActiveActiveFailoverScenarioTest {
 
     private FailoverReporter setupFailoverReporter() {
         FailoverReporter reporter = new FailoverReporter();
-        eventSubscription = multiDbClient.getResources().eventBus().get().subscribe(event -> {
+        eventSubscription = multiDbClient.getResources().eventBus().subscribe(event -> {
             if (event instanceof DatabaseSwitchEvent) {
                 reporter.accept((DatabaseSwitchEvent) event);
             }

--- a/src/test/java/io/lettuce/scenario/ConnectionEventBusMonitoringUtil.java
+++ b/src/test/java/io/lettuce/scenario/ConnectionEventBusMonitoringUtil.java
@@ -40,7 +40,7 @@ public class ConnectionEventBusMonitoringUtil {
     public void setupEventBusMonitoring(RedisClient client) {
         EventBus eventBus = client.getResources().eventBus();
 
-        eventBus.get().subscribe(event -> {
+        eventBus.subscribe(event -> {
             if (!monitoringActive.get())
                 return;
 

--- a/src/test/java/io/lettuce/scenario/ReconnectionTimingTracker.java
+++ b/src/test/java/io/lettuce/scenario/ReconnectionTimingTracker.java
@@ -19,7 +19,7 @@ import io.lettuce.core.event.connection.ConnectionActivatedEvent;
 import io.lettuce.core.event.connection.ConnectionDeactivatedEvent;
 import io.lettuce.core.event.connection.ReconnectAttemptEvent;
 import io.lettuce.core.event.connection.ReconnectFailedEvent;
-import reactor.core.Disposable;
+import io.lettuce.core.Subscription;
 
 /**
  * Utility class for tracking Redis connection reconnection timing. Provides comprehensive monitoring of connection lifecycle
@@ -38,7 +38,7 @@ public class ReconnectionTimingTracker {
     private final AtomicReference<Instant> lastDisconnectTime = new AtomicReference<>();
 
     // Event bus tracking
-    private Disposable eventSubscription;
+    private Subscription eventSubscription;
 
     // Connection state tracking
     private final AtomicReference<Instant> stateDisconnectTime = new AtomicReference<>();
@@ -61,7 +61,7 @@ public class ReconnectionTimingTracker {
      * @return this tracker for method chaining
      */
     public ReconnectionTimingTracker trackWithEventBus(RedisClient client) {
-        eventSubscription = client.getResources().eventBus().get().subscribe(event -> {
+        eventSubscription = client.getResources().eventBus().subscribe(event -> {
             Instant now = Instant.now();
 
             if (event instanceof ConnectionDeactivatedEvent) {
@@ -175,8 +175,8 @@ public class ReconnectionTimingTracker {
      * Clean up resources and stop tracking.
      */
     public void dispose() {
-        if (eventSubscription != null && !eventSubscription.isDisposed()) {
-            eventSubscription.dispose();
+        if (eventSubscription != null) {
+            eventSubscription.close();
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API removal (`Flux#get`) and changed delivery semantics (drops, per-subscriber ordering, no global Reactor backpressure) affect all connection/metrics/failover event consumers; scope is broad but not security-critical.
> 
> **Overview**
> **Replaces the Reactor-based event bus with a callback `subscribe` API backed by Netty `EventExecutorGroup`, removing the deprecated `EventBus#get()` `Flux` surface (8.0).**
> 
> `DefaultEventBus` no longer uses `Sinks`/`publishOn`; it fans out `publish` to registered listeners on dedicated executors, with per-subscription in-flight limits (default 1024) that **drop** events for slow consumers instead of blocking publishers. Typed `subscribe(Class, …)` filters by type before counting in-flight so unrelated events cannot starve a listener.
> 
> `DefaultClientResources` constructs `new DefaultEventBus(eventExecutorGroup)` directly (no Reactor `Schedulers`). Call sites in tests, examples, and scenario utilities switch from `get().subscribe()` / `Disposable` to `subscribe` + `Subscription#close()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a7467fc46bfa9683c60a34c0fc30727d1398094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->