### PR TITLE
Repair the Spring Data Redis Integration Test

### DIFF
--- a/.github/workflows/spring-data-redis-integration.yml
+++ b/.github/workflows/spring-data-redis-integration.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build Lettuce (skip tests)
         working-directory: lettuce
         run: |
-          mvn -B clean javadoc:jar install -DskipTests -Dgpg.skip=true
+          mvn -B clean javadoc:jar install -DskipTests -Dgpg.skip=true -Dmaven.javadoc.failOnError=false
           LETTUCE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "LETTUCE_VERSION=$LETTUCE_VERSION" >> $GITHUB_ENV
           echo "Built Lettuce version: $LETTUCE_VERSION"

--- a/.github/workflows/spring-data-redis-integration.yml
+++ b/.github/workflows/spring-data-redis-integration.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build Lettuce (skip tests)
         working-directory: lettuce
         run: |
-          mvn -B clean install -DskipTests -Dgpg.skip=true
+          mvn -B clean javadoc:jar install -DskipTests -Dgpg.skip=true
           LETTUCE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "LETTUCE_VERSION=$LETTUCE_VERSION" >> $GITHUB_ENV
           echo "Built Lettuce version: $LETTUCE_VERSION"


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
### The problem
This is a direct consequence of https://github.com/spring-projects/spring-data-build/issues/2886

That commit added a maven-dependency-plugin execution unpack-javadoc-offline-links that unpacks the javadoc classifier jar of io.lettuce:lettuce-core (and redis.clients:jedis) to wire up Javadoc offline links:

On the side of Lettuce automation the workflow's "Build Lettuce" step only installed the main + sources jars, so the build failed in an early phase — before any test ran, which is why the artifact-upload step also reported empty surefire-reports. 

### The fix 
The "Build Lettuce" step now runs
```bash
mvn -B clean javadoc:jar install -DskipTests -Dgpg.skip=true -Dmaven.javadoc.failOnError=false
```
so the javadoc jar is attached and installed into the local ~/.m2 for SDR to consume. 


Make sure that:
- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Maven command change with no runtime or library behavior impact.
> 
> **Overview**
> Fixes the **Spring Data Redis integration** workflow failing before tests run because upstream SDR now unpacks the `io.lettuce:lettuce-core` **javadoc** classifier for offline Javadoc links, while CI only installed the main (and sources) artifacts.
> 
> The **Build Lettuce** step now runs `javadoc:jar` as part of `mvn clean install`, with `-Dmaven.javadoc.failOnError=false`, so the javadoc jar is attached and published to the local `~/.m2` for the patched SDR build to consume.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a43d82256e4351f8d78260d143a529e3a8cbee0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->