### PR TITLE
[reactor-optional] Make clean transition from reactive to async credentials provider

### DIFF
--- a/src/main/java/io/lettuce/authx/TokenBasedRedisCredentialsProvider.java
+++ b/src/main/java/io/lettuce/authx/TokenBasedRedisCredentialsProvider.java
@@ -8,6 +8,7 @@ package io.lettuce.authx;
 
 import io.lettuce.core.RedisCredentials;
 import io.lettuce.core.RedisCredentialsProvider;
+import io.lettuce.core.Subscription;
 import io.lettuce.core.internal.LettuceAssert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +53,7 @@ public class TokenBasedRedisCredentialsProvider implements RedisCredentialsProvi
 
     private static final Logger log = LoggerFactory.getLogger(TokenBasedRedisCredentialsProvider.class);
 
-    private static class SimpleSubscription implements CredentialsSubscription {
+    private static class SimpleSubscription implements Subscription {
 
         private final TokenBasedRedisCredentialsProvider provider;
 
@@ -205,7 +206,7 @@ public class TokenBasedRedisCredentialsProvider implements RedisCredentialsProvi
      * @return a {@link CompletionStage} that completes with the latest Redis credentials
      */
     @Override
-    public CompletionStage<RedisCredentials> resolveCredentials() {
+    public CompletionStage<RedisCredentials> resolveCredentialsAsync() {
         CompletableFuture<RedisCredentials> result = new CompletableFuture<>();
         credentialsFutureRef.get().whenComplete((creds, throwable) -> {
             if (throwable != null) {
@@ -218,7 +219,7 @@ public class TokenBasedRedisCredentialsProvider implements RedisCredentialsProvi
     }
 
     @Override
-    public CredentialsSubscription subscribeToCredentials(Consumer<RedisCredentials> onNext, Consumer<Throwable> onError) {
+    public Subscription subscribeToCredentials(Consumer<RedisCredentials> onNext, Consumer<Throwable> onError) {
         if (isClosed) {
             throw new IllegalStateException("Credentials provider closed");
         }
@@ -280,7 +281,7 @@ public class TokenBasedRedisCredentialsProvider implements RedisCredentialsProvi
      * <ul>
      * <li>Subscriber {@code onNext}/{@code onError} callbacks for live token renewals run on the {@link TokenManager}'s renewal
      * thread. A slow or blocking subscriber can delay or miss subsequent renewals.</li>
-     * <li>Continuations chained off {@link #resolveCredentials()} run on the renewal thread when the initial future
+     * <li>Continuations chained off {@link #resolveCredentialsAsync()} run on the renewal thread when the initial future
      * completes.</li>
      * <li>Replay deliveries to a newly subscribing consumer run on the subscribing thread.</li>
      * </ul>
@@ -323,7 +324,7 @@ public class TokenBasedRedisCredentialsProvider implements RedisCredentialsProvi
      * <ul>
      * <li>Subscriber {@code onNext}/{@code onError} callbacks for live token renewals run on the {@link TokenManager}'s renewal
      * thread. A slow or blocking subscriber can delay or miss subsequent renewals.</li>
-     * <li>Continuations chained off {@link #resolveCredentials()} run on the renewal thread when the initial future
+     * <li>Continuations chained off {@link #resolveCredentialsAsync()} run on the renewal thread when the initial future
      * completes.</li>
      * <li>Replay deliveries to a newly subscribing consumer run on the subscribing thread.</li>
      * </ul>

--- a/src/main/java/io/lettuce/core/RedisAuthenticationHandler.java
+++ b/src/main/java/io/lettuce/core/RedisAuthenticationHandler.java
@@ -6,7 +6,6 @@
  */
 package io.lettuce.core;
 
-import io.lettuce.core.RedisCredentialsProvider.CredentialsSubscription;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.event.connection.ReauthenticationEvent;
@@ -48,7 +47,7 @@ public class RedisAuthenticationHandler<K, V> {
 
     private final RedisCredentialsProvider credentialsProvider;
 
-    private final AtomicReference<CredentialsSubscription> credentialsSubscription = new AtomicReference<>();
+    private final AtomicReference<Subscription> credentialsSubscription = new AtomicReference<>();
 
     private final Boolean isPubSubConnection;
 
@@ -128,10 +127,9 @@ public class RedisAuthenticationHandler<K, V> {
             return;
         }
 
-        CredentialsSubscription credentialsSub = credentialsProvider.subscribeToCredentials(this::reauthenticate,
-                this::onError);
+        Subscription credentialsSub = credentialsProvider.subscribeToCredentials(this::reauthenticate, this::onError);
 
-        CredentialsSubscription oldSub = credentialsSubscription.getAndSet(credentialsSub);
+        Subscription oldSub = credentialsSubscription.getAndSet(credentialsSub);
         if (oldSub != null) {
             try {
                 oldSub.close();
@@ -145,7 +143,7 @@ public class RedisAuthenticationHandler<K, V> {
      * Unsubscribes from the current credentials stream.
      */
     public void unsubscribe() {
-        CredentialsSubscription sub = credentialsSubscription.getAndSet(null);
+        Subscription sub = credentialsSubscription.getAndSet(null);
         if (sub != null) {
             try {
                 sub.close();

--- a/src/main/java/io/lettuce/core/RedisCredentialsProvider.java
+++ b/src/main/java/io/lettuce/core/RedisCredentialsProvider.java
@@ -1,6 +1,5 @@
 package io.lettuce.core;
 
-import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
@@ -23,25 +22,16 @@ import io.lettuce.core.internal.LettuceAssert;
 public interface RedisCredentialsProvider {
 
     /**
-     * Handle to a subscription created by {@link #subscribeToCredentials(Consumer, Consumer)}. Closing the subscription stops
-     * the provider from delivering further credential updates to the registered consumers.
-     */
-    interface CredentialsSubscription extends Closeable {
-
-        @Override
-        void close();
-
-    }
-
-    /**
      * Returns {@link RedisCredentials} that can be used to authorize a Redis connection. Each implementation of
      * {@code RedisCredentialsProvider} can choose its own strategy for loading credentials. For example, an implementation
      * might load credentials from an existing key management system, or load new credentials when credentials are rotated. If
-     * an error occurs during the loading of credentials or credentials could not be found, a runtime exception will be raised.
+     * an error occurs during the loading of credentials or credentials could not be found, the returned {@link CompletionStage}
+     * completes exceptionally.
      *
-     * @return a {@link CompletionStage} emitting {@link RedisCredentials} that can be used to authorize a Redis connection.
+     * @return a {@link CompletionStage} that completes with the {@link RedisCredentials} used to authorize a Redis connection.
+     * @since 7.7
      */
-    CompletionStage<RedisCredentials> resolveCredentials();
+    CompletionStage<RedisCredentials> resolveCredentialsAsync();
 
     /**
      * Creates a new {@link RedisCredentialsProvider} from a given {@link Supplier}.
@@ -101,10 +91,10 @@ public interface RedisCredentialsProvider {
      *
      * @param onNext consumer invoked with each new {@link RedisCredentials} value, must not be {@code null}.
      * @param onError consumer invoked with errors observed while producing credentials, must not be {@code null}.
-     * @return a {@link CredentialsSubscription} that can be used to stop receiving updates.
+     * @return a {@link Subscription} that can be used to stop receiving updates.
      * @throws UnsupportedOperationException if the provider does not support streaming credentials.
      */
-    default CredentialsSubscription subscribeToCredentials(Consumer<RedisCredentials> onNext, Consumer<Throwable> onError) {
+    default Subscription subscribeToCredentials(Consumer<RedisCredentials> onNext, Consumer<Throwable> onError) {
         throw new UnsupportedOperationException("Streaming credentials are not supported by this provider.");
     }
 
@@ -116,7 +106,7 @@ public interface RedisCredentialsProvider {
     interface ImmediateRedisCredentialsProvider extends RedisCredentialsProvider {
 
         @Override
-        default CompletionStage<RedisCredentials> resolveCredentials() {
+        default CompletionStage<RedisCredentials> resolveCredentialsAsync() {
             try {
                 RedisCredentials credentials = resolveCredentialsNow();
                 if (credentials == null) {

--- a/src/main/java/io/lettuce/core/RedisHandshake.java
+++ b/src/main/java/io/lettuce/core/RedisHandshake.java
@@ -210,7 +210,8 @@ class RedisHandshake implements ConnectionInitializer {
                     ((RedisCredentialsProvider.ImmediateRedisCredentialsProvider) credentialsProvider).resolveCredentialsNow());
         }
 
-        CompletableFuture<RedisCredentials> credentialsFuture = credentialsProvider.resolveCredentials().toCompletableFuture();
+        CompletableFuture<RedisCredentials> credentialsFuture = credentialsProvider.resolveCredentialsAsync()
+                .toCompletableFuture();
 
         return credentialsFuture.thenComposeAsync(credentials -> dispatchAuthOrPing(channel, credentials));
     }
@@ -243,7 +244,8 @@ class RedisHandshake implements ConnectionInitializer {
                     ((RedisCredentialsProvider.ImmediateRedisCredentialsProvider) credentialsProvider).resolveCredentialsNow());
         }
 
-        CompletableFuture<RedisCredentials> credentialsFuture = credentialsProvider.resolveCredentials().toCompletableFuture();
+        CompletableFuture<RedisCredentials> credentialsFuture = credentialsProvider.resolveCredentialsAsync()
+                .toCompletableFuture();
 
         return credentialsFuture.thenComposeAsync(credentials -> dispatchHello(channel, credentials));
     }

--- a/src/main/java/io/lettuce/core/RedisURI.java
+++ b/src/main/java/io/lettuce/core/RedisURI.java
@@ -976,7 +976,7 @@ public class RedisURI implements Serializable, ConnectionPoint {
                 // would get asterix for each character of the password.
                 RedisCredentials creds;
                 try {
-                    creds = credentialsProvider.resolveCredentials().toCompletableFuture().join();
+                    creds = credentialsProvider.resolveCredentialsAsync().toCompletableFuture().join();
                 } catch (Exception e) {
                     throw Exceptions.bubble(e);
                 }

--- a/src/main/java/io/lettuce/core/StaticCredentialsProvider.java
+++ b/src/main/java/io/lettuce/core/StaticCredentialsProvider.java
@@ -44,7 +44,7 @@ public class StaticCredentialsProvider
     }
 
     @Override
-    public CompletionStage<RedisCredentials> resolveCredentials() {
+    public CompletionStage<RedisCredentials> resolveCredentialsAsync() {
         return future;
     }
 

--- a/src/main/java/io/lettuce/core/Subscription.java
+++ b/src/main/java/io/lettuce/core/Subscription.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026-Present, Redis Ltd. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+package io.lettuce.core;
+
+import java.io.Closeable;
+
+/**
+ * Handle to a callback subscription on a Lettuce streaming SPI, such as
+ * {@link io.lettuce.core.RedisCredentialsProvider#subscribeToCredentials(java.util.function.Consumer, java.util.function.Consumer)}
+ * or {@link io.lettuce.core.event.EventBus}. Closing the subscription stops delivery of further values to the registered
+ * callback.
+ * <p>
+ * This is not related to {@code org.reactivestreams.Subscription} or to Redis Pub/Sub channel subscriptions.
+ *
+ * @author Aleksandar Todorov
+ * @since 7.7
+ */
+public interface Subscription extends Closeable {
+
+    /**
+     * Stop delivering to the registered callback. Idempotent; calling it more than once has no further effect and never throws.
+     */
+    @Override
+    void close();
+
+}

--- a/src/test/java/io/lettuce/authx/DefaultAzureCredentialsIntegrationTests.java
+++ b/src/test/java/io/lettuce/authx/DefaultAzureCredentialsIntegrationTests.java
@@ -79,7 +79,8 @@ public class DefaultAzureCredentialsIntegrationTests {
     @Test
     public void azureTokenAuthWithDefaultAzureCredentials() throws ExecutionException, InterruptedException, TimeoutException {
 
-        RedisCredentials credentials = credentialsProvider.resolveCredentials().toCompletableFuture().get(5, TimeUnit.SECONDS);
+        RedisCredentials credentials = credentialsProvider.resolveCredentialsAsync().toCompletableFuture().get(5,
+                TimeUnit.SECONDS);
         assertThat(credentials).isNotNull();
 
         String key = UUID.randomUUID().toString();

--- a/src/test/java/io/lettuce/authx/EntraIdIntegrationTests.java
+++ b/src/test/java/io/lettuce/authx/EntraIdIntegrationTests.java
@@ -1,7 +1,6 @@
 package io.lettuce.authx;
 
 import io.lettuce.core.*;
-import io.lettuce.core.RedisCredentialsProvider.CredentialsSubscription;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.api.reactive.RedisReactiveCommands;
@@ -116,7 +115,7 @@ public class EntraIdIntegrationTests {
         commandThread.start();
 
         CountDownLatch latch = new CountDownLatch(10); // Wait for at least 10 token renewalss
-        CredentialsSubscription subscription = credentialsProvider.subscribeToCredentials(cred -> latch.countDown(), t -> {
+        Subscription subscription = credentialsProvider.subscribeToCredentials(cred -> latch.countDown(), t -> {
         });
         try {
             assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue(); // Wait to reach 10 renewals
@@ -150,7 +149,7 @@ public class EntraIdIntegrationTests {
             pubsubThread.start();
 
             CountDownLatch latch = new CountDownLatch(10);
-            CredentialsSubscription subscription = credentialsProvider.subscribeToCredentials(cred -> latch.countDown(), t -> {
+            Subscription subscription = credentialsProvider.subscribeToCredentials(cred -> latch.countDown(), t -> {
             });
             try {
                 assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue(); // Wait for at least 10 token renewals

--- a/src/test/java/io/lettuce/authx/TokenBasedRedisCredentialsProviderTest.java
+++ b/src/test/java/io/lettuce/authx/TokenBasedRedisCredentialsProviderTest.java
@@ -2,7 +2,7 @@ package io.lettuce.authx;
 
 import io.lettuce.TestTags;
 import io.lettuce.core.RedisCredentials;
-import io.lettuce.core.RedisCredentialsProvider.CredentialsSubscription;
+import io.lettuce.core.Subscription;
 import io.lettuce.core.TestTokenManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -44,7 +44,7 @@ public class TokenBasedRedisCredentialsProviderTest {
     public void shouldReturnPreviouslyEmittedTokenWhenResolved() {
         tokenManager.emitToken(testToken("test-user", "token-1"));
 
-        Mono<RedisCredentials> credentials = Mono.fromCompletionStage(credentialsProvider.resolveCredentials());
+        Mono<RedisCredentials> credentials = Mono.fromCompletionStage(credentialsProvider.resolveCredentialsAsync());
 
         StepVerifier.create(credentials).assertNext(actual -> {
             assertThat(actual.getUsername()).isEqualTo("test-user");
@@ -57,7 +57,7 @@ public class TokenBasedRedisCredentialsProviderTest {
         tokenManager.emitToken(testToken("test-user", "token-2"));
         tokenManager.emitToken(testToken("test-user", "token-3")); // Latest token
 
-        Mono<RedisCredentials> credentials = Mono.fromCompletionStage(credentialsProvider.resolveCredentials());
+        Mono<RedisCredentials> credentials = Mono.fromCompletionStage(credentialsProvider.resolveCredentialsAsync());
 
         StepVerifier.create(credentials).assertNext(actual -> {
             assertThat(actual.getUsername()).isEqualTo("test-user");
@@ -71,7 +71,7 @@ public class TokenBasedRedisCredentialsProviderTest {
         tokenManager.emitToken(testToken("test-user", "token-1"));
 
         // Test resolveCredentials
-        Mono<RedisCredentials> credentials1 = Mono.fromCompletionStage(credentialsProvider.resolveCredentials());
+        Mono<RedisCredentials> credentials1 = Mono.fromCompletionStage(credentialsProvider.resolveCredentialsAsync());
 
         StepVerifier.create(credentials1).assertNext(actual -> {
             assertThat(actual.getUsername()).isEqualTo("test-user");
@@ -81,7 +81,7 @@ public class TokenBasedRedisCredentialsProviderTest {
         // Emit second token and subscribe another
         tokenManager.emitToken(testToken("test-user", "token-2"));
         tokenManager.emitToken(testToken("test-user", "token-3"));
-        Mono<RedisCredentials> credentials2 = Mono.fromCompletionStage(credentialsProvider.resolveCredentials());
+        Mono<RedisCredentials> credentials2 = Mono.fromCompletionStage(credentialsProvider.resolveCredentialsAsync());
         StepVerifier.create(credentials2).assertNext(actual -> {
             assertThat(actual.getUsername()).isEqualTo("test-user");
             assertThat(new String(actual.getPassword())).isEqualTo("token-3");
@@ -90,7 +90,7 @@ public class TokenBasedRedisCredentialsProviderTest {
 
     @Test
     public void shouldWaitForAndReturnTokenWhenEmittedLater() {
-        Mono<RedisCredentials> result = Mono.fromCompletionStage(credentialsProvider.resolveCredentials());
+        Mono<RedisCredentials> result = Mono.fromCompletionStage(credentialsProvider.resolveCredentialsAsync());
 
         tokenManager.emitTokenWithDelay(testToken("test-user", "delayed-token"), 100); // Emit token after 100ms
         StepVerifier.create(result)
@@ -104,12 +104,12 @@ public class TokenBasedRedisCredentialsProviderTest {
         List<RedisCredentials> received2 = new CopyOnWriteArrayList<>();
         CountDownLatch firstTokenLatch = new CountDownLatch(2);
 
-        CredentialsSubscription sub1 = credentialsProvider.subscribeToCredentials(c -> {
+        Subscription sub1 = credentialsProvider.subscribeToCredentials(c -> {
             received1.add(c);
             firstTokenLatch.countDown();
         }, t -> {
         });
-        CredentialsSubscription sub2 = credentialsProvider.subscribeToCredentials(c -> {
+        Subscription sub2 = credentialsProvider.subscribeToCredentials(c -> {
             received2.add(c);
             firstTokenLatch.countDown();
         }, t -> {
@@ -140,7 +140,7 @@ public class TokenBasedRedisCredentialsProviderTest {
         List<RedisCredentials> received = new CopyOnWriteArrayList<>();
         CountDownLatch latch = new CountDownLatch(2);
 
-        CredentialsSubscription sub = credentialsProvider.subscribeToCredentials(c -> {
+        Subscription sub = credentialsProvider.subscribeToCredentials(c -> {
             received.add(c);
             latch.countDown();
         }, t -> {
@@ -166,7 +166,7 @@ public class TokenBasedRedisCredentialsProviderTest {
         AtomicReference<RedisCredentials> received = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
 
-        CredentialsSubscription sub = credentialsProvider.subscribeToCredentials(c -> {
+        Subscription sub = credentialsProvider.subscribeToCredentials(c -> {
             received.set(c);
             latch.countDown();
         }, t -> {
@@ -187,7 +187,7 @@ public class TokenBasedRedisCredentialsProviderTest {
         CountDownLatch tokensLatch = new CountDownLatch(2);
         CountDownLatch errorLatch = new CountDownLatch(1);
 
-        CredentialsSubscription sub = credentialsProvider.subscribeToCredentials(c -> {
+        Subscription sub = credentialsProvider.subscribeToCredentials(c -> {
             received.add(c);
             tokensLatch.countDown();
         }, t -> {

--- a/src/test/java/io/lettuce/core/ConnectionCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/ConnectionCommandIntegrationTests.java
@@ -285,8 +285,8 @@ class ConnectionCommandIntegrationTests extends TestSupport {
         } catch (RedisException e) {
             assertThat(e.getMessage()).startsWith("ERR").contains("AUTH");
             StatefulRedisConnectionImpl<String, String> connectionImpl = (StatefulRedisConnectionImpl<String, String>) connection;
-            assertThat(connectionImpl.getConnectionState().getCredentialsProvider().resolveCredentials().toCompletableFuture()
-                    .join().getPassword()).isNull();
+            assertThat(connectionImpl.getConnectionState().getCredentialsProvider().resolveCredentialsAsync()
+                    .toCompletableFuture().join().getPassword()).isNull();
         } finally {
             connection.close();
         }

--- a/src/test/java/io/lettuce/core/MyStreamingRedisCredentialsProvider.java
+++ b/src/test/java/io/lettuce/core/MyStreamingRedisCredentialsProvider.java
@@ -30,12 +30,12 @@ public class MyStreamingRedisCredentialsProvider implements RedisCredentialsProv
     }
 
     @Override
-    public CompletionStage<RedisCredentials> resolveCredentials() {
+    public CompletionStage<RedisCredentials> resolveCredentialsAsync() {
         return credentialsFutureRef.get();
     }
 
     @Override
-    public CredentialsSubscription subscribeToCredentials(Consumer<RedisCredentials> onNext, Consumer<Throwable> onError) {
+    public Subscription subscribeToCredentials(Consumer<RedisCredentials> onNext, Consumer<Throwable> onError) {
         LettuceAssert.notNull(onNext, "onNext consumer must not be null");
         LettuceAssert.notNull(onError, "onError consumer must not be null");
         Listener listener = new Listener(onNext, onError);

--- a/src/test/java/io/lettuce/core/RedisHandshakeUnitTests.java
+++ b/src/test/java/io/lettuce/core/RedisHandshakeUnitTests.java
@@ -359,7 +359,7 @@ class RedisHandshakeUnitTests {
         private final Sinks.One<RedisCredentials> credentialsSink = Sinks.one();
 
         @Override
-        public CompletionStage<RedisCredentials> resolveCredentials() {
+        public CompletionStage<RedisCredentials> resolveCredentialsAsync() {
             return credentialsSink.asMono().toFuture();
         }
 

--- a/src/test/java/io/lettuce/core/RedisURIBuilderUnitTests.java
+++ b/src/test/java/io/lettuce/core/RedisURIBuilderUnitTests.java
@@ -171,7 +171,7 @@ class RedisURIBuilderUnitTests {
         assertThat(result.getSentinels()).isEmpty();
         assertThat(result.getHost()).isEqualTo("localhost");
         assertThat(result.getPort()).isEqualTo(RedisURI.DEFAULT_REDIS_PORT);
-        StepVerifier.create(Mono.fromCompletionStage(result.getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(Mono.fromCompletionStage(result.getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
@@ -183,14 +183,14 @@ class RedisURIBuilderUnitTests {
     @Test
     void redisFromUrlNoPassword() {
         RedisURI redisURI = RedisURI.create("redis://localhost:1234/5");
-        StepVerifier.create(Mono.fromCompletionStage(redisURI.getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(Mono.fromCompletionStage(redisURI.getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isNull();
                 }).verifyComplete();
 
         redisURI = RedisURI.create("redis://h:@localhost.com:14589");
-        StepVerifier.create(Mono.fromCompletionStage(redisURI.getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(Mono.fromCompletionStage(redisURI.getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isNull();
@@ -201,7 +201,7 @@ class RedisURIBuilderUnitTests {
     void redisFromUrlPassword() {
         RedisURI redisURI = RedisURI.create("redis://h:password@localhost.com:14589");
 
-        StepVerifier.create(Mono.fromCompletionStage(redisURI.getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(Mono.fromCompletionStage(redisURI.getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isEqualTo("h");
                     assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
@@ -236,7 +236,7 @@ class RedisURIBuilderUnitTests {
         assertThat(result.getSentinels()).isEmpty();
         assertThat(result.getHost()).isEqualTo("localhost");
         assertThat(result.getPort()).isEqualTo(RedisURI.DEFAULT_REDIS_PORT);
-        StepVerifier.create(Mono.fromCompletionStage(result.getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(Mono.fromCompletionStage(result.getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
@@ -254,7 +254,7 @@ class RedisURIBuilderUnitTests {
         assertThat(result.getPort()).isEqualTo(RedisURI.DEFAULT_REDIS_PORT);
         assertThat(result.getSentinelMasterId()).isEqualTo("master");
         assertThat(result.toString()).contains("master");
-        StepVerifier.create(Mono.fromCompletionStage(result.getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(Mono.fromCompletionStage(result.getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
@@ -266,7 +266,7 @@ class RedisURIBuilderUnitTests {
         assertThat(result.getHost()).isNull();
         assertThat(result.getPort()).isEqualTo(RedisURI.DEFAULT_REDIS_PORT);
         assertThat(result.getSentinelMasterId()).isEqualTo("master");
-        StepVerifier.create(Mono.fromCompletionStage(result.getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(Mono.fromCompletionStage(result.getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
@@ -291,7 +291,7 @@ class RedisURIBuilderUnitTests {
         RedisURI result = RedisURI.Builder.sentinel("host", 1234, "master", "foo").build();
 
         RedisURI sentinel = result.getSentinels().get(0);
-        StepVerifier.create(Mono.fromCompletionStage(sentinel.getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(Mono.fromCompletionStage(sentinel.getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isEqualTo("foo".toCharArray());
@@ -309,7 +309,7 @@ class RedisURIBuilderUnitTests {
         assertThat(sentinel.isStartTls()).isTrue();
         assertThat(sentinel.isVerifyPeer()).isFalse();
 
-        StepVerifier.create(Mono.fromCompletionStage(sentinel.getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(Mono.fromCompletionStage(sentinel.getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isEqualTo("foo".toCharArray());
@@ -324,14 +324,16 @@ class RedisURIBuilderUnitTests {
         RedisURI result = RedisURI.Builder.sentinel("host", 1234, "master").withSentinel(sentinel).build();
 
         StepVerifier
-                .create(Mono.fromCompletionStage(result.getSentinels().get(0).getCredentialsProvider().resolveCredentials()))
+                .create(Mono
+                        .fromCompletionStage(result.getSentinels().get(0).getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isNull();
                 }).verifyComplete();
 
         StepVerifier
-                .create(Mono.fromCompletionStage(result.getSentinels().get(1).getCredentialsProvider().resolveCredentials()))
+                .create(Mono
+                        .fromCompletionStage(result.getSentinels().get(1).getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isEqualTo("bar".toCharArray());
@@ -344,14 +346,16 @@ class RedisURIBuilderUnitTests {
         RedisURI result = RedisURI.Builder.sentinel("host", 1234, "master", "foo").withSentinel("bar").build();
 
         StepVerifier
-                .create(Mono.fromCompletionStage(result.getSentinels().get(0).getCredentialsProvider().resolveCredentials()))
+                .create(Mono
+                        .fromCompletionStage(result.getSentinels().get(0).getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isEqualTo("foo".toCharArray());
                 }).verifyComplete();
 
         StepVerifier
-                .create(Mono.fromCompletionStage(result.getSentinels().get(1).getCredentialsProvider().resolveCredentials()))
+                .create(Mono
+                        .fromCompletionStage(result.getSentinels().get(1).getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isNull();
@@ -361,14 +365,16 @@ class RedisURIBuilderUnitTests {
                 .withSentinel("bar", 1234, "baz").build();
 
         StepVerifier
-                .create(Mono.fromCompletionStage(result.getSentinels().get(0).getCredentialsProvider().resolveCredentials()))
+                .create(Mono
+                        .fromCompletionStage(result.getSentinels().get(0).getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isNull();
                 }).verifyComplete();
 
         StepVerifier
-                .create(Mono.fromCompletionStage(result.getSentinels().get(1).getCredentialsProvider().resolveCredentials()))
+                .create(Mono
+                        .fromCompletionStage(result.getSentinels().get(1).getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isEqualTo("baz".toCharArray());
@@ -425,7 +431,7 @@ class RedisURIBuilderUnitTests {
         assertThat(result.getPort()).isEqualTo(RedisURI.DEFAULT_REDIS_PORT);
         assertThat(result.isSsl()).isFalse();
 
-        StepVerifier.create(Mono.fromCompletionStage(result.getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(Mono.fromCompletionStage(result.getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isNull();
@@ -444,7 +450,7 @@ class RedisURIBuilderUnitTests {
         assertThat(result.getPort()).isEqualTo(RedisURI.DEFAULT_REDIS_PORT);
         assertThat(result.isSsl()).isFalse();
 
-        StepVerifier.create(Mono.fromCompletionStage(result.getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(Mono.fromCompletionStage(result.getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
@@ -497,7 +503,7 @@ class RedisURIBuilderUnitTests {
         assertThat(target.isSsl()).isEqualTo(source.isSsl());
         assertThat(target.isVerifyPeer()).isEqualTo(source.isVerifyPeer());
 
-        StepVerifier.create(Mono.fromCompletionStage(target.getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(Mono.fromCompletionStage(target.getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isEqualTo("baz".toCharArray());

--- a/src/test/java/io/lettuce/core/RedisURIUnitTests.java
+++ b/src/test/java/io/lettuce/core/RedisURIUnitTests.java
@@ -284,7 +284,7 @@ class RedisURIUnitTests {
         String uri = "redis-sentinel://" + translatedPassword + "@h1:1234,h2:1234,h3:1234/0?sentinelMasterId=masterId";
         RedisURI redisURI = RedisURI.create(uri);
         assertThat(redisURI.getSentinels().get(0).getHost()).isEqualTo("h1");
-        StepVerifier.create(Mono.fromCompletionStage(redisURI.getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(Mono.fromCompletionStage(redisURI.getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isEqualTo(password.toCharArray());
@@ -294,7 +294,7 @@ class RedisURIUnitTests {
         uri = "redis://" + translatedPassword + "@h1:1234/0";
         redisURI = RedisURI.create(uri);
         assertThat(redisURI.getHost()).isEqualTo("h1");
-        StepVerifier.create(Mono.fromCompletionStage(redisURI.getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(Mono.fromCompletionStage(redisURI.getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isEqualTo(password.toCharArray());
@@ -427,7 +427,7 @@ class RedisURIUnitTests {
         RedisURI target = new RedisURI();
         target.applyAuthentication(source);
 
-        StepVerifier.create(Mono.fromCompletionStage(target.getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(Mono.fromCompletionStage(target.getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isEqualTo("foo");
                     assertThat(credentials.getPassword()).isEqualTo("bar".toCharArray());
@@ -436,7 +436,7 @@ class RedisURIUnitTests {
         source.setCredentialsProvider(new StaticCredentialsProvider(null, "bar".toCharArray()));
         target.applyAuthentication(source);
 
-        StepVerifier.create(Mono.fromCompletionStage(target.getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(Mono.fromCompletionStage(target.getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isEqualTo("bar".toCharArray());
@@ -451,7 +451,7 @@ class RedisURIUnitTests {
         RedisURI targetCp = new RedisURI();
         targetCp.applyAuthentication(sourceCp);
 
-        StepVerifier.create(Mono.fromCompletionStage(targetCp.getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(Mono.fromCompletionStage(targetCp.getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isEqualTo("suppliedUsername");
                     assertThat(credentials.getPassword()).isEqualTo("suppliedPassword".toCharArray());

--- a/src/test/java/io/lettuce/core/cluster/RedisClusterURIUtilUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisClusterURIUtilUnitTests.java
@@ -75,7 +75,7 @@ class RedisClusterURIUtilUnitTests {
         assertThat(host1.isStartTls()).isTrue();
         assertThat(host1.getHost()).isEqualTo("host1");
         assertThat(host1.getPort()).isEqualTo(6379);
-        StepVerifier.create(Mono.fromCompletionStage(host1.getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(Mono.fromCompletionStage(host1.getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
@@ -94,7 +94,7 @@ class RedisClusterURIUtilUnitTests {
         assertThat(host1.isStartTls()).isTrue();
         assertThat(host1.getHost()).isEqualTo("host1");
         assertThat(host1.getPort()).isEqualTo(6379);
-        StepVerifier.create(Mono.fromCompletionStage(host1.getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(Mono.fromCompletionStage(host1.getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
@@ -105,7 +105,7 @@ class RedisClusterURIUtilUnitTests {
         assertThat(host2.isStartTls()).isTrue();
         assertThat(host2.getHost()).isEqualTo("host2");
         assertThat(host2.getPort()).isEqualTo(6380);
-        StepVerifier.create(Mono.fromCompletionStage(host2.getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(Mono.fromCompletionStage(host2.getCredentialsProvider().resolveCredentialsAsync()))
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());


### PR DESCRIPTION
Follow up of https://github.com/redis/lettuce/pull/3785 that provides clean transition between 7.x and 8.x branches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public SPI renames affect any external `RedisCredentialsProvider` implementations at compile time; connection/auth behavior is otherwise unchanged.
> 
> **Overview**
> Renames the credentials provider API for a cleaner 7.x → 8.x transition: **`resolveCredentials()`** becomes **`resolveCredentialsAsync()`**, and the nested **`RedisCredentialsProvider.CredentialsSubscription`** is replaced by a top-level **`Subscription`** interface (shared handle for streaming SPIs such as credentials and the event bus).
> 
> **`RedisCredentialsProvider`** javadoc now states that failures complete the returned **`CompletionStage`** exceptionally instead of implying a runtime throw. Implementations (**`StaticCredentialsProvider`**, **`TokenBasedRedisCredentialsProvider`**, test helpers) and internal callers (**`RedisHandshake`**, **`RedisAuthenticationHandler`**, **`RedisURI`** masking) are updated to the new names only; streaming subscribe/close behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f558dbb1f28d4cf972af4be3de92ec2cd1fd9cc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->