### PR TITLE
Fix backwards compatibility in connection interface

### DIFF
--- a/src/main/java/io/lettuce/core/api/StatefulRedisConnection.java
+++ b/src/main/java/io/lettuce/core/api/StatefulRedisConnection.java
@@ -80,8 +80,12 @@ public interface StatefulRedisConnection<K, V> extends StatefulConnection<K, V> 
      * @param factory the command API factory, must not be {@code null}
      * @param <T> the command API type
      * @return the command API bound to this connection
+     * @throws UnsupportedOperationException if the connection implementation does not override this method. The default is
+     *         provided only for source compatibility in Lettuce 7.x and becomes an abstract method in Lettuce 8.0.
      * @since 7.7
      */
-    <T> T commands(CommandsFactory<StatefulRedisConnection<K, V>, T> factory);
+    default <T> T commands(CommandsFactory<StatefulRedisConnection<K, V>, T> factory) {
+        throw new UnsupportedOperationException("commands(CommandsFactory) is not implemented by this connection");
+    }
 
 }

--- a/src/main/java/io/lettuce/core/cluster/api/StatefulRedisClusterConnection.java
+++ b/src/main/java/io/lettuce/core/cluster/api/StatefulRedisClusterConnection.java
@@ -304,8 +304,12 @@ public interface StatefulRedisClusterConnection<K, V> extends StatefulConnection
      * @param factory the command API factory, must not be {@code null}
      * @param <T> the command API type
      * @return the command API bound to this connection
+     * @throws UnsupportedOperationException if the connection implementation does not override this method. The default is
+     *         provided only for source compatibility in Lettuce 7.x and becomes an abstract method in Lettuce 8.0.
      * @since 7.7
      */
-    <T> T commands(CommandsFactory<StatefulRedisClusterConnection<K, V>, T> factory);
+    default <T> T commands(CommandsFactory<StatefulRedisClusterConnection<K, V>, T> factory) {
+        throw new UnsupportedOperationException("commands(CommandsFactory) is not implemented by this connection");
+    }
 
 }

--- a/src/main/java/io/lettuce/core/cluster/pubsub/StatefulRedisClusterPubSubConnection.java
+++ b/src/main/java/io/lettuce/core/cluster/pubsub/StatefulRedisClusterPubSubConnection.java
@@ -208,8 +208,12 @@ public interface StatefulRedisClusterPubSubConnection<K, V> extends StatefulRedi
      * @param factory the command API factory, must not be {@code null}
      * @param <T> the command API type
      * @return the command API bound to this connection
+     * @throws UnsupportedOperationException if the connection implementation does not override this method. The default is
+     *         provided only for source compatibility in Lettuce 7.x and becomes an abstract method in Lettuce 8.0.
      * @since 7.7
      */
-    <T> T commands(ClusterPubSubCommandsFactory<StatefulRedisClusterPubSubConnection<K, V>, T> factory);
+    default <T> T commands(ClusterPubSubCommandsFactory<StatefulRedisClusterPubSubConnection<K, V>, T> factory) {
+        throw new UnsupportedOperationException("commands(ClusterPubSubCommandsFactory) is not implemented by this connection");
+    }
 
 }

--- a/src/main/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnection.java
+++ b/src/main/java/io/lettuce/core/pubsub/StatefulRedisPubSubConnection.java
@@ -76,8 +76,12 @@ public interface StatefulRedisPubSubConnection<K, V> extends StatefulRedisConnec
      * @param factory the command API factory, must not be {@code null}
      * @param <T> the command API type
      * @return the command API bound to this connection
+     * @throws UnsupportedOperationException if the connection implementation does not override this method. The default is
+     *         provided only for source compatibility in Lettuce 7.x and becomes an abstract method in Lettuce 8.0.
      * @since 7.7
      */
-    <T> T commands(PubSubCommandsFactory<StatefulRedisPubSubConnection<K, V>, T> factory);
+    default <T> T commands(PubSubCommandsFactory<StatefulRedisPubSubConnection<K, V>, T> factory) {
+        throw new UnsupportedOperationException("commands(PubSubCommandsFactory) is not implemented by this connection");
+    }
 
 }

--- a/src/main/java/io/lettuce/core/sentinel/api/StatefulRedisSentinelConnection.java
+++ b/src/main/java/io/lettuce/core/sentinel/api/StatefulRedisSentinelConnection.java
@@ -60,8 +60,12 @@ public interface StatefulRedisSentinelConnection<K, V> extends StatefulConnectio
      * @param factory the command API factory, must not be {@code null}
      * @param <T> the command API type
      * @return the command API bound to this connection
+     * @throws UnsupportedOperationException if the connection implementation does not override this method. The default is
+     *         provided only for source compatibility in Lettuce 7.x and becomes an abstract method in Lettuce 8.0.
      * @since 7.7
      */
-    <T> T commands(CommandsFactory<StatefulRedisSentinelConnection<K, V>, T> factory);
+    default <T> T commands(CommandsFactory<StatefulRedisSentinelConnection<K, V>, T> factory) {
+        throw new UnsupportedOperationException("commands(CommandsFactory) is not implemented by this connection");
+    }
 
 }


### PR DESCRIPTION
Fixes backwards compatibility for the connection interfaces after #3781 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public API surface change is limited to interface defaults; official implementations are unchanged and callers using Lettuce connections are unaffected.
> 
> **Overview**
> Restores **source compatibility** after #3781 by turning the new `commands(...)` API on five stateful connection interfaces into **default methods** that throw `UnsupportedOperationException`, instead of leaving them abstract.
> 
> The change applies to `StatefulRedisConnection`, cluster, cluster Pub/Sub, Pub/Sub, and Sentinel connection interfaces. Each default documents that it is temporary for Lettuce **7.x** and that the method becomes **abstract again in 8.0**. Built-in Lettuce connection implementations still override `commands(...)` with the real factory-based behavior; only custom implementors that have not added the method compile without changes but fail at runtime if they call the default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbcbbec0b09697bbf958839bd3d972b125b67691. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->