### PR TITLE
Count YIELD_SCORE_AS tokens in FT.HYBRID COMBINE clause #3811

### DIFF
--- a/src/main/java/io/lettuce/core/search/arguments/hybrid/Combiner.java
+++ b/src/main/java/io/lettuce/core/search/arguments/hybrid/Combiner.java
@@ -39,6 +39,7 @@ import io.lettuce.core.protocol.CommandKeyword;
  *
  * @param <K> Key type
  * @author Aleksandar Todorov
+ * @author apoorva-01
  * @since 7.5
  * @see Combiners
  * @see <a href="https://redis.io/docs/latest/commands/ft.hybrid/">FT.HYBRID</a>
@@ -97,7 +98,8 @@ public abstract class Combiner<K> {
         args.add(name);
 
         List<Object> ownArgs = getOwnArgs();
-        args.add(ownArgs.size());
+        // The count must cover the YIELD_SCORE_AS alias pair appended below, otherwise Redis rejects it
+        args.add(ownArgs.size() + (scoreAlias != null ? 2 : 0));
         for (Object arg : ownArgs) {
             args.add(arg);
         }

--- a/src/test/java/io/lettuce/core/RediSearchCommandBuilderUnitTests.java
+++ b/src/test/java/io/lettuce/core/RediSearchCommandBuilderUnitTests.java
@@ -882,6 +882,40 @@ class RediSearchCommandBuilderUnitTests {
                 .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("loadAll()");
     }
 
+    @Test
+    void combinerWithScoreAliasShouldCountYieldScoreAsTokens() {
+        CommandArgs<String, String> args = new CommandArgs<>(new StringCodec());
+        Combiners.<String> rrf().window(20).constant(60).as("score").build(args);
+
+        // The count after RRF must cover the trailing YIELD_SCORE_AS pair, otherwise Redis rejects the alias
+        assertThat(args.toCommandString()).isEqualTo("RRF 6 WINDOW 20 CONSTANT 60.0 YIELD_SCORE_AS key<score>");
+    }
+
+    @Test
+    void linearCombinerWithScoreAliasShouldCountYieldScoreAsTokens() {
+        CommandArgs<String, String> args = new CommandArgs<>(new StringCodec());
+        Combiners.<String> linear().alpha(0.7).beta(0.3).as("combined_score").build(args);
+
+        assertThat(args.toCommandString()).isEqualTo("LINEAR 6 ALPHA 0.7 BETA 0.3 YIELD_SCORE_AS key<combined_score>");
+    }
+
+    @Test
+    void defaultCombinerWithScoreAliasShouldCountYieldScoreAsTokens() {
+        CommandArgs<String, String> args = new CommandArgs<>(new StringCodec());
+        Combiners.<String> rrf().as("score").build(args);
+
+        // No combiner parameters, so the count reflects only the YIELD_SCORE_AS pair
+        assertThat(args.toCommandString()).isEqualTo("RRF 2 YIELD_SCORE_AS key<score>");
+    }
+
+    @Test
+    void combinerWithoutScoreAliasShouldNotCountYieldScoreAs() {
+        CommandArgs<String, String> args = new CommandArgs<>(new StringCodec());
+        Combiners.<String> rrf().window(20).constant(60).build(args);
+
+        assertThat(args.toCommandString()).isEqualTo("RRF 4 WINDOW 20 CONSTANT 60.0");
+    }
+
     private byte[] floatArrayToByteArray(float[] vector) {
         ByteBuffer buffer = ByteBuffer.allocate(vector.length * 4).order(ByteOrder.LITTLE_ENDIAN);
         for (float value : vector) {

--- a/src/test/java/io/lettuce/core/search/FtHybridIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/search/FtHybridIntegrationTests.java
@@ -287,12 +287,12 @@ public class FtHybridIntegrationTests {
     @Test
     @Order(6)
     void hybridWithScoreAliases() {
-        // Test YIELD_SCORE_AS for SEARCH and VSIM
+        // Test YIELD_SCORE_AS for SEARCH, VSIM and the COMBINE combiner
         HybridArgs<String, String> args = HybridArgs.<String, String> builder()
                 .search(HybridSearchArgs.<String, String> builder().query("smartphone").scoreAlias("text_score").build())
                 .vectorSearch(HybridVectorArgs.<String, String> builder().field("@embedding").vector("$vec")
                         .method(HybridVectorArgs.Knn.of(10)).scoreAlias("vector_score").build())
-                .combine(Combiners.<String> rrf().window(20).constant(60))
+                .combine(Combiners.<String> rrf().window(20).constant(60).as("combined_score"))
                 .postProcessing(PostProcessingArgs.<String, String> builder().load("@title", "@brand").build())
                 .param("vec", queryVectorClose).build();
 
@@ -300,8 +300,10 @@ public class FtHybridIntegrationTests {
 
         assertThat(reply).isNotNull();
         assertThat(reply.getResults()).isNotEmpty();
-        // Results should be returned with the aliased scores available
         assertThat(reply.getTotalResults()).isGreaterThan(0);
+        assertThat(reply.getResults()).allSatisfy(result -> assertThat(result).containsKey("combined_score"));
+        assertThat(reply.getResults()).anySatisfy(result -> assertThat(result).containsKey("text_score"));
+        assertThat(reply.getResults()).anySatisfy(result -> assertThat(result).containsKey("vector_score"));
     }
 
     // ==================== TEST 7: Reducers AVG, MIN, MAX ====================


### PR DESCRIPTION
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. (Existing bug report #3811, not a new feature.)
- [x] You applied code formatting rules using the `mvn formatter:format` target.
- [x] You submit test cases (unit or integration tests) that back your changes.

`Combiners.rrf().window(20).constant(60).as("score")` serializes the COMBINE clause as `RRF 4 WINDOW 20 CONSTANT 60 YIELD_SCORE_AS score`, but that count only covers the four combiner params. The `YIELD_SCORE_AS score` pair falls outside it, so Redis rejects the command as an unknown argument. Any hybrid query that sets a score alias is broken.

The count is written in `Combiner.build()` before the alias is appended, so I add the two tokens when an alias is set. It's on the `final` base, so RRF and LINEAR both pick it up. Jedis fixed the twin issue the same way (redis/jedis#4575).

This is `@Experimental`, so one to confirm: the fix assumes the count has to include `YIELD_SCORE_AS` to match how the server parses the clause. If you'd prefer an integration test against a live Redis too, I'll add one.

Heads up: #3831 opened for the same issue while I was wrapping this up. I put mine together independently and it mirrors the Jedis fix, so I'm sending it as an alternative. Glad to defer to whichever you'd rather take.

closes #3811


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow serialization fix in experimental hybrid search command building, with unit and integration coverage and no change when no score alias is used.
> 
> **Overview**
> Fixes **broken `FT.HYBRID` COMBINE clauses** when a combined score alias is set via `Combiners.*.as(...)`. Redis expects the numeric token count after `RRF`/`LINEAR` to cover every following combiner argument, including the **`YIELD_SCORE_AS` + alias** pair; previously only combiner params (e.g. `WINDOW`, `CONSTANT`) were counted, so the server treated the alias as an invalid extra argument.
> 
> `Combiner.build()` now adds **2** to that count when `scoreAlias` is set, which applies to both RRF and LINEAR through the shared base class. **Unit tests** lock the serialized command strings for alias and no-alias cases; the **hybrid integration test** uses `.as("combined_score")` on the combiner and asserts `combined_score`, `text_score`, and `vector_score` appear in results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fac5ecf483cfe0b35ddbe66a3cae264eb0cf175. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->