### PR TITLE
[Redis 8.10] add malay and tagalog lang support

### DIFF
--- a/src/main/java/io/lettuce/core/search/arguments/DocumentLanguage.java
+++ b/src/main/java/io/lettuce/core/search/arguments/DocumentLanguage.java
@@ -94,6 +94,10 @@ public enum DocumentLanguage {
      */
     LITHUANIAN("lithuanian", new Locale("lt")),
     /**
+     * Malay
+     */
+    MALAY("malay", new Locale("ms")),
+    /**
      * Nepali
      */
     NEPALI("nepali", new Locale("ne")),
@@ -125,6 +129,10 @@ public enum DocumentLanguage {
      * Swedish
      */
     SWEDISH("swedish", new Locale("sv")),
+    /**
+     * Tagalog
+     */
+    TAGALOG("tagalog", new Locale("tl")),
     /**
      * Tamil
      */

--- a/src/test/java/io/lettuce/core/search/RediSearchAdvancedConceptsIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/search/RediSearchAdvancedConceptsIntegrationTests.java
@@ -13,6 +13,7 @@ import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.search.arguments.*;
 import io.lettuce.test.Wait;
+import io.lettuce.test.condition.RedisConditions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -25,6 +26,7 @@ import java.util.Map;
 
 import static io.lettuce.TestTags.INTEGRATION_TEST;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Integration tests for Redis Search advanced concepts based on the Redis documentation.
@@ -598,6 +600,59 @@ public class RediSearchAdvancedConceptsIntegrationTests {
 
         // Cleanup
         redis.ftDropindex("idx:german");
+    }
+
+    /**
+     * Test Malay and Tagalog stemming, which were added in Redis 8.10. The test is guarded by a server version assumption so
+     * that it is skipped on pre-8.10 environments where the corresponding stemmers are not available.
+     */
+    @Test
+    void testMalayAndTagalogStemming() {
+        assumeTrue(RedisConditions.of(redis).hasVersionGreaterOrEqualsTo("8.10"),
+                "Malay and Tagalog stemming require Redis 8.10 or newer");
+
+        // Test 1: Malay stemming
+        FieldArgs<String> malayWordField = TextFieldArgs.<String> builder().name("perkataan").build();
+
+        CreateArgs<String, String> malayArgs = CreateArgs.<String, String> builder().withPrefix("ms:")
+                .on(CreateArgs.TargetType.HASH).defaultLanguage(DocumentLanguage.MALAY).build();
+
+        redis.ftCreate("idx:malay", malayArgs, Collections.singletonList(malayWordField));
+
+        // Add Malay words derived from the root "masak" (to cook): masak, memasak, masakan, dimasak
+        redis.hset("ms:1", "perkataan", "masak");
+        redis.hset("ms:2", "perkataan", "memasak");
+        redis.hset("ms:3", "perkataan", "masakan");
+        redis.hset("ms:4", "perkataan", "dimasak");
+
+        // Searching the root should find at least the exact match; with Malay stemming enabled it additionally groups the
+        // derived forms. We assert the lower bound to verify the language is accepted end-to-end without coupling to the
+        // exact server-side stemmer data.
+        SearchReply<String, String> results = redis.ftSearch("idx:malay", "@perkataan:(masak)");
+        assertThat(results.getCount()).isGreaterThanOrEqualTo(1);
+
+        redis.ftDropindex("idx:malay");
+
+        // Test 2: Tagalog stemming
+        FieldArgs<String> tagalogWordField = TextFieldArgs.<String> builder().name("salita").build();
+
+        CreateArgs<String, String> tagalogArgs = CreateArgs.<String, String> builder().withPrefix("tl:")
+                .on(CreateArgs.TargetType.HASH).defaultLanguage(DocumentLanguage.TAGALOG).build();
+
+        redis.ftCreate("idx:tagalog", tagalogArgs, Collections.singletonList(tagalogWordField));
+
+        // Add Tagalog words derived from the root "luto" (to cook): luto, magluto, niluto, lutuin
+        redis.hset("tl:1", "salita", "luto");
+        redis.hset("tl:2", "salita", "magluto");
+        redis.hset("tl:3", "salita", "niluto");
+        redis.hset("tl:4", "salita", "lutuin");
+
+        // As with Malay, assert the lower bound to verify the language is accepted end-to-end without overfitting to the
+        // exact stemmer output.
+        results = redis.ftSearch("idx:tagalog", "@salita:(luto)");
+        assertThat(results.getCount()).isGreaterThanOrEqualTo(1);
+
+        redis.ftDropindex("idx:tagalog");
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small enum additions and optional integration coverage; no changes to auth, persistence, or core client behavior.
> 
> **Overview**
> Adds **Malay** and **Tagalog** to `DocumentLanguage` so RediSearch index/create and search APIs can pass the new Redis 8.10 stemmer language names (`malay` / `tagalog` with locales `ms` and `tl`).
> 
> An integration test creates indexes with `defaultLanguage(DocumentLanguage.MALAY)` and `TAGALOG`, indexes related word forms, and asserts at least one hit per language. The test is skipped unless the server is **Redis 8.10+**, where those stemmers exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 929b4ed8b19c0303cbdcb7b64d13f697581a36f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->