### PR TITLE
Reset topology-refresh in-progress flag on synchronous exception

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/ClusterTopologyRefreshScheduler.java
+++ b/src/main/java/io/lettuce/core/cluster/ClusterTopologyRefreshScheduler.java
@@ -349,6 +349,7 @@ class ClusterTopologyRefreshScheduler implements Runnable, ClusterEventListener 
                 });
             } catch (Exception e) {
                 logger.warn("Cannot refresh Redis Cluster topology", e);
+                set(false);
             }
         }
 

--- a/src/test/java/io/lettuce/core/cluster/ClusterTopologyRefreshSchedulerUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/ClusterTopologyRefreshSchedulerUnitTests.java
@@ -273,6 +273,26 @@ class ClusterTopologyRefreshSchedulerUnitTests {
     }
 
     @Test
+    void doRunShouldResetInProgressFlagOnSynchronousException() {
+
+        when(clusterClient.getClusterClientOptions()).thenReturn(clusterClientOptions);
+        when(clusterClient.refreshPartitionsAsync()).thenThrow(new IllegalStateException("boom"));
+
+        when(eventExecutors.submit(any(Runnable.class))).then(invocation -> {
+            ((Runnable) invocation.getArguments()[0]).run();
+            return null;
+        });
+
+        sut.run();
+
+        assertThat(sut.isTopologyRefreshInProgress()).isFalse();
+
+        sut.run();
+
+        verify(clusterClient, times(2)).refreshPartitionsAsync();
+    }
+
+    @Test
     void shouldRetrievePartitionsViaAdaptiveRefreshTriggeredEvent() {
 
         ClusterClientOptions clusterClientOptions = ClusterClientOptions.builder().topologyRefreshOptions(immediateRefresh)


### PR DESCRIPTION
ClusterTopologyRefreshTask only cleared its in-progress flag inside the `whenComplete` callback of the reload stage.

If `reloadTopologyAsync.get()` throws synchronously before returning a stage, the catch block logs the error but leaves the flag set. That can cause later topology refresh attempts to be skipped because the in-progress guard remains true.

This change resets the flag in the synchronous exception path as well.

Added a unit test that verifies:
- `refreshPartitionsAsync()` throws synchronously
- the in-progress flag is reset afterward
- a second run can start another refresh attempt

Fixes #3730


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized fix to error handling in cluster topology refresh with a matching unit test; no auth or data-path changes.
> 
> **Overview**
> Fixes a bug where **cluster topology refresh could get stuck** if `refreshPartitionsAsync()` failed before returning a `CompletionStage`.
> 
> `ClusterTopologyRefreshTask` only cleared its in-progress guard in `whenComplete`. A synchronous throw from `reloadTopologyAsync.get()` was logged but left the flag set, so later refreshes were skipped with “already in progress.”
> 
> The catch path now calls **`set(false)`** so the guard matches async failure handling. A unit test asserts the flag clears after a sync throw and a second `run()` can call `refreshPartitionsAsync()` again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1b09d0cb0ca1aaec3e22528a6d8d319cef64552. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->