### PR TITLE
Fix streams response parsing

### DIFF
--- a/src/main/java/io/lettuce/core/output/StreamReadOutput.java
+++ b/src/main/java/io/lettuce/core/output/StreamReadOutput.java
@@ -38,6 +38,8 @@ public class StreamReadOutput<K, V> extends CommandOutput<K, V, List<StreamMessa
 
     private boolean bodyReceived = false;
 
+    private int entryEmitDepth = -1;
+
     public StreamReadOutput(RedisCodec<K, V> codec) {
         super(codec, Collections.emptyList());
         setSubscriber(ListSubscriber.instance());
@@ -114,7 +116,10 @@ public class StreamReadOutput<K, V> extends CommandOutput<K, V, List<StreamMessa
     public void complete(int depth) {
 
         // Emit the message when the entry array (id/body[/extras]) completes.
-        if (depth == 2 && bodyReceived) {
+        // entryEmitDepth is resolved dynamically because RESP2 and RESP3 differ by one nesting level:
+        // RESP2 wraps results in an outer *N array so the stream key fires complete(2) and entries fire complete(3).
+        // RESP3 uses a top-level map so the stream key fires complete(1) and entries fire complete(2).
+        if (entryEmitDepth >= 0 && depth == entryEmitDepth && bodyReceived) {
             Map<K, V> map = body == null ? Collections.emptyMap() : body;
             if (msSinceLastDelivery != null && redeliveryCount != null) {
                 subscriber.onNext(output, new StreamMessage<>(stream, id, map, msSinceLastDelivery, redeliveryCount));
@@ -129,14 +134,18 @@ public class StreamReadOutput<K, V> extends CommandOutput<K, V, List<StreamMessa
             redeliveryCount = null;
         }
 
-        // RESP2/RESP3 compat
+        // Resolve entry emit depth from stream key depth (entryEmitDepth = streamKeyDepth + 1).
+        // RESP2: stream key fires complete(2), so entries fire complete(3).
+        // RESP3: stream key fires complete(1), so entries fire complete(2).
         if (depth == 2 && skipStreamKeyReset) {
             skipStreamKeyReset = false;
+            entryEmitDepth = depth + 1;
         }
 
         if (depth == 1) {
             if (skipStreamKeyReset) {
                 skipStreamKeyReset = false;
+                entryEmitDepth = depth + 1;
             } else {
                 stream = null;
             }

--- a/src/test/java/io/lettuce/core/commands/StreamCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/StreamCommandIntegrationTests.java
@@ -52,7 +52,6 @@ import java.util.UUID;
 import static io.lettuce.TestTags.INTEGRATION_TEST;
 import static io.lettuce.core.protocol.CommandType.XINFO;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
@@ -67,7 +66,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 @Tag(INTEGRATION_TEST)
 public class StreamCommandIntegrationTests extends TestSupport {
 
-    private final RedisCommands<String, String> redis;
+    protected final RedisCommands<String, String> redis;
 
     @Inject
     protected StreamCommandIntegrationTests(RedisCommands<String, String> redis) {

--- a/src/test/java/io/lettuce/core/commands/StreamCommandResp2IntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/StreamCommandResp2IntegrationTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026-Present, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ */
+package io.lettuce.core.commands;
+
+import static io.lettuce.TestTags.INTEGRATION_TEST;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Tag;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.core.protocol.ProtocolVersion;
+
+/**
+ * Integration tests for {@link io.lettuce.core.api.sync.RedisStreamCommands} using RESP2 protocol.
+ * <p>
+ * Extends {@link StreamCommandIntegrationTests} and runs all the same tests using the RESP2 protocol to ensure backward
+ * compatibility. Also includes regression tests that are RESP2-specific.
+ *
+ * @author Aleksandar Todorov
+ */
+@Tag(INTEGRATION_TEST)
+public class StreamCommandResp2IntegrationTests extends StreamCommandIntegrationTests {
+
+    @Inject
+    public StreamCommandResp2IntegrationTests(RedisClient client) {
+        super(connectWithResp2(client));
+    }
+
+    private static RedisCommands<String, String> connectWithResp2(RedisClient client) {
+        client.setOptions(ClientOptions.builder().protocolVersion(ProtocolVersion.RESP2).build());
+        return client.connect().sync();
+    }
+
+}

--- a/src/test/java/io/lettuce/core/output/StreamReadOutputUnitTests.java
+++ b/src/test/java/io/lettuce/core/output/StreamReadOutputUnitTests.java
@@ -129,6 +129,60 @@ class StreamReadOutputUnitTests {
     }
 
     @Test
+    void shouldDecodeTwoEntriesRESP2FullDepth() {
+        // Regression test for https://github.com/redis/lettuce/issues/3800
+        // Models the actual RESP2 XREADGROUP wire format including the outer *1 wrapper.
+        // RESP2: *1 outer -> *2 [stream_key, *N entries] -> *2 entry [id, *M body]
+        // The outer *1 shifts all depths by +1 relative to tests that omit it.
+        // stream_key fires complete(2), entries fire complete(3).
+
+        sut.multi(1); // outer *1
+        sut.multi(2); // *2 [stream_key, entries]
+        sut.set(ByteBuffer.wrap("stream-key".getBytes()));
+        sut.complete(2); // stream_key at depth 2 -> entryEmitDepth = 3
+        sut.multi(2); // *2 entries
+
+        // Entry 1
+        sut.multi(2); // *2 [id, body]
+        sut.set(ByteBuffer.wrap("1234-11".getBytes()));
+        sut.complete(4);
+        sut.multi(2); // *2 body
+        sut.set(ByteBuffer.wrap("key1".getBytes()));
+        sut.complete(5);
+        sut.set(ByteBuffer.wrap("value1".getBytes()));
+        sut.complete(5);
+        sut.complete(4); // body done
+        sut.complete(3); // entry done -> EMIT at entryEmitDepth=3
+
+        // Entry 2
+        sut.multi(2);
+        sut.set(ByteBuffer.wrap("1234-22".getBytes()));
+        sut.complete(4);
+        sut.multi(2);
+        sut.set(ByteBuffer.wrap("key2".getBytes()));
+        sut.complete(5);
+        sut.set(ByteBuffer.wrap("value2".getBytes()));
+        sut.complete(5);
+        sut.complete(4);
+        sut.complete(3); // entry done -> EMIT
+
+        sut.complete(2); // entries done
+        sut.complete(1); // stream_array done -> stream = null
+        sut.complete(0);
+
+        assertThat(sut.get()).hasSize(2);
+        StreamMessage<String, String> m1 = sut.get().get(0);
+        assertThat(m1.getId()).isEqualTo("1234-11");
+        assertThat(m1.getStream()).isEqualTo("stream-key");
+        assertThat(m1.getBody()).hasSize(1).containsEntry("key1", "value1");
+
+        StreamMessage<String, String> m2 = sut.get().get(1);
+        assertThat(m2.getId()).isEqualTo("1234-22");
+        assertThat(m2.getStream()).isEqualTo("stream-key");
+        assertThat(m2.getBody()).hasSize(1).containsEntry("key2", "value2");
+    }
+
+    @Test
     void shouldDecodeFromTwoStreams() {
 
         sut.multi(4);


### PR DESCRIPTION
Fixes streams response parsing after regression in https://github.com/redis/lettuce/pull/3486

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core protocol decoding for all stream read-style commands on both RESP2 and RESP3; wrong depth logic would silently lose or mis-emit messages, though coverage was expanded for RESP2.
> 
> **Overview**
> Fixes **stream command response parsing** for clients on **RESP2**, where messages from `XREAD` / `XREADGROUP` (and related outputs using `StreamReadOutput`) could be dropped or parsed incorrectly after a recent regression.
> 
> `StreamReadOutput` no longer emits each `StreamMessage` on a fixed `complete(2)` depth. It records **`entryEmitDepth`** when the stream key is first seen (`streamKeyDepth + 1`), because RESP2’s extra outer array shifts nesting: entries complete at **depth 3** on RESP2 vs **depth 2** on RESP3.
> 
> **Tests:** a unit regression models the full RESP2 wire shape (issue #3800); stream integration tests are **`protected`** so a new **`StreamCommandResp2IntegrationTests`** subclass re-runs the suite with `ProtocolVersion.RESP2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e81ebda01a44418a1a2aa353ff14aaf3c06e03a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->