### PR TITLE
 Publish ClusterTopologyChangedEvent after applying the new topology #2860

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
@@ -946,6 +946,8 @@ public class RedisClusterClient extends AbstractRedisClient {
 
         return loadPartitionsAsync().thenAccept(loadedPartitions -> {
 
+            ClusterTopologyChangedEvent topologyChangedEvent = null;
+
             if (TopologyComparators.isChanged(getPartitions(), loadedPartitions)) {
 
                 logger.debug("Using a new cluster topology");
@@ -953,11 +955,15 @@ public class RedisClusterClient extends AbstractRedisClient {
                 List<RedisClusterNode> before = new ArrayList<>(getPartitions());
                 List<RedisClusterNode> after = new ArrayList<>(loadedPartitions);
 
-                getResources().eventBus().publish(new ClusterTopologyChangedEvent(before, after));
+                topologyChangedEvent = new ClusterTopologyChangedEvent(before, after);
             }
 
             this.partitions.reload(loadedPartitions.getPartitions());
             updatePartitionsInConnections();
+
+            if (topologyChangedEvent != null) {
+                getResources().eventBus().publish(topologyChangedEvent);
+            }
         }).whenComplete((unused, throwable) -> event.record());
     }
 

--- a/src/test/java/io/lettuce/core/cluster/RedisClusterClientTopologyRefreshUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisClusterClientTopologyRefreshUnitTests.java
@@ -1,0 +1,89 @@
+package io.lettuce.core.cluster;
+
+import static io.lettuce.TestTags.UNIT_TEST;
+import static io.lettuce.core.cluster.PartitionsConsensusTestSupport.createNode;
+import static io.lettuce.core.cluster.PartitionsConsensusTestSupport.createPartitions;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.cluster.event.ClusterTopologyChangedEvent;
+import io.lettuce.core.cluster.models.partitions.Partitions;
+import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
+import io.lettuce.core.event.Event;
+import io.lettuce.core.event.EventBus;
+import io.lettuce.core.resource.ClientResources;
+import io.lettuce.test.resource.FastShutdown;
+import reactor.core.publisher.Flux;
+
+/**
+ * Unit tests for {@link RedisClusterClient} topology refresh.
+ */
+@Tag(UNIT_TEST)
+class RedisClusterClientTopologyRefreshUnitTests {
+
+    private final RecordingEventBus eventBus = new RecordingEventBus();
+
+    private final ClientResources clientResources = ClientResources.builder().eventBus(eventBus).build();
+
+    private final RedisClusterClient client = spy(
+            RedisClusterClient.create(clientResources, RedisURI.create("localhost", 6379)));
+
+    @AfterEach
+    void tearDown() {
+        FastShutdown.shutdown(client);
+        FastShutdown.shutdown(clientResources);
+    }
+
+    @Test
+    void refreshPartitionsShouldPublishTopologyChangedEventAfterApplyingPartitions() {
+
+        Partitions before = createPartitions(createNode(1));
+        Partitions after = createPartitions(createNode(2), createNode(3));
+
+        client.setPartitions(before);
+        eventBus.partitionsSupplier = client::getPartitions;
+        doReturn(CompletableFuture.completedFuture(after)).when(client).loadPartitionsAsync();
+
+        client.refreshPartitions();
+
+        // The event must be published only after reload() applied the new topology to the client partitions. Otherwise
+        // listeners that inspect the topology (e.g. through node selection on a connection) would observe stale partitions.
+        assertThat(eventBus.partitionsWhenPublished.get()).as("partitions observed when the event was published")
+                .containsExactlyInAnyOrderElementsOf(after);
+    }
+
+    /**
+     * Captures the client partitions at the exact moment a {@link ClusterTopologyChangedEvent} is published, so the publish
+     * ordering relative to the partition update can be asserted deterministically.
+     */
+    static class RecordingEventBus implements EventBus {
+
+        volatile Supplier<Partitions> partitionsSupplier = Partitions::new;
+
+        final AtomicReference<List<RedisClusterNode>> partitionsWhenPublished = new AtomicReference<>();
+
+        @Override
+        public Flux<Event> get() {
+            return Flux.empty();
+        }
+
+        @Override
+        public void publish(Event event) {
+            if (event instanceof ClusterTopologyChangedEvent) {
+                partitionsWhenPublished.set(new ArrayList<>(partitionsSupplier.get()));
+            }
+        }
+    }
+}

--- a/src/test/java/io/lettuce/core/cluster/RedisClusterClientTopologyRefreshUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisClusterClientTopologyRefreshUnitTests.java
@@ -85,5 +85,7 @@ class RedisClusterClientTopologyRefreshUnitTests {
                 partitionsWhenPublished.set(new ArrayList<>(partitionsSupplier.get()));
             }
         }
+
     }
+
 }


### PR DESCRIPTION
 Closes #2860

  ## Problem

  In `RedisClusterClient.refreshPartitionsAsync()` the `ClusterTopologyChangedEvent` is
  published *before* the new topology is applied:

      getResources().eventBus().publish(new ClusterTopologyChangedEvent(before, after)); // published first
      ...
      this.partitions.reload(loadedPartitions.getPartitions());                          // applied afterwards
      updatePartitionsInConnections();

  Since `getPartitions()` returns the same `Partitions` instance that `reload()` mutates in
  place, an event listener that inspects the topology while handling the event can observe
  **stale partitions**.

  Concrete impact: an application that re-subscribes to master nodes on
  `ClusterTopologyChangedEvent` (using `connection.getPartitions()` / node selection) can,
  right after a failover, select the **demoted old masters (now replicas)** instead of the
  newly promoted masters, and stay subscribed to replicas until the next topology change.

  ## Fix

  Capture the `before`/`after` snapshots before applying the topology (so the event payload
  stays correct), apply the topology via `reload()` + `updatePartitionsInConnections()`, and
  publish the event only afterwards. Listeners now observe the up-to-date partitions.