### PR TITLE
[reactor-optional] Remove deprecated Context utils

### DIFF
--- a/src/main/java/io/lettuce/core/tracing/Tracing.java
+++ b/src/main/java/io/lettuce/core/tracing/Tracing.java
@@ -20,10 +20,6 @@
 package io.lettuce.core.tracing;
 
 import java.net.SocketAddress;
-import java.util.function.Function;
-
-import reactor.core.publisher.Mono;
-import reactor.util.context.Context;
 
 /**
  * Interface declaring methods to trace Redis commands. This interface contains declarations of basic required interfaces and
@@ -77,46 +73,6 @@ public interface Tracing {
      */
     static Tracing disabled() {
         return NoOpTracing.INSTANCE;
-    }
-
-    /**
-     * Gets the {@link TraceContextProvider} from the Reactor {@link Context}.
-     *
-     * @return a {@link Mono} emitting the {@link TraceContextProvider} held in the subscriber {@link Context}, if any.
-     * @deprecated since 7.7, use {@link io.lettuce.core.AbstractRedisReactiveCommands.ReactorTraceContext#getContext()}
-     *             instead; scheduled for removal in Lettuce 8.0.
-     */
-    @Deprecated
-    static Mono<TraceContextProvider> getContext() {
-        return Mono.deferContextual(Mono::justOrEmpty).filter(c -> c.hasKey(TraceContextProvider.class))
-                .map(c -> c.get(TraceContextProvider.class));
-    }
-
-    /**
-     * Returns a {@link Function} that clears the {@link TraceContextProvider} from a Reactor {@link Context}.
-     *
-     * @return a {@link Function} that removes the {@link TraceContextProvider} from a {@link Context}.
-     * @deprecated since 7.7, use {@link io.lettuce.core.AbstractRedisReactiveCommands.ReactorTraceContext#clearContext()}
-     *             instead; scheduled for removal in Lettuce 8.0.
-     */
-    @Deprecated
-    static Function<Context, Context> clearContext() {
-        return context -> context.delete(TraceContextProvider.class);
-    }
-
-    /**
-     * Creates a Reactor {@link Context} holding the given {@link TraceContextProvider} that can be merged into another
-     * {@link Context}.
-     *
-     * @param supplier the {@link TraceContextProvider} to place into the returned Reactor {@link Context}.
-     * @return a Reactor {@link Context} containing the {@link TraceContextProvider}.
-     * @deprecated since 7.7, use
-     *             {@link io.lettuce.core.AbstractRedisReactiveCommands.ReactorTraceContext#withTraceContextProvider(TraceContextProvider)}
-     *             instead; scheduled for removal in Lettuce 8.0.
-     */
-    @Deprecated
-    static Context withTraceContextProvider(TraceContextProvider supplier) {
-        return Context.of(TraceContextProvider.class, supplier);
     }
 
     /**


### PR DESCRIPTION
Part of #3614 and follow up of #3834

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public tracing API surface is reduced, so downstream code still calling the removed deprecated methods will fail at compile time; behavior inside Lettuce should be unchanged because call sites already use `ReactorTraceContext`.
> 
> **Overview**
> Removes the **deprecated** Reactor `Context` helpers from `Tracing` (`getContext`, `clearContext`, `withTraceContextProvider`) and drops the related Reactor imports from that interface.
> 
> This continues the reactor-optional work by deleting APIs that were superseded in 7.7 by `AbstractRedisReactiveCommands.ReactorTraceContext`, which the reactive command path and tracing tests already use for trace propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e70bdb621a525ca525776fc6730877da32ef0b48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->