### PR TITLE
Add an AI skill and slash command for generating PR descriptions

### DIFF
--- a/.agents/skills/creating-description-for-gh-pr/SKILL.md
+++ b/.agents/skills/creating-description-for-gh-pr/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: creating-description-for-gh-pr
+description: Generate a clear, concise GitHub PR title and description from the diff between two local git branches, and save it to prDescription.md in the repo root. Use this whenever the user asks to write, generate, draft, or update a PR description or PR title from local branch changes — including phrasing like "summarize this diff into a PR description," "write a PR description for my current branch," "create a PR title and description," or any request to compare a base and target branch for PR purposes. Trigger even if the user doesn't name specific branches; this skill knows how to default them.
+---
+
+# PR Description Generator
+
+Writes a GitHub PR title and description from the diff between two local git branches, focused on what reviewers need: purpose, key decisions/assumptions, behavioral or conceptual changes, and a brief testing note if relevant. Uses only standard git commands, so any agent can follow it.
+
+## 1. Resolve branches
+
+- Both named → use as given.
+- Only one named → it's the **base**; target defaults to current branch.
+- None named → base defaults to `main`, then `master` if `main` doesn't exist (`git branch --list`). **Only check these two names — no scanning other branches, no guessing.** If neither exists, stop and ask. Target defaults to current branch (`git branch --show-current`).
+
+State the resolved base/target before proceeding.
+
+## 2. Diff
+
+- Confirm both branches exist (`git branch --list <name>`); stop if not.
+- `git diff <base>...<target>` and `git log <base>..<target> --oneline`
+- Empty diff → stop and say so, don't fabricate a description.
+
+## 3. Analyze
+
+From the diff/log, identify: purpose of the change; key decisions and trade-offs; assumptions the code relies on; behavioral changes (concrete: "X now rejects Y" not "changed validation"); conceptual/contract changes; breaking changes, new config/env vars, migrations; test changes (what new tests cover conceptually, why existing ones were adapted — not test-by-test).
+
+Skip routine stuff (formatting, trivial renames). No file/line enumeration — write like explaining to a teammate, not a changelog.
+
+## 4. Output structure
+
+Write to `prDescription.md` (repo root, overwrite if exists):
+
+```markdown
+# <Title — imperative, <70 chars>
+
+## Summary
+<2-3 sentences>
+
+## Key Decisions & Assumptions
+<bullets — omit if none>
+
+## Behavioral / Conceptual Changes
+<bullets, concrete — omit if none>
+
+## Testing
+<2-3 sentences, only if diff touches tests — omit otherwise, don't write "no tests">
+
+## Notes
+<breaking changes, follow-ups — omit if none>
+```
+
+Keep it brief (readable in under a minute, ~150-200 words total unless the change is genuinely large). Omit empty sections rather than padding them. Never fabricate testing details, tickets, or names not evidenced in the diff — flag uncertainty in Notes instead.
+
+## 5. Confirm
+
+After writing, give a short confirmation (don't reprint the file) and offer to run `gh pr create --title "..." --body-file prDescription.md` if `gh` is available. Include the provided/resolved base and target branch names into the suggested command as part of the suggestion. At the end, ask if the user wants to open the PR now and wait for confirmation before proceeding. If the user declines, stop and say the PR description is ready in `prDescription.md`.

--- a/.claude/commands/createPRDescription.md
+++ b/.claude/commands/createPRDescription.md
@@ -1,0 +1,17 @@
+---
+description: Generate a PR title and description from the diff between two local branches, using the create-pr-description skill, and save to prDescription.md
+argument-hint: [base-branch] [target-branch]
+---
+
+Use the "create-pr-description" skill to generate a PR title and description.
+
+Arguments provided to this command: base = `$1`, target = `$2` (either may be empty).
+
+Pass this context into the skill's branch resolution logic (Step 1). Since these are positional arguments, only three states are possible:
+- Both `$1` and `$2` given → `$1` is the explicit base branch, `$2` is the explicit target branch.
+- Only `$1` given (`$2` empty) → `$1` is the explicit base branch; let the skill default the target branch.
+- Neither given (both empty) → let the skill default both base and target branches.
+
+`$1` cannot be empty while `$2` is non-empty — do not handle that case.
+
+Do not duplicate or reinterpret the skill's instructions; follow them as written, including the output structure, the writing-style constraints, and the save/confirm steps.

--- a/.claude/commands/createPRDescription.md
+++ b/.claude/commands/createPRDescription.md
@@ -1,9 +1,9 @@
 ---
-description: Generate a PR title and description from the diff between two local branches, using the create-pr-description skill, and save to prDescription.md
+description: Generate a PR title and description from the diff between two local branches, using the creating-description-for-gh-pr skill, and save to prDescription.md
 argument-hint: [base-branch] [target-branch]
 ---
 
-Use the "create-pr-description" skill to generate a PR title and description.
+Use the "creating-description-for-gh-pr" skill to generate a PR title and description.
 
 Arguments provided to this command: base = `$1`, target = `$2` (either may be empty).
 

--- a/.claude/skills/creating-description-for-gh-pr
+++ b/.claude/skills/creating-description-for-gh-pr
@@ -1,0 +1,1 @@
+../../.agents/skills/creating-description-for-gh-pr


### PR DESCRIPTION
## Summary
Adds a reusable Claude Code skill that generates a GitHub PR title and description from the diff between two local branches, plus a `/createPRDescription` slash command that invokes it. Output is written to `prDescription.md` at the repo root. This is agent tooling only and does not touch any Lettuce library code.

## Key Decisions & Assumptions
- The skill definition lives under `.agents/skills/` and is exposed to Claude Code via a symlink at `.claude/skills/`, keeping a single source of truth while satisfying the `.claude` discovery path.
- Branch resolution defaults are baked in: with no arguments, base falls back to `main` (then `master`), and target defaults to the current branch. Only those two base names are checked — no broader branch scanning.
- The skill relies only on standard git commands, so it is portable across agents and environments.

## Behavioral / Conceptual Changes
- A new `/createPRDescription [base-branch] [target-branch]` command is available; both positional arguments are optional and resolved per the documented defaulting rules.
- Running the skill overwrites `prDescription.md` in the repo root and, if `gh` is available, offers to open the PR after confirmation.

## Notes
- This is the only commit on the branch and introduces tooling/config files exclusively.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent configuration only; no runtime, auth, or product code paths are modified.
> 
> **Overview**
> Introduces **agent-only** workflow for drafting GitHub PR copy from a local `git diff` between two branches, without changing application/library code.
> 
> A new skill **`creating-description-for-gh-pr`** defines branch defaulting (`main`/`master` → current branch), diff/log analysis rules, a fixed `prDescription.md` template, and an optional `gh pr create` follow-up. It lives under **`.agents/skills/`** and is exposed to Claude Code via a **symlink** at **`.claude/skills/`**.
> 
> A **`/createPRDescription [base] [target]`** command delegates to that skill and maps positional args to the skill’s three branch-resolution cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94b4e2c49257c9a4f7c41e2f31a5beffdb17a447. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->