### PR TITLE
[reactor-optional] Remove mono from Tracing

### DIFF
--- a/src/main/java/io/lettuce/core/tracing/BraveTracing.java
+++ b/src/main/java/io/lettuce/core/tracing/BraveTracing.java
@@ -26,7 +26,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import reactor.core.publisher.Mono;
 import brave.Span;
 import brave.propagation.TraceContextOrSamplingFlags;
 import io.lettuce.core.internal.LettuceAssert;
@@ -484,20 +483,6 @@ public class BraveTracing implements Tracing {
                 }
             }
             return null;
-        }
-
-        @Override
-        public Mono<TraceContext> getTraceContextLater() {
-
-            return Mono.deferContextual(Mono::justOrEmpty)
-                    .filter(it -> it.hasKey(Span.class) || it.hasKey(brave.propagation.TraceContext.class)).map(it -> {
-
-                        if (it.hasKey(Span.class)) {
-                            return new BraveTraceContext(it.get(Span.class).context());
-                        }
-
-                        return new BraveTraceContext(it.get(brave.propagation.TraceContext.class));
-                    });
         }
 
         @Override

--- a/src/main/java/io/lettuce/core/tracing/MicrometerTracing.java
+++ b/src/main/java/io/lettuce/core/tracing/MicrometerTracing.java
@@ -16,7 +16,6 @@ import io.lettuce.core.tracing.Tracer.Span;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
-import reactor.core.publisher.Mono;
 
 /**
  * {@link Tracing} adapter using Micrometer's {@link Observation}. This adapter integrates with Micrometer to propagate
@@ -268,26 +267,6 @@ public class MicrometerTracing implements Tracing {
             }
 
             return new MicrometerTraceContext(observation);
-        }
-
-        @Override
-        public Mono<TraceContext> getTraceContextLater() {
-
-            return Mono.deferContextual(Mono::justOrEmpty).filter((it) -> {
-                return it.hasKey(TraceContext.class) || it.hasKey(Observation.class)
-                        || it.hasKey(ObservationThreadLocalAccessor.KEY);
-            }).map((it) -> {
-
-                if (it.hasKey(Observation.class)) {
-                    return new MicrometerTraceContext(it.get(Observation.class));
-                }
-
-                if (it.hasKey(TraceContext.class)) {
-                    return it.get(TraceContext.class);
-                }
-
-                return new MicrometerTraceContext(it.get(ObservationThreadLocalAccessor.KEY));
-            });
         }
 
         @Override

--- a/src/main/java/io/lettuce/core/tracing/TraceContextProvider.java
+++ b/src/main/java/io/lettuce/core/tracing/TraceContextProvider.java
@@ -1,11 +1,7 @@
 package io.lettuce.core.tracing;
 
-import java.util.AbstractMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Supplier;
-
-import reactor.core.publisher.Mono;
 
 /**
  * Interface to obtain a {@link TraceContext} allowing propagation of {@link Tracer.Span} {@link TraceContext}s across threads.
@@ -26,44 +22,14 @@ public interface TraceContextProvider {
     TraceContext getTraceContext();
 
     /**
-     * Returns the {@link TraceContext} in a deferred fashion as a {@link Mono}.
+     * Provides a {@link TraceContext} in delayed fashion, accepts an application context to obtain/populate a particular
+     * context in case required.
      * <p>
-     * The emitted value may be {@code null} depending on the implementation and the application context it is called from.
-     *
-     * @return a {@link Mono} emitting the {@link TraceContext}.
-     * @deprecated since 7.7, override {@link #getTraceContextAsync(Map)} instead; scheduled for removal in Lettuce 8.0.
-     */
-    @Deprecated
-    default Mono<TraceContext> getTraceContextLater() {
-        return Mono.deferContextual(ctx -> Mono.justOrEmpty(getTraceContextAsync(new AbstractMap<Object, Object>() {
-
-            @Override
-            public Object get(Object key) {
-                return ctx.hasKey(key) ? ctx.get(key) : null;
-            }
-
-            @Override
-            public boolean containsKey(Object key) {
-                return ctx.hasKey(key);
-            }
-
-            @Override
-            public Set<Entry<Object, Object>> entrySet() {
-                throw new UnsupportedOperationException();
-            }
-
-        }).get()));
-    }
-
-    /**
-     * Returns a {@link Supplier} that resolves the {@link TraceContext} on demand, using the given application context to
-     * obtain or populate a particular context where required.
-     * <p>
-     * The value produced by the {@link Supplier} may be {@code null} depending on the implementation and the application
+     * Return value of the supplier, the {@link TraceContext}, can be null depending on the implementation, and application
      * context it is called from.
      *
-     * @param appContext the application context used to resolve the {@link TraceContext}.
-     * @return a {@link Supplier} of the {@link TraceContext}.
+     * @param appContext application context
+     * @return the supplier for the {@link TraceContext}.
      * @since 7.7
      */
     default Supplier<TraceContext> getTraceContextAsync(Map<Object, Object> appContext) {


### PR DESCRIPTION
Follow up of #3708 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow API removal with no remaining in-repo callers; behavior for reactive commands should already rely on `getTraceContextAsync` via Reactor context adapters elsewhere.
> 
> **Overview**
> Removes **Reactor** from the tracing SPI by deleting `TraceContextProvider.getTraceContextLater()` and its Brave/Micrometer overrides, along with related `reactor.core.publisher.Mono` imports.
> 
> Trace context for reactive flows is now obtained only through **`getTraceContextAsync(Map)`** (since 7.7), which returns a `Supplier<TraceContext>` instead of deferring via Reactor context inside the tracing implementations. Javadoc on `getTraceContextAsync` is tightened to match the blocking `getTraceContext()` style.
> 
> This continues the work to make Reactor an optional dependency for tracing (#3708).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca9b30f271a790b4a42156a46fe0f29a5dca406a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->