### PR TITLE
ci: run full Redis version matrix only nightly

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,14 +35,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redis_version:
-          - "8.8"
-          - "8.6"
-          - "8.4"
-          - "8.2"
-          - "8.0"
-          - "7.4"
-          - "7.2"
+        # Full version set runs only on the nightly schedule; PRs and pushes
+        # test a reduced set (7.2 LTS, 7.4 LTS, 8.2 LTS, 8.8 current stable, 8.10 - next) to keep CI fast.
+        redis_version: ${{ fromJSON(github.event_name == 'schedule'
+          && '["8.10", "8.8", "8.6", "8.4", "8.2", "7.4", "7.2"]'
+          || '["8.10", "8.8", "8.2", "7.4", "7.2"]') }}
     uses: ./.github/workflows/run-tests.yml
     with:
       redis_version: ${{ matrix.redis_version }}

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 PATH := ./work/redis-git/src:${PATH}
 ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 PROFILE ?= ci
-SUPPORTED_TEST_ENV_VERSIONS := 8.8 8.6 8.4 8.2 8.0 7.4 7.2
+SUPPORTED_TEST_ENV_VERSIONS := 8.10 8.8 8.6 8.4 8.2 8.0 7.4 7.2
 DEFAULT_TEST_ENV_VERSION := 8.8
 export REDIS_ENV_WORK_DIR := $(or ${REDIS_ENV_WORK_DIR},$(ROOT_DIR)/work)
 MVN_SOCKET_ARGS := -Ddomainsocket="$(REDIS_ENV_WORK_DIR)/socket-6482" -Dsentineldomainsocket="$(REDIS_ENV_WORK_DIR)/socket-26379"

--- a/src/test/resources/docker-env/.env.v8.10
+++ b/src/test/resources/docker-env/.env.v8.10
@@ -1,0 +1,3 @@
+REDIS_ENV_WORK_DIR=../../../../work/docker
+REDIS_VERSION=custom-28772936538-debian
+REDIS_STACK_VERSION=custom-28772936538-debian

--- a/src/test/resources/docker-env/.env.v8.8
+++ b/src/test/resources/docker-env/.env.v8.8
@@ -1,0 +1,3 @@
+REDIS_ENV_WORK_DIR=../../../../work/docker
+REDIS_VERSION=8.8.0
+REDIS_STACK_VERSION=8.8.0


### PR DESCRIPTION
PRs and pushes now test a reduced set of LTS+current+next (7.2, 7.4, 8.2, 8.8, 8.10); the STS versions (8.4, 8.6) run only on the nightly schedule to keep PR CI fast.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect CI matrix selection and test docker env files; no application or runtime behavior changes.
> 
> **Overview**
> **PR/push CI** now runs integration tests against a smaller Redis matrix (**7.2**, **7.4**, **8.2**, **8.8**, **8.10**); the **nightly `schedule`** job still exercises the full set including **8.4** and **8.6** (and drops **8.0** from the listed matrix in favor of **8.10**).
> 
> Local/docker test support adds **8.10** to `SUPPORTED_TEST_ENV_VERSIONS` in the **Makefile**, plus new **`docker-env/.env.v8.10`** (custom image tags) and **`.env.v8.8`** (pinned **8.8.0** stack/redis versions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0d37959dfb1ec70a1d2927ac03dbc5560cddc8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->