### PR TITLE
Fix JFR event recorder unit tests #3066

### DIFF
--- a/src/test/java/io/lettuce/core/event/jfr/JfrEventRecorderUnitTests.java
+++ b/src/test/java/io/lettuce/core/event/jfr/JfrEventRecorderUnitTests.java
@@ -1,6 +1,5 @@
 package io.lettuce.core.event.jfr;
 
-import static io.lettuce.TestTags.INTEGRATION_TEST;
 import static io.lettuce.TestTags.UNIT_TEST;
 import static org.assertj.core.api.Assertions.*;
 
@@ -8,7 +7,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collections;
 
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
@@ -17,14 +15,15 @@ import jdk.jfr.consumer.RecordingFile;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.lettuce.core.event.Event;
 import io.lettuce.core.event.connection.ConnectionActivatedEvent;
-import io.lettuce.core.event.metrics.CommandLatencyEvent;
 import io.netty.channel.unix.DomainSocketAddress;
 
 /**
  * Unit tests for {@link JfrEventRecorder}.
  *
  * @author Mark Paluch
+ * @author Sanghun Lee
  */
 @Tag(UNIT_TEST)
 class JfrEventRecorderUnitTests {
@@ -56,7 +55,7 @@ class JfrEventRecorderUnitTests {
         Recording recording = new Recording();
         recording.start();
 
-        EventRecorder.getInstance().record(new CommandLatencyEvent(Collections.emptyMap()));
+        EventRecorder.getInstance().record(new EventWithoutJfrType());
         recording.stop();
 
         File temp = getFile(recording);
@@ -83,6 +82,9 @@ class JfrEventRecorderUnitTests {
         fos.close();
 
         return temp;
+    }
+
+    private static class EventWithoutJfrType implements Event {
     }
 
 }


### PR DESCRIPTION
Closes #3066.

## What changed

- Move `JfrEventRecorderUnitTests` from `src/test/kotlin` to `src/test/java` so the Java unit test is compiled and executed by Surefire.
- Replace `CommandLatencyEvent` in `shouldNotEmitEventForAbsentJfrEventType` with a local event fixture that has no corresponding JFR event type.
- Remove now-unused imports.

## Why

The test was not discovered from its previous location. Once executed, the absent-JFR-type assertion also used a stale fixture because `CommandLatencyEvent` now has `JfrCommandLatencyEvent` support.

## Verification

- `JAVA_HOME=/Users/leesanghun/Library/Java/JavaVirtualMachines/ms-21.0.10/Contents/Home mvn -Dtest=io.lettuce.core.event.jfr.JfrEventRecorderUnitTests test`
- `JAVA_HOME=/Users/leesanghun/Library/Java/JavaVirtualMachines/ms-21.0.10/Contents/Home mvn formatter:format -DskipTests`

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code impact.
> 
> **Overview**
> Updates **`shouldNotEmitEventForAbsentJfrEventType`** so it records a **`EventWithoutJfrType`** stub instead of **`CommandLatencyEvent`**, which now maps to JFR via **`JfrCommandLatencyEvent`** and would make the “no JFR event emitted” assertion wrong.
> 
> Cleans up unused imports and tags the test class with **`UNIT_TEST`** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e6ee5c91ade554e6ce77ff6595a07b640aa2aca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->