### PR TITLE
Add more tests around SCH

### DIFF
--- a/src/test/java/io/lettuce/core/ClientOptionsIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/ClientOptionsIntegrationTests.java
@@ -96,6 +96,22 @@ class ClientOptionsIntegrationTests extends TestSupport {
     }
 
     @Test
+    void maintNotificationsEnabledShouldNotFailHandshakeOnUnsupportedServer() {
+
+        // Redis OSS does not support the CLIENT MAINT_NOTIFICATIONS command. Enabling maintenance
+        // notifications must not break the connection handshake - the error response is expected to
+        // be swallowed and the connection should still come up.
+        client.setOptions(ClientOptions.builder()
+                .maintNotificationsConfig(MaintNotificationsConfig.enabled(MaintNotificationsConfig.EndpointType.INTERNAL_IP))
+                .build());
+
+        try (StatefulRedisConnection<String, String> connection = client.connect()) {
+            assertThat(connection.isOpen()).isTrue();
+            assertThat(connection.sync().ping()).isEqualTo("PONG");
+        }
+    }
+
+    @Test
     void requestQueueSize() {
         client.setOptions(ClientOptions.builder().requestQueueSize(10).timeoutOptions(DISABLE_COMMAND_TIMEOUT).build());
         try (StatefulRedisConnection<String, String> connection = client.connect()) {

--- a/src/test/java/io/lettuce/core/RedisHandshakeUnitTests.java
+++ b/src/test/java/io/lettuce/core/RedisHandshakeUnitTests.java
@@ -290,6 +290,39 @@ class RedisHandshakeUnitTests {
         assertThat(maintCommand.getArgs().toString()).doesNotContain("moving-endpoint-type");
     }
 
+    @Test
+    void handshakeWithMaintNotificationsErrorResponseShouldNotFailHandshake() {
+
+        EmbeddedChannel channel = new EmbeddedChannel(true, false);
+
+        // Mock address type source
+        MaintNotificationsConfig.EndpointTypeSource endpointTypeSource = mock(
+                MaintNotificationsConfig.EndpointTypeSource.class);
+        when(endpointTypeSource.getEndpointType(any(SocketAddress.class), anyBoolean()))
+                .thenReturn(MaintNotificationsConfig.EndpointType.INTERNAL_IP);
+
+        ConnectionState state = new ConnectionState();
+        state.setCredentialsProvider(new StaticCredentialsProvider(null, null));
+        RedisHandshake handshake = new RedisHandshake(ProtocolVersion.RESP3, false, state, endpointTypeSource);
+        CompletionStage<Void> handshakeInit = handshake.initialize(channel);
+
+        AsyncCommand<String, String, Map<String, String>> hello = channel.readOutbound();
+        helloResponse(hello.getOutput());
+        hello.complete();
+
+        // Server rejects CLIENT MAINT_NOTIFICATIONS ON with an ERR response
+        List<AsyncCommand<?, ?, ?>> commands = channel.readOutbound();
+        assertThat(commands).hasSize(1);
+
+        AsyncCommand<?, ?, ?> maintCommand = commands.get(0);
+        maintCommand.getOutput().setError(ERR_UNKNOWN_COMMAND);
+        maintCommand.completeExceptionally(new RedisException(ERR_UNKNOWN_COMMAND));
+        maintCommand.complete();
+
+        // The error should be swallowed and the handshake should still complete successfully
+        assertThat(handshakeInit.toCompletableFuture().isCompletedExceptionally()).isFalse();
+    }
+
     private static void helloResponse(CommandOutput<String, String, Map<String, String>> output) {
 
         output.multiMap(8);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only changes with no production code modifications.
> 
> **Overview**
> Adds regression coverage for **maintenance notifications during the connection handshake** when the server does not implement `CLIENT MAINT_NOTIFICATIONS`.
> 
> A new **integration** test enables `MaintNotificationsConfig` on the client and asserts a real connect still succeeds and `PING` returns `PONG` on Redis OSS. A new **unit** test drives `RedisHandshake` through HELLO plus a failed maint command and asserts the handshake future does **not** complete exceptionally—documenting that the ERR is expected to be swallowed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21321b994c64d078baf7d7ab62a449ffbe2d146f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->