### PR TITLE
[reactor-optional] Deprecate Context utils

### DIFF
--- a/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
+++ b/src/main/java/io/lettuce/core/AbstractRedisReactiveCommands.java
@@ -83,7 +83,6 @@ import io.lettuce.core.search.arguments.SugGetArgs;
 import io.lettuce.core.search.arguments.SynUpdateArgs;
 import io.lettuce.core.tracing.TraceContext;
 import io.lettuce.core.tracing.TraceContextProvider;
-import io.lettuce.core.tracing.Tracing;
 import io.lettuce.core.vector.RawVector;
 import io.lettuce.core.vector.VSimScoreAttribs;
 import io.lettuce.core.vector.VectorMetadata;
@@ -91,12 +90,14 @@ import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.context.Context;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -782,9 +783,52 @@ public abstract class AbstractRedisReactiveCommands<K, V>
 
     private Mono<TraceContext> withTraceContext() {
 
-        return Tracing.getContext()
+        return ReactorTraceContext.getContext()
                 .switchIfEmpty(Mono.fromSupplier(() -> clientResources.tracing().initialTraceContextProvider()))
                 .flatMap(TraceContextProvider::getTraceContextLater).defaultIfEmpty(TraceContext.EMPTY);
+    }
+
+    /**
+     * Helpers for propagating a {@link TraceContextProvider} through a Reactor {@link Context} on the reactive command path.
+     *
+     * @author Aleksandar Todorov
+     * @since 7.7
+     */
+    public static final class ReactorTraceContext {
+
+        private ReactorTraceContext() {
+        }
+
+        /**
+         * Gets the {@link TraceContextProvider} from the Reactor {@link Context}.
+         *
+         * @return a {@link Mono} emitting the {@link TraceContextProvider} held in the subscriber {@link Context}, if any.
+         */
+        public static Mono<TraceContextProvider> getContext() {
+            return Mono.deferContextual(Mono::justOrEmpty).filter(c -> c.hasKey(TraceContextProvider.class))
+                    .map(c -> c.get(TraceContextProvider.class));
+        }
+
+        /**
+         * Returns a {@link Function} that clears the {@link TraceContextProvider} from a Reactor {@link Context}.
+         *
+         * @return a {@link Function} that removes the {@link TraceContextProvider} from a {@link Context}.
+         */
+        public static Function<Context, Context> clearContext() {
+            return context -> context.delete(TraceContextProvider.class);
+        }
+
+        /**
+         * Creates a Reactor {@link Context} holding the given {@link TraceContextProvider} that can be merged into another
+         * {@link Context}.
+         *
+         * @param provider the {@link TraceContextProvider} to place into the returned Reactor {@link Context}.
+         * @return a Reactor {@link Context} containing the {@link TraceContextProvider}.
+         */
+        public static Context withTraceContextProvider(TraceContextProvider provider) {
+            return Context.of(TraceContextProvider.class, provider);
+        }
+
     }
 
     protected <T> Mono<T> createMono(CommandType type, CommandOutput<K, V, T> output, CommandArgs<K, V> args) {

--- a/src/main/java/io/lettuce/core/tracing/Tracing.java
+++ b/src/main/java/io/lettuce/core/tracing/Tracing.java
@@ -80,31 +80,41 @@ public interface Tracing {
     }
 
     /**
-     * Gets the {@link TraceContextProvider} from Reactor {@link Context}.
+     * Gets the {@link TraceContextProvider} from the Reactor {@link Context}.
      *
-     * @return the {@link TraceContextProvider}.
+     * @return a {@link Mono} emitting the {@link TraceContextProvider} held in the subscriber {@link Context}, if any.
+     * @deprecated since 7.7, use {@link io.lettuce.core.AbstractRedisReactiveCommands.ReactorTraceContext#getContext()}
+     *             instead; scheduled for removal in Lettuce 8.0.
      */
+    @Deprecated
     static Mono<TraceContextProvider> getContext() {
         return Mono.deferContextual(Mono::justOrEmpty).filter(c -> c.hasKey(TraceContextProvider.class))
                 .map(c -> c.get(TraceContextProvider.class));
     }
 
     /**
-     * Clears the {@code Mono<TracerProvider>} from Reactor {@link Context}.
+     * Returns a {@link Function} that clears the {@link TraceContextProvider} from a Reactor {@link Context}.
      *
-     * @return Return a {@link Function} that clears the {@link TraceContextProvider} context.
+     * @return a {@link Function} that removes the {@link TraceContextProvider} from a {@link Context}.
+     * @deprecated since 7.7, use {@link io.lettuce.core.AbstractRedisReactiveCommands.ReactorTraceContext#clearContext()}
+     *             instead; scheduled for removal in Lettuce 8.0.
      */
+    @Deprecated
     static Function<Context, Context> clearContext() {
         return context -> context.delete(TraceContextProvider.class);
     }
 
     /**
-     * Creates a Reactor {@link Context} that contains the {@code Mono<TraceContextProvider>}. that can be merged into another
+     * Creates a Reactor {@link Context} holding the given {@link TraceContextProvider} that can be merged into another
      * {@link Context}.
      *
-     * @param supplier the {@link TraceContextProvider} to set in the returned Reactor {@link Context}.
-     * @return a Reactor {@link Context} that contains the {@code Mono<TraceContextProvider>}.
+     * @param supplier the {@link TraceContextProvider} to place into the returned Reactor {@link Context}.
+     * @return a Reactor {@link Context} containing the {@link TraceContextProvider}.
+     * @deprecated since 7.7, use
+     *             {@link io.lettuce.core.AbstractRedisReactiveCommands.ReactorTraceContext#withTraceContextProvider(TraceContextProvider)}
+     *             instead; scheduled for removal in Lettuce 8.0.
      */
+    @Deprecated
     static Context withTraceContextProvider(TraceContextProvider supplier) {
         return Context.of(TraceContextProvider.class, supplier);
     }

--- a/src/test/java/io/lettuce/core/tracing/BraveTracingIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/tracing/BraveTracingIntegrationTests.java
@@ -28,6 +28,7 @@ import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import io.lettuce.core.AbstractRedisReactiveCommands.ReactorTraceContext;
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.MaintNotificationsConfig;
 import org.junit.jupiter.api.AfterAll;
@@ -243,7 +244,7 @@ class BraveTracingIntegrationTests extends TestSupport {
 
         StatefulRedisConnection<String, String> connect = client.connect();
         connect.reactive().set("foo", "bar").then(connect.reactive().get("foo"))
-                .contextWrite(io.lettuce.core.tracing.Tracing
+                .contextWrite(ReactorTraceContext
                         .withTraceContextProvider(() -> BraveTracing.BraveTraceContext.create(trace.context()))) //
                 .as(StepVerifier::create) //
                 .expectNext("bar").verifyComplete();


### PR DESCRIPTION
Part of #3614 and follow up of #3827 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving API relocation with deprecations; only reactive tracing context wiring and call-site migration in tests change.
> 
> **Overview**
> Moves **Reactor `Context` helpers** for trace propagation off `Tracing` and onto a new public nested type **`AbstractRedisReactiveCommands.ReactorTraceContext`** (`getContext`, `clearContext`, `withTraceContextProvider`). Reactive command creation now reads trace context via **`ReactorTraceContext.getContext()`** instead of **`Tracing.getContext()`**.
> 
> The three equivalent **`Tracing` static methods** are **deprecated since 7.7** (removal in 8.0) with Javadoc pointing to `ReactorTraceContext`. **`BraveTracingIntegrationTests`** is updated to use **`ReactorTraceContext.withTraceContextProvider`** for `contextWrite`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d9396a72aca2cfe8b6b26a03616134597a89b09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->