### PR TITLE
Add 'connection.commands(factory)' accessor and deprecate 'reactive()' (#3781) (part 2)

### DIFF
--- a/src/test/jmh/io/lettuce/core/EmptyStatefulRedisConnection.java
+++ b/src/test/jmh/io/lettuce/core/EmptyStatefulRedisConnection.java
@@ -2,8 +2,8 @@ package io.lettuce.core;
 
 import java.time.Duration;
 import java.util.Collection;
-import java.util.concurrent.TimeUnit;
 
+import io.lettuce.core.api.CommandsFactory;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.api.push.PushListener;
@@ -42,6 +42,11 @@ public class EmptyStatefulRedisConnection extends RedisChannelHandler implements
 
     @Override
     public RedisReactiveCommands reactive() {
+        return null;
+    }
+
+    @Override
+    public Object commands(CommandsFactory factory) {
         return null;
     }
 


### PR DESCRIPTION
As part of #3781 - the `EmptyStatefulRedisConnection` was not addressed and caused issues in the benchmarks CI

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only JMH stub change with no production or runtime behavior impact.
> 
> **Overview**
> Follow-up to **#3781**: the JMH stub `EmptyStatefulRedisConnection` now **implements** `commands(CommandsFactory)` on `StatefulRedisConnection`, returning `null` like `sync()`, `async()`, and `reactive()`.
> 
> An unused `java.util.concurrent.TimeUnit` import was removed. This unblocks **benchmarks CI** that failed to compile after the interface gained the new accessor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85ddf51a8d3934e84c897187c82de73e2b683842. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->