### PR TITLE
Fix FT.HYBRID COMBINE argument count to include YIELD_SCORE_AS tokens

### DIFF
--- a/src/main/java/io/lettuce/core/search/arguments/hybrid/Combiner.java
+++ b/src/main/java/io/lettuce/core/search/arguments/hybrid/Combiner.java
@@ -97,7 +97,15 @@ public abstract class Combiner<K> {
         args.add(name);
 
         List<Object> ownArgs = getOwnArgs();
-        args.add(ownArgs.size());
+        // The COMBINE clause is serialized as COMBINE <method> <count> <args...>, where <count> must cover every token that
+        // follows, including the two YIELD_SCORE_AS <alias> tokens appended below. Omitting them makes Redis read past the
+        // clause and reject the command with "YIELD_SCORE_AS: Unknown argument".
+        int argCount = ownArgs.size();
+        if (scoreAlias != null) {
+            argCount += 2;
+        }
+        args.add(argCount);
+
         for (Object arg : ownArgs) {
             args.add(arg);
         }

--- a/src/test/java/io/lettuce/core/search/arguments/hybrid/CombinerTest.java
+++ b/src/test/java/io/lettuce/core/search/arguments/hybrid/CombinerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ */
+
+package io.lettuce.core.search.arguments.hybrid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.lettuce.TestTags;
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.protocol.CommandArgs;
+
+/**
+ * Unit tests for {@link Combiner} argument serialization in the FT.HYBRID {@code COMBINE} clause.
+ * <p>
+ * The {@code COMBINE <method> <count> <args...>} count must cover every token the combiner appends, including the two
+ * {@code YIELD_SCORE_AS <alias>} tokens emitted by {@link Combiner#as(Object)}. If the count omits them, Redis reads past the
+ * clause and rejects the command with {@code YIELD_SCORE_AS: Unknown argument}.
+ *
+ * @author Develop-KIM
+ */
+@Tag(TestTags.UNIT_TEST)
+class CombinerTest {
+
+    private static String[] serialize(Combiner<String> combiner) {
+        CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8);
+        combiner.build(args);
+        return args.toCommandString().split(" ");
+    }
+
+    @Test
+    void rrfWithoutAliasCountsOwnArgsOnly() {
+        String[] tokens = serialize(Combiners.<String> rrf().window(20).constant(60));
+
+        assertThat(tokens[0]).isEqualTo("RRF");
+        assertThat(tokens[1]).isEqualTo("4");
+        assertThat(String.join(" ", tokens)).doesNotContain("YIELD_SCORE_AS");
+    }
+
+    @Test
+    void rrfWithAliasCountsYieldScoreAsTokens() {
+        String[] tokens = serialize(Combiners.<String> rrf().window(20).constant(60).as("score"));
+
+        // COMBINE RRF 6 WINDOW 20 CONSTANT 60 YIELD_SCORE_AS score
+        assertThat(tokens[0]).isEqualTo("RRF");
+        assertThat(tokens[1]).isEqualTo("6");
+        assertThat(String.join(" ", tokens)).contains("YIELD_SCORE_AS");
+    }
+
+    @Test
+    void linearWithoutAliasCountsOwnArgsOnly() {
+        String[] tokens = serialize(Combiners.<String> linear().alpha(0.7).beta(0.3));
+
+        assertThat(tokens[0]).isEqualTo("LINEAR");
+        assertThat(tokens[1]).isEqualTo("4");
+        assertThat(String.join(" ", tokens)).doesNotContain("YIELD_SCORE_AS");
+    }
+
+    @Test
+    void linearWithAliasCountsYieldScoreAsTokens() {
+        String[] tokens = serialize(Combiners.<String> linear().alpha(0.7).beta(0.3).as("score"));
+
+        // COMBINE LINEAR 6 ALPHA 0.7 BETA 0.3 YIELD_SCORE_AS score
+        assertThat(tokens[0]).isEqualTo("LINEAR");
+        assertThat(tokens[1]).isEqualTo("6");
+        assertThat(String.join(" ", tokens)).contains("YIELD_SCORE_AS");
+    }
+
+}


### PR DESCRIPTION
Fixes #3811.

`Combiner#build` writes the COMBINE count as `ownArgs.size()`, which omits the two `YIELD_SCORE_AS <alias>` tokens appended when a combined-score alias is set via `Combiner#as`. Redis reads past the clause and rejects the command with `YIELD_SCORE_AS: Unknown argument`, so any hybrid query that sets a combined-score alias fails.

`Combiners.rrf().window(20).constant(60).as("score")` serialized to:

```
COMBINE RRF 4 WINDOW 20 CONSTANT 60 YIELD_SCORE_AS score   # count 4, alias tokens uncounted
```

and now serializes to:

```
COMBINE RRF 6 WINDOW 20 CONSTANT 60 YIELD_SCORE_AS score
```

The two alias tokens are counted only when an alias is present, so the no-alias path is unchanged. Both RRF and LINEAR are affected since `build()` is the shared base method.

Added `CombinerTest` with protocol-level serialization assertions for both combiners, with and without an alias. The two alias cases fail on `main` and pass with this change.

This is the same fix jedis shipped for the identical bug (redis/jedis#4575).

Assisted by Claude Code; I've reviewed the change and verified it locally (`mvn test -Dtest=CombinerTest`: 4 passing).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted protocol serialization fix with unit tests; no auth or data-path changes.
> 
> **Overview**
> Fixes **FT.HYBRID** hybrid queries that set a combined-score alias via `Combiner#as`, which previously failed on Redis with `YIELD_SCORE_AS: Unknown argument`.
> 
> `Combiner#build` now increases the COMBINE `<count>` by **2** when a score alias is present, so the count covers the `YIELD_SCORE_AS` keyword and alias tokens—not only combiner-specific args (RRF/LINEAR paths share this logic; no-alias serialization is unchanged).
> 
> Adds **`CombinerTest`** with protocol-level serialization checks for RRF and LINEAR, with and without an alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1fc8a237c6cc4ede3970d3336e1e631ab54d244. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->