### PR TITLE
[reactor-optional] Deprecate reactive in TraceContextProvider

### DIFF
--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -120,7 +120,6 @@ import static io.lettuce.core.protocol.CommandType.GEORADIUS_RO;
  * @author SeugnSu Kim
  * @author Yordan Tsintsov
  * @author dae won
- * @author Aleksandar Todorov
  * @since 4.0
  */
 public abstract class AbstractRedisReactiveCommands<K, V>

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -82,6 +82,7 @@ import io.lettuce.core.search.arguments.SugAddArgs;
 import io.lettuce.core.search.arguments.SugGetArgs;
 import io.lettuce.core.search.arguments.SynUpdateArgs;
 import io.lettuce.core.tracing.TraceContext;
+import io.lettuce.core.tracing.TraceContextProvider;
 import io.lettuce.core.tracing.Tracing;
 import io.lettuce.core.vector.RawVector;
 import io.lettuce.core.vector.VSimScoreAttribs;
@@ -90,11 +91,9 @@ import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.util.context.ContextView;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.AbstractMap;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -158,37 +157,6 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     private final boolean tracingEnabled;
 
     private volatile EventExecutorGroup scheduler;
-
-    /**
-     * Adapts a Reactor {@link ContextView} to the {@link Map} interface, delegating reads directly to the underlying
-     * {@link ContextView} without copying. This allows reusing code that expects a {@link Map}-shaped context, such as
-     * {@link TraceContextProvider#getTraceContextAsync(Map)}.
-     */
-    static class ContextViewMapAdapter extends AbstractMap<Object, Object> {
-
-        private final ContextView ctx;
-
-        public ContextViewMapAdapter(ContextView ctx) {
-            this.ctx = ctx;
-        }
-
-        @Override
-        public Object get(Object key) {
-            return ctx.hasKey(key) ? ctx.get(key) : null;
-        }
-
-        @Override
-        public boolean containsKey(Object key) {
-            return ctx.hasKey(key);
-        }
-
-        @Override
-        public Set<Entry<Object, Object>> entrySet() {
-            // no need to implement, just for the sake of AbstractMap contract
-            throw new UnsupportedOperationException();
-        }
-
-    }
 
     /**
      * Initialize a new instance.
@@ -814,11 +782,10 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     private Mono<TraceContext> withTraceContext() {
+
         return Tracing.getContext()
                 .switchIfEmpty(Mono.fromSupplier(() -> clientResources.tracing().initialTraceContextProvider()))
-                .flatMap(p -> Mono
-                        .deferContextual(ctx -> Mono.justOrEmpty(p.getTraceContextAsync(new ContextViewMapAdapter(ctx)).get())))
-                .defaultIfEmpty(TraceContext.EMPTY);
+                .flatMap(TraceContextProvider::getTraceContextLater).defaultIfEmpty(TraceContext.EMPTY);
     }
 
     protected <T> Mono<T> createMono(CommandType type, CommandOutput<K, V, T> output, CommandArgs<K, V> args) {

--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -82,7 +82,6 @@ import io.lettuce.core.search.arguments.SugAddArgs;
 import io.lettuce.core.search.arguments.SugGetArgs;
 import io.lettuce.core.search.arguments.SynUpdateArgs;
 import io.lettuce.core.tracing.TraceContext;
-import io.lettuce.core.tracing.TraceContextProvider;
 import io.lettuce.core.tracing.Tracing;
 import io.lettuce.core.vector.RawVector;
 import io.lettuce.core.vector.VSimScoreAttribs;
@@ -91,9 +90,11 @@ import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.context.ContextView;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.AbstractMap;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -120,6 +121,7 @@ import static io.lettuce.core.protocol.CommandType.GEORADIUS_RO;
  * @author SeugnSu Kim
  * @author Yordan Tsintsov
  * @author dae won
+ * @author Aleksandar Todorov
  * @since 4.0
  */
 public abstract class AbstractRedisReactiveCommands<K, V>
@@ -156,6 +158,37 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     private final boolean tracingEnabled;
 
     private volatile EventExecutorGroup scheduler;
+
+    /**
+     * Adapts a Reactor {@link ContextView} to the {@link Map} interface, delegating reads directly to the underlying
+     * {@link ContextView} without copying. This allows reusing code that expects a {@link Map}-shaped context, such as
+     * {@link TraceContextProvider#getTraceContextAsync(Map)}.
+     */
+    static class ContextViewMapAdapter extends AbstractMap<Object, Object> {
+
+        private final ContextView ctx;
+
+        public ContextViewMapAdapter(ContextView ctx) {
+            this.ctx = ctx;
+        }
+
+        @Override
+        public Object get(Object key) {
+            return ctx.hasKey(key) ? ctx.get(key) : null;
+        }
+
+        @Override
+        public boolean containsKey(Object key) {
+            return ctx.hasKey(key);
+        }
+
+        @Override
+        public Set<Entry<Object, Object>> entrySet() {
+            // no need to implement, just for the sake of AbstractMap contract
+            throw new UnsupportedOperationException();
+        }
+
+    }
 
     /**
      * Initialize a new instance.
@@ -781,10 +814,11 @@ public abstract class AbstractRedisReactiveCommands<K, V>
     }
 
     private Mono<TraceContext> withTraceContext() {
-
         return Tracing.getContext()
                 .switchIfEmpty(Mono.fromSupplier(() -> clientResources.tracing().initialTraceContextProvider()))
-                .flatMap(TraceContextProvider::getTraceContextLater).defaultIfEmpty(TraceContext.EMPTY);
+                .flatMap(p -> Mono
+                        .deferContextual(ctx -> Mono.justOrEmpty(p.getTraceContextAsync(new ContextViewMapAdapter(ctx)).get())))
+                .defaultIfEmpty(TraceContext.EMPTY);
     }
 
     protected <T> Mono<T> createMono(CommandType type, CommandOutput<K, V, T> output, CommandArgs<K, V> args) {

--- a/src/main/java/io/lettuce/core/tracing/BraveTracing.java
+++ b/src/main/java/io/lettuce/core/tracing/BraveTracing.java
@@ -21,8 +21,10 @@ package io.lettuce.core.tracing;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import reactor.core.publisher.Mono;
 import brave.Span;
@@ -53,6 +55,7 @@ import io.lettuce.core.protocol.RedisCommand;
  *
  * @author Mark Paluch
  * @author Daniel Albuquerque
+ * @author Aleksandar Todorov
  * @see brave.Tracer
  * @see brave.Tracing#currentTracer()
  * @see BraveTraceContextProvider
@@ -496,6 +499,28 @@ public class BraveTracing implements Tracing {
 
                         return new BraveTraceContext(it.get(brave.propagation.TraceContext.class));
                     });
+        }
+
+        @Override
+        public Supplier<TraceContext> getTraceContextAsync(Map<Object, Object> asyncContext) {
+            return () -> {
+                if (asyncContext != null) {
+                    if (asyncContext.containsKey(Span.class)) {
+                        return new BraveTraceContext(((Span) asyncContext.get(Span.class)).context());
+                    }
+
+                    if (asyncContext.containsKey(brave.propagation.TraceContext.class)) {
+                        return new BraveTraceContext(
+                                (brave.propagation.TraceContext) asyncContext.get(brave.propagation.TraceContext.class));
+                    }
+
+                    // this is a deliberate choice to not fallback to ThreadLocal in async context
+                    // as we cannot guarantee that the ThreadLocal will be the same as the one that created the async context
+                    return null;
+                }
+                // fallback — no async context map provided, read ThreadLocal
+                return getTraceContext();
+            };
         }
 
     }

--- a/src/main/java/io/lettuce/core/tracing/BraveTracing.java
+++ b/src/main/java/io/lettuce/core/tracing/BraveTracing.java
@@ -55,7 +55,6 @@ import io.lettuce.core.protocol.RedisCommand;
  *
  * @author Mark Paluch
  * @author Daniel Albuquerque
- * @author Aleksandar Todorov
  * @see brave.Tracer
  * @see brave.Tracing#currentTracer()
  * @see BraveTraceContextProvider

--- a/src/main/java/io/lettuce/core/tracing/MicrometerTracing.java
+++ b/src/main/java/io/lettuce/core/tracing/MicrometerTracing.java
@@ -6,10 +6,12 @@ import java.net.SocketAddress;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import io.lettuce.core.internal.LettuceAssert;
 import io.lettuce.core.protocol.CompleteableCommand;
 import io.lettuce.core.protocol.RedisCommand;
+import io.lettuce.core.tracing.RedisObservation.HighCardinalityCommandKeyNames;
 import io.lettuce.core.tracing.Tracer.Span;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
@@ -25,6 +27,7 @@ import reactor.core.publisher.Mono;
  * be captured in traces including these that may contain sensitive details.
  *
  * @author Mark Paluch
+ * @author Aleksandar Todorov
  * @since 6.3
  */
 public class MicrometerTracing implements Tracing {
@@ -286,6 +289,29 @@ public class MicrometerTracing implements Tracing {
 
                 return new MicrometerTraceContext(it.get(ObservationThreadLocalAccessor.KEY));
             });
+        }
+
+        @Override
+        public Supplier<TraceContext> getTraceContextAsync(Map<Object, Object> asyncContext) {
+            return () -> {
+                if (asyncContext != null) {
+                    if (asyncContext.containsKey(Observation.class)) {
+                        return new MicrometerTraceContext((Observation) asyncContext.get(Observation.class));
+                    }
+                    if (asyncContext.containsKey(TraceContext.class)) {
+                        return (TraceContext) asyncContext.get(TraceContext.class);
+                    }
+                    if (asyncContext.containsKey(ObservationThreadLocalAccessor.KEY)) {
+                        return new MicrometerTraceContext((Observation) asyncContext.get(ObservationThreadLocalAccessor.KEY));
+                    }
+
+                    // this is a deliberate choice to not fallback to ThreadLocal in async context
+                    // as we cannot guarantee that the ThreadLocal will be the same as the one that created the async context
+                    return null;
+                }
+                // fallback — no async context map provided, read ThreadLocal
+                return getTraceContext();
+            };
         }
 
         public ObservationRegistry getRegistry() {

--- a/src/main/java/io/lettuce/core/tracing/MicrometerTracing.java
+++ b/src/main/java/io/lettuce/core/tracing/MicrometerTracing.java
@@ -27,7 +27,6 @@ import reactor.core.publisher.Mono;
  * be captured in traces including these that may contain sensitive details.
  *
  * @author Mark Paluch
- * @author Aleksandar Todorov
  * @since 6.3
  */
 public class MicrometerTracing implements Tracing {

--- a/src/main/java/io/lettuce/core/tracing/TraceContextProvider.java
+++ b/src/main/java/io/lettuce/core/tracing/TraceContextProvider.java
@@ -31,12 +31,7 @@ public interface TraceContextProvider {
      * The emitted value may be {@code null} depending on the implementation and the application context it is called from.
      *
      * @return a {@link Mono} emitting the {@link TraceContext}.
-     * @deprecated since 7.7, override {@link #getTraceContextAsync(Map)} instead; scheduled for removal in Lettuce 8.0 as part
-     *             of making Reactor an optional dependency. See
-     *             <a href="https://github.com/redis/lettuce/issues/3614">lettuce#3614</a>. The default implementation delegates
-     *             to {@link #getTraceContextAsync(Map)}, exposing the subscriber {@link reactor.util.context.ContextView} as a
-     *             read-only {@link Map}, so implementations that override only {@code getTraceContextAsync(Map)} are honored on
-     *             the reactive path without reimplementing this method.
+     * @deprecated since 7.7, override {@link #getTraceContextAsync(Map)} instead; scheduled for removal in Lettuce 8.0.
      */
     @Deprecated
     default Mono<TraceContext> getTraceContextLater() {

--- a/src/main/java/io/lettuce/core/tracing/TraceContextProvider.java
+++ b/src/main/java/io/lettuce/core/tracing/TraceContextProvider.java
@@ -1,26 +1,57 @@
 package io.lettuce.core.tracing;
 
+import java.util.Map;
+import java.util.function.Supplier;
+
 import reactor.core.publisher.Mono;
 
 /**
  * Interface to obtain a {@link TraceContext} allowing propagation of {@link Tracer.Span} {@link TraceContext}s across threads.
  *
  * @author Mark Paluch
+ * @author Aleksandar Todorov
  * @since 5.1
  */
 @FunctionalInterface
 public interface TraceContextProvider {
 
     /**
+     * Returns the {@link TraceContext} in a blocking fashion.
+     * <p>
+     * Return value can be null depending on the implementation, and application context it is called from.
+     * 
      * @return the {@link TraceContext}.
      */
     TraceContext getTraceContext();
 
     /**
-     * @return the {@link TraceContext}.
+     * Returns the {@link TraceContext} in a deferred fashion as a {@link Mono}.
+     * <p>
+     * The emitted value may be {@code null} depending on the implementation and the application context it is called from.
+     *
+     * @return a {@link Mono} emitting the {@link TraceContext}.
+     * @deprecated since 7.7, override {@link #getTraceContextAsync(Map)} instead; scheduled for removal in Lettuce 8.0 as part
+     *             of making Reactor an optional dependency. See
+     *             <a href="https://github.com/redis/lettuce/issues/3614">lettuce#3614</a>.
      */
+    @Deprecated
     default Mono<TraceContext> getTraceContextLater() {
         return Mono.justOrEmpty(getTraceContext());
+    }
+
+    /**
+     * Returns a {@link Supplier} that resolves the {@link TraceContext} on demand, using the given application context to
+     * obtain or populate a particular context where required.
+     * <p>
+     * The value produced by the {@link Supplier} may be {@code null} depending on the implementation and the application
+     * context it is called from.
+     *
+     * @param appContext the application context used to resolve the {@link TraceContext}.
+     * @return a {@link Supplier} of the {@link TraceContext}.
+     * @since 7.7
+     */
+    default Supplier<TraceContext> getTraceContextAsync(Map<Object, Object> appContext) {
+        return () -> getTraceContext();
     }
 
 }

--- a/src/main/java/io/lettuce/core/tracing/TraceContextProvider.java
+++ b/src/main/java/io/lettuce/core/tracing/TraceContextProvider.java
@@ -11,7 +11,6 @@ import reactor.core.publisher.Mono;
  * Interface to obtain a {@link TraceContext} allowing propagation of {@link Tracer.Span} {@link TraceContext}s across threads.
  *
  * @author Mark Paluch
- * @author Aleksandar Todorov
  * @since 5.1
  */
 @FunctionalInterface

--- a/src/main/java/io/lettuce/core/tracing/TraceContextProvider.java
+++ b/src/main/java/io/lettuce/core/tracing/TraceContextProvider.java
@@ -1,6 +1,8 @@
 package io.lettuce.core.tracing;
 
+import java.util.AbstractMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import reactor.core.publisher.Mono;
@@ -32,11 +34,31 @@ public interface TraceContextProvider {
      * @return a {@link Mono} emitting the {@link TraceContext}.
      * @deprecated since 7.7, override {@link #getTraceContextAsync(Map)} instead; scheduled for removal in Lettuce 8.0 as part
      *             of making Reactor an optional dependency. See
-     *             <a href="https://github.com/redis/lettuce/issues/3614">lettuce#3614</a>.
+     *             <a href="https://github.com/redis/lettuce/issues/3614">lettuce#3614</a>. The default implementation delegates
+     *             to {@link #getTraceContextAsync(Map)}, exposing the subscriber {@link reactor.util.context.ContextView} as a
+     *             read-only {@link Map}, so implementations that override only {@code getTraceContextAsync(Map)} are honored on
+     *             the reactive path without reimplementing this method.
      */
     @Deprecated
     default Mono<TraceContext> getTraceContextLater() {
-        return Mono.justOrEmpty(getTraceContext());
+        return Mono.deferContextual(ctx -> Mono.justOrEmpty(getTraceContextAsync(new AbstractMap<Object, Object>() {
+
+            @Override
+            public Object get(Object key) {
+                return ctx.hasKey(key) ? ctx.get(key) : null;
+            }
+
+            @Override
+            public boolean containsKey(Object key) {
+                return ctx.hasKey(key);
+            }
+
+            @Override
+            public Set<Entry<Object, Object>> entrySet() {
+                throw new UnsupportedOperationException();
+            }
+
+        }).get()));
     }
 
     /**
@@ -51,7 +73,7 @@ public interface TraceContextProvider {
      * @since 7.7
      */
     default Supplier<TraceContext> getTraceContextAsync(Map<Object, Object> appContext) {
-        return () -> getTraceContext();
+        return this::getTraceContext;
     }
 
 }

--- a/src/test/java/io/lettuce/core/tracing/AsynchronousIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/tracing/AsynchronousIntegrationTests.java
@@ -1,0 +1,99 @@
+package io.lettuce.core.tracing;
+
+import static io.lettuce.TestTags.INTEGRATION_TEST;
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.protocol.CommandType;
+import io.lettuce.core.protocol.RedisCommand;
+import io.lettuce.core.resource.ClientResources;
+import io.lettuce.test.TestFutures;
+import io.lettuce.test.resource.FastShutdown;
+import io.lettuce.test.settings.TestSettings;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.tracing.exporter.FinishedSpan;
+import io.micrometer.tracing.test.SampleTestRunner;
+import org.junit.jupiter.api.Tag;
+
+/**
+ * Collection of tests that log metrics and tracing using the asynchronous API. This guards against regressions in the
+ * Micrometer tracing integration for async command flows.
+ *
+ * @author Aleksandar Todorov
+ */
+@Tag(INTEGRATION_TEST)
+public class AsynchronousIntegrationTests extends SampleTestRunner {
+
+    AsynchronousIntegrationTests() {
+        super(SampleRunnerConfig.builder().build());
+    }
+
+    @Override
+    protected MeterRegistry createMeterRegistry() {
+        return TestConfig.METER_REGISTRY;
+    }
+
+    @Override
+    protected ObservationRegistry createObservationRegistry() {
+        return TestConfig.OBSERVATION_REGISTRY;
+    }
+
+    public static void main(String[] args) throws Exception {
+        AsynchronousIntegrationTests tests = new AsynchronousIntegrationTests();
+        TracingSetup[] setups = tests.getTracingSetup();
+        TracingSetup setup = setups[0];
+        Class<AsynchronousIntegrationTests> c = AsynchronousIntegrationTests.class;
+        Method m = c.getSuperclass().getDeclaredMethod("run", TracingSetup.class);
+        m.setAccessible(true);
+        tests.setupRegistry();
+        m.invoke(tests, setup);
+    }
+
+    @Override
+    public SampleTestRunnerConsumer yourCode() {
+
+        LinkedBlockingQueue<RedisCommand<?, ?, ?>> commands = new LinkedBlockingQueue<>();
+        ObservationRegistry observationRegistry = createObservationRegistry();
+        observationRegistry.observationConfig().observationPredicate((s, context) -> {
+
+            if (context instanceof LettuceObservationContext) {
+                commands.add(((LettuceObservationContext) context).getRequiredCommand());
+            }
+
+            return true;
+        });
+        ClientResources clientResources = ClientResources.builder()
+                .tracing(new MicrometerTracing(observationRegistry, "Redis", true)).build();
+
+        return (tracer, meterRegistry) -> {
+
+            RedisURI redisURI = RedisURI.create(TestSettings.host(), TestSettings.port());
+            RedisClient redisClient = RedisClient.create(clientResources, redisURI);
+            StatefulRedisConnection<String, String> connection = redisClient.connect();
+
+            TestFutures.getOrTimeout(connection.async().ping());
+
+            connection.close();
+            FastShutdown.shutdown(redisClient);
+            FastShutdown.shutdown(clientResources);
+
+            assertThat(tracer.getFinishedSpans()).isNotEmpty();
+
+            for (FinishedSpan finishedSpan : tracer.getFinishedSpans()) {
+                assertThat(finishedSpan.getTags()).containsEntry("db.system", "redis")
+                        .containsEntry("net.sock.peer.addr", TestSettings.host())
+                        .containsEntry("net.sock.peer.port", "" + TestSettings.port());
+                assertThat(finishedSpan.getTags()).containsKeys("db.operation");
+            }
+
+            assertThat(commands).extracting(RedisCommand::getType).contains(CommandType.PING, CommandType.HELLO);
+        };
+    }
+
+}

--- a/src/test/java/io/lettuce/core/tracing/ReactiveIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/tracing/ReactiveIntegrationTests.java
@@ -1,0 +1,122 @@
+package io.lettuce.core.tracing;
+
+import static io.lettuce.TestTags.INTEGRATION_TEST;
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
+import io.lettuce.core.protocol.CommandType;
+import io.lettuce.core.protocol.RedisCommand;
+import io.lettuce.core.resource.ClientResources;
+import io.lettuce.test.resource.FastShutdown;
+import io.lettuce.test.settings.TestSettings;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.tracing.exporter.FinishedSpan;
+import io.micrometer.tracing.test.SampleTestRunner;
+import org.junit.jupiter.api.Tag;
+import reactor.test.StepVerifier;
+
+/**
+ * Collection of tests that log metrics and tracing using the reactive API. This guards against regressions in the
+ * {@link MicrometerTracing.MicrometerTraceContextProvider#getTraceContextAsync} path used by
+ * {@link io.lettuce.core.AbstractRedisReactiveCommands#withTraceContext()}.
+ * <p>
+ * The {@link SampleTestRunner} framework manages an {@link Observation} on the ThreadLocal. Since {@code getTraceContextAsync}
+ * deliberately does not fall back to ThreadLocal when a Reactor context map is provided, this test propagates the current
+ * {@link Observation} into the Reactor context via {@code contextWrite} using the {@link Observation Observation.class} key,
+ * then verifies that the resulting Lettuce spans are children of the propagated observation (i.e. share its trace id).
+ *
+ * @author Ali Takavci
+ */
+@Tag(INTEGRATION_TEST)
+public class ReactiveIntegrationTests extends SampleTestRunner {
+
+    ReactiveIntegrationTests() {
+        super(SampleRunnerConfig.builder().build());
+    }
+
+    @Override
+    protected MeterRegistry createMeterRegistry() {
+        return TestConfig.METER_REGISTRY;
+    }
+
+    @Override
+    protected ObservationRegistry createObservationRegistry() {
+        return TestConfig.OBSERVATION_REGISTRY;
+    }
+
+    public static void main(String[] args) throws Exception {
+        ReactiveIntegrationTests tests = new ReactiveIntegrationTests();
+        TracingSetup[] setups = tests.getTracingSetup();
+        TracingSetup setup = setups[0];
+        Class<ReactiveIntegrationTests> c = ReactiveIntegrationTests.class;
+        Method m = c.getSuperclass().getDeclaredMethod("run", TracingSetup.class);
+        m.setAccessible(true);
+        tests.setupRegistry();
+        m.invoke(tests, setup);
+    }
+
+    @Override
+    public SampleTestRunnerConsumer yourCode() {
+
+        LinkedBlockingQueue<RedisCommand<?, ?, ?>> commands = new LinkedBlockingQueue<>();
+        ObservationRegistry observationRegistry = createObservationRegistry();
+        observationRegistry.observationConfig().observationPredicate((s, context) -> {
+
+            if (context instanceof LettuceObservationContext) {
+                commands.add(((LettuceObservationContext) context).getRequiredCommand());
+            }
+
+            return true;
+        });
+        ClientResources clientResources = ClientResources.builder()
+                .tracing(new MicrometerTracing(observationRegistry, "Redis", true)).build();
+
+        return (tracer, meterRegistry) -> {
+
+            RedisURI redisURI = RedisURI.create(TestSettings.host(), TestSettings.port());
+            RedisClient redisClient = RedisClient.create(clientResources, redisURI);
+            StatefulRedisConnection<String, String> connection = redisClient.connect();
+
+            // Grab the trace id of the SampleTestRunner's current span so we can verify
+            // that Lettuce spans become children of this trace.
+            io.micrometer.tracing.TraceContext c = tracer.getTracer().currentSpan().context();
+            String ctxTraceId = c.traceId();
+            String ctxSpanId = c.spanId();
+
+            // Propagate the Observation via the Observation.class key.
+            // This exercises the Observation.class branch in getTraceContextAsync.
+            connection.commands(RedisReactiveCommands.factory()).ping()
+                    .contextWrite(ctx -> ctx.put(Observation.class, observationRegistry.getCurrentObservation()))
+                    .as(StepVerifier::create).expectNext("PONG").verifyComplete();
+
+            connection.close();
+            FastShutdown.shutdown(redisClient);
+            FastShutdown.shutdown(clientResources);
+
+            assertThat(tracer.getFinishedSpans()).isNotEmpty();
+
+            for (FinishedSpan finishedSpan : tracer.getFinishedSpans()) {
+                assertThat(finishedSpan.getTags()).containsEntry("db.system", "redis")
+                        .containsEntry("net.sock.peer.addr", TestSettings.host())
+                        .containsEntry("net.sock.peer.port", "" + TestSettings.port());
+                assertThat(finishedSpan.getTags()).containsKeys("db.operation");
+            }
+
+            assertThat(tracer.getFinishedSpans()).anySatisfy(span -> {
+                assertThat(span.getTraceId()).isEqualTo(ctxTraceId);
+                assertThat(span.getParentId()).isEqualTo(ctxSpanId);
+            });
+
+            assertThat(commands).extracting(RedisCommand::getType).contains(CommandType.PING, CommandType.HELLO);
+        };
+    }
+
+}


### PR DESCRIPTION
Deprecates reactive code in TraceContextProvider as part of #3614 and follows #3708 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes distributed-tracing propagation semantics for async/reactive paths; missing context keys no longer inherit ThreadLocal, which can break parent span linking if callers do not propagate context.
> 
> **Overview**
> Introduces **`getTraceContextAsync(Map)`** on `TraceContextProvider` as the preferred way to resolve parent trace context from an application/Reactor context map, and **deprecates `getTraceContextLater()`** (removal in 8.0). The default `getTraceContextLater()` now defers to `getTraceContextAsync` by adapting Reactor `Context` into a map.
> 
> **Brave** and **Micrometer** providers override `getTraceContextAsync` to read their usual context keys (`Span` / Brave `TraceContext`, or `Observation` / `TraceContext` / observation thread-local key). When a non-null async context map is supplied but none of those keys are present, they **return null instead of falling back to ThreadLocal**, so trace parentage must be propagated explicitly in async/reactive flows.
> 
> Adds **integration tests** for Micrometer tracing over the **async** API and the **reactive** API (including `contextWrite` with `Observation` to verify child spans link to the parent trace).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 039a7720c7fe89460a436d5bdac489d0863092f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->