### PR TITLE
Fix VADD command for single-element vectors #3802

### DIFF
--- a/src/main/java/io/lettuce/core/RedisVectorSetCommandBuilder.java
+++ b/src/main/java/io/lettuce/core/RedisVectorSetCommandBuilder.java
@@ -116,13 +116,9 @@ public class RedisVectorSetCommandBuilder<K, V> extends BaseRedisCommandBuilder<
             args.add(dimensionality);
         }
 
-        if (vectors.length > 1) {
-            args.add(CommandKeyword.VALUES);
-            args.add(vectors.length);
-            Arrays.stream(vectors).map(Object::toString).forEach(args::add);
-        } else {
-            args.add(vectors[0]);
-        }
+        args.add(CommandKeyword.VALUES);
+        args.add(vectors.length);
+        Arrays.stream(vectors).map(Object::toString).forEach(args::add);
 
         args.addValue(element);
 

--- a/src/test/java/io/lettuce/core/RedisVectorSetCommandBuilderUnitTests.java
+++ b/src/test/java/io/lettuce/core/RedisVectorSetCommandBuilderUnitTests.java
@@ -65,8 +65,9 @@ class RedisVectorSetCommandBuilderUnitTests {
         ByteBuf buf = Unpooled.directBuffer();
         command.encode(buf);
 
-        assertThat(buf.toString(StandardCharsets.UTF_8)).isEqualTo("*4\r\n" + "$4\r\n" + "VADD\r\n" + "$10\r\n"
-                + "vector:set\r\n" + "$3\r\n" + "0.1\r\n" + "$8\r\n" + "element1\r\n");
+        assertThat(buf.toString(StandardCharsets.UTF_8))
+                .isEqualTo("*6\r\n" + "$4\r\n" + "VADD\r\n" + "$10\r\n" + "vector:set\r\n" + "$6\r\n" + "VALUES\r\n" + "$1\r\n"
+                        + "1\r\n" + "$3\r\n" + "0.1\r\n" + "$8\r\n" + "element1\r\n");
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/vector/RedisVectorSetIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/vector/RedisVectorSetIntegrationTests.java
@@ -128,6 +128,13 @@ public class RedisVectorSetIntegrationTests {
     }
 
     @Test
+    void vaddSingleElementVector() {
+        Boolean result = redis.vadd(VECTOR_SET_KEY + ":single", "item", 0.1);
+        assertThat(result).isTrue();
+        assertThat(redis.vcard(VECTOR_SET_KEY + ":single")).isEqualTo(1L);
+    }
+
+    @Test
     void vcard() {
         Long count = redis.vcard(VECTOR_SET_KEY);
         assertThat(count).isEqualTo(3);


### PR DESCRIPTION
Closes #3802

## Problem

`vadd` built an invalid command for single-element vectors: the `VALUES <count>` keyword was only written when the vector had more than one element, so Lettuce sent `VADD key 0.1 element` instead of `VADD key VALUES 1 0.1 element`. Redis rejects the former with `ERR wrong number of arguments`, so a single-element vector could never be added.

## Changes

- `RedisVectorSetCommandBuilder#vadd`: always emit the `VALUES` clause, regardless
  of the element count
- Updated the affected unit test and added an integration test covering a
  single-element vector

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized protocol-encoding fix in vector-set command building with matching test updates; no auth, security, or broad API changes.
> 
> **Overview**
> **Fixes invalid `VADD` wire format when the vector has only one dimension** (closes #3802).
> 
> Previously `RedisVectorSetCommandBuilder#vadd` skipped the `VALUES <count>` prefix for length-1 arrays and sent something like `VADD key 0.1 element`, which Redis rejects. The builder now **always** adds `VALUES`, the count, then each component—e.g. `VALUES 1 0.1`—matching multi-vector encoding.
> 
> Tests were updated: the single-vector unit test expects the new RESP shape, and an integration test adds a one-dimensional vector and checks `vcard`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aca88ac6cc69fdf23a10d5ac2ad7b457d426c83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->