### PR TITLE
Fix FT.AGGREGATE ADDSCORES argument position

### DIFF
--- a/src/main/java/io/lettuce/core/search/arguments/AggregateArgs.java
+++ b/src/main/java/io/lettuce/core/search/arguments/AggregateArgs.java
@@ -479,6 +479,10 @@ public class AggregateArgs<K, V> {
     public void build(CommandArgs<K, V> args) {
         verbatim.ifPresent(v -> args.add(CommandKeyword.VERBATIM));
 
+        // ADDSCORES is a query-level option and must be emitted before the result-processing pipeline
+        // (GROUPBY/SORTBY/APPLY/...); the server rejects it if it appears after those clauses.
+        addScores.ifPresent(v -> args.add(CommandKeyword.ADDSCORES));
+
         if (!loadFields.isEmpty()) {
             args.add(CommandKeyword.LOAD);
             if (loadFields.size() == 1 && loadFields.get(0).field == null) {
@@ -543,8 +547,6 @@ public class AggregateArgs<K, V> {
             args.add(CommandKeyword.SCORER);
             args.addValue(s);
         });
-
-        addScores.ifPresent(v -> args.add(CommandKeyword.ADDSCORES));
 
         args.add(CommandKeyword.DIALECT);
         args.add(dialect.toString());

--- a/src/test/java/io/lettuce/core/RediSearchCommandBuilderUnitTests.java
+++ b/src/test/java/io/lettuce/core/RediSearchCommandBuilderUnitTests.java
@@ -712,6 +712,7 @@ class RediSearchCommandBuilderUnitTests {
 
         String result = "*42\r\n" + "$12\r\n" + "FT.AGGREGATE\r\n" + "$3\r\n" + "idx\r\n" + "$1\r\n" + "*\r\n"//
                 + "$8\r\n" + "VERBATIM\r\n"//
+                + "$9\r\n" + "ADDSCORES\r\n"//
                 + "$4\r\n" + "LOAD\r\n" + "$1\r\n" + "1\r\n" + "$5\r\n" + "title\r\n"//
                 + "$7\r\n" + "GROUPBY\r\n" + "$1\r\n" + "1\r\n" + "$9\r\n" + "@category\r\n"//
                 + "$6\r\n" + "REDUCE\r\n" + "$5\r\n" + "COUNT\r\n" + "$1\r\n" + "0\r\n" + "$2\r\n" + "AS\r\n" + "$5\r\n"
@@ -724,7 +725,6 @@ class RediSearchCommandBuilderUnitTests {
                 + "$5\r\n" + "10000\r\n"//
                 + "$6\r\n" + "PARAMS\r\n" + "$1\r\n" + "2\r\n" + "$8\r\n" + "category\r\n" + "$11\r\n" + "electronics\r\n"//
                 + "$6\r\n" + "SCORER\r\n" + "$5\r\n" + "TFIDF\r\n"//
-                + "$9\r\n" + "ADDSCORES\r\n"//
                 + "$7\r\n" + "DIALECT\r\n" + "$1\r\n2\r\n";//
 
         assertThat(buf.toString(StandardCharsets.UTF_8)).isEqualTo(result);


### PR DESCRIPTION
AggregateArgs.build() emitted ADDSCORES after the result-processing pipeline (LOAD/APPLY/SORTBY/PARAMS/SCORER), but RediSearch only accepts ADDSCORES as an early query-level option (like VERBATIM). Any AggregateArgs.addScores() combined with a pipeline therefore failed with "SEARCH_ARG_UNRECOGNIZED Unknown argument `ADDSCORES`".

Emit ADDSCORES right after VERBATIM (before the pipeline) and update the command-builder unit test accordingly.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small protocol argument-order fix in RediSearch command encoding with an updated unit test; no auth or data-path changes.
> 
> **Overview**
> **`AggregateArgs.build()`** now serializes **`ADDSCORES`** immediately after **`VERBATIM`** and before **`LOAD`** / pipeline steps (**`GROUPBY`**, **`SORTBY`**, **`APPLY`**, etc.), matching RediSearch’s query-level option ordering.
> 
> Previously **`ADDSCORES`** was appended near **`SCORER`** / **`DIALECT`**, so **`addScores()`** together with any pipeline caused **`SEARCH_ARG_UNRECOGNIZED Unknown argument ADDSCORES`**. The **`FT.AGGREGATE`** command-builder unit test expected RESP was updated to reflect the new argument order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9412470828f5ee49dcf7098ccd88c33513a4c7cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->