### PR TITLE
Fix quadratic key-order restoration in cluster reactive MGET

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImpl.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisAdvancedClusterReactiveCommandsImpl.java
@@ -344,7 +344,6 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
         return mget(Arrays.asList(keys));
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     public Flux<KeyValue<K, V>> mget(Iterable<K> keys) {
         List<K> keyList = LettuceLists.newList(keys);
         Map<Integer, List<K>> partitioned = SlotHash.partition(codec, keyList);
@@ -353,24 +352,26 @@ public class RedisAdvancedClusterReactiveCommandsImpl<K, V> extends AbstractRedi
             return super.mget(keyList);
         }
 
-        List<Publisher<KeyValue<K, V>>> publishers = partitioned.values().stream().map(super::mget)
-                .collect(Collectors.toList());
+        // Maps each key to its position within the flattened, partition-ordered result list for O(1) lookups below
+        Map<K, Integer> keyToResultIndex = new HashMap<>(keyList.size());
+        List<Publisher<KeyValue<K, V>>> publishers = new ArrayList<>(partitioned.size());
+        int offset = 0;
+
+        for (List<K> partitionKeys : partitioned.values()) {
+            publishers.add(super.mget(partitionKeys));
+            for (int i = 0; i < partitionKeys.size(); i++) {
+                keyToResultIndex.put(partitionKeys.get(i), offset + i);
+            }
+            offset += partitionKeys.size();
+        }
 
         return Flux.mergeSequential(publishers).collectList().map(results -> {
-            KeyValue<K, V>[] values = new KeyValue[keyList.size()];
-            int offset = 0;
-
-            for (List<K> partitionKeys : partitioned.values()) {
-                for (int i = 0; i < keyList.size(); i++) {
-                    int index = partitionKeys.indexOf(keyList.get(i));
-                    if (index != -1) {
-                        values[i] = results.get(offset + index);
-                    }
-                }
-                offset += partitionKeys.size();
+            List<KeyValue<K, V>> orderedResults = new ArrayList<>(keyList.size());
+            for (K key : keyList) {
+                orderedResults.add(results.get(keyToResultIndex.get(key)));
             }
 
-            return Arrays.asList(values);
+            return orderedResults;
         }).flatMapMany(Flux::fromIterable);
     }
 

--- a/src/test/java/io/lettuce/core/cluster/AdvancedClusterReactiveIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/AdvancedClusterReactiveIntegrationTests.java
@@ -154,6 +154,26 @@ class AdvancedClusterReactiveIntegrationTests extends TestSupport {
     }
 
     @Test
+    void mgetCrossSlotWithDuplicateKeys() {
+
+        msetCrossSlot();
+
+        List<String> keysWithDuplicates = new ArrayList<>(KeysAndValues.KEYS);
+        keysWithDuplicates.add(KeysAndValues.KEYS.get(0));
+        keysWithDuplicates.add(KeysAndValues.KEYS.get(1));
+
+        List<String> expectedValues = new ArrayList<>(KeysAndValues.VALUES);
+        expectedValues.add(KeysAndValues.VALUES.get(0));
+        expectedValues.add(KeysAndValues.VALUES.get(1));
+
+        Flux<KeyValue<String, String>> flux = commands.mget(keysWithDuplicates.toArray(new String[0]));
+        List<KeyValue<String, String>> result = flux.collectList().block();
+
+        assertThat(result).hasSize(keysWithDuplicates.size());
+        assertThat(result.stream().map(Value::getValue).collect(Collectors.toList())).isEqualTo(expectedValues);
+    }
+
+    @Test
     void mgetCrossSlotStreaming() {
 
         msetCrossSlot();


### PR DESCRIPTION
What changed

Optimized RedisAdvancedClusterReactiveCommandsImpl#mget(Iterable<K>) by replacing repeated List.indexOf() result reordering with a map-based lookup.

Why

For large cross-slot Redis Cluster MGET requests, the reactive implementation repeatedly scanned partition key lists to restore the original key order. This made result reordering expensive for large key sets.

This PR keeps the change limited to the reactive cluster MGET path and preserves existing behavior.

Tests

Added regression coverage for cross-slot reactive MGET with duplicate keys to verify values remain aligned with the original request order.

Fixes #3741