### PR TITLE
[reactor-optional] Fix remaining reactive leakage

### DIFF
--- a/src/main/java/io/lettuce/core/RedisClient.java
+++ b/src/main/java/io/lettuce/core/RedisClient.java
@@ -25,12 +25,11 @@ import static io.lettuce.core.internal.LettuceStrings.*;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -57,7 +56,6 @@ import io.lettuce.core.sentinel.StatefulRedisSentinelConnectionImpl;
 import io.lettuce.core.sentinel.api.StatefulRedisSentinelConnection;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import reactor.core.publisher.Mono;
 
 /**
  * A scalable and thread-safe <a href="https://redis.io/">Redis</a> client supporting synchronous, asynchronous and reactive
@@ -524,46 +522,44 @@ public class RedisClient extends AbstractRedisClient {
         }
 
         List<RedisURI> sentinels = redisURI.getSentinels();
-        Queue<Throwable> exceptionCollector = new LinkedBlockingQueue<>();
         validateUrisAreOfSameConnectionType(sentinels);
 
-        Mono<StatefulRedisSentinelConnection<K, V>> connectionLoop = null;
+        if (sentinels.isEmpty()) {
+            return Futures
+                    .failed(new RedisConnectionException("Cannot connect to a Redis Sentinel: " + redisURI.getSentinels()));
+        }
 
+        List<Supplier<CompletionStage<StatefulRedisSentinelConnection<K, V>>>> attempts = new ArrayList<>(sentinels.size());
         for (RedisURI uri : sentinels) {
-
-            Mono<StatefulRedisSentinelConnection<K, V>> connectionMono = Mono
-                    .fromCompletionStage(() -> doConnectSentinelAsync(codec, uri, timeout, new ConnectionMetadata(redisURI)))
-                    .onErrorMap(CompletionException.class, Throwable::getCause)
-                    .onErrorMap(e -> new RedisConnectionException("Cannot connect Redis Sentinel at " + uri, e))
-                    .doOnError(exceptionCollector::add);
-
-            if (connectionLoop == null) {
-                connectionLoop = connectionMono;
-            } else {
-                connectionLoop = connectionLoop.onErrorResume(t -> connectionMono);
-            }
+            attempts.add(() -> {
+                CompletableFuture<StatefulRedisSentinelConnection<K, V>> attempt = new CompletableFuture<>();
+                doConnectSentinelAsync(codec, uri, timeout, new ConnectionMetadata(redisURI)).whenComplete((connection, e) -> {
+                    if (e != null) {
+                        Throwable cause = e instanceof CompletionException && e.getCause() != null ? e.getCause() : e;
+                        attempt.completeExceptionally(
+                                new RedisConnectionException("Cannot connect Redis Sentinel at " + uri, cause));
+                    } else {
+                        attempt.complete(connection);
+                    }
+                });
+                return attempt;
+            });
         }
 
-        if (connectionLoop == null) {
-            return Mono
-                    .<StatefulRedisSentinelConnection<K, V>> error(
-                            new RedisConnectionException("Cannot connect to a Redis Sentinel: " + redisURI.getSentinels()))
-                    .toFuture();
-        }
+        return Futures.firstSuccess(attempts, errors -> {
 
-        return connectionLoop.onErrorMap(e -> {
-
+            Throwable last = errors.get(errors.size() - 1);
             RedisConnectionException ex = new RedisConnectionException(
-                    "Cannot connect to a Redis Sentinel: " + redisURI.getSentinels(), e);
+                    "Cannot connect to a Redis Sentinel: " + redisURI.getSentinels(), last);
 
-            for (Throwable throwable : exceptionCollector) {
-                if (e != throwable) {
+            for (Throwable throwable : errors) {
+                if (throwable != last) {
                     ex.addSuppressed(throwable);
                 }
             }
 
             return ex;
-        }).toFuture();
+        });
     }
 
     private <K, V> ConnectionFuture<StatefulRedisSentinelConnection<K, V>> doConnectSentinelAsync(RedisCodec<K, V> codec,

--- a/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
@@ -72,7 +72,6 @@ import io.lettuce.core.pubsub.StatefulRedisPubSubConnectionImpl;
 import io.lettuce.core.resource.ClientResources;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import reactor.core.publisher.Mono;
 
 import static io.lettuce.core.RedisAuthenticationHandler.createHandler;
 
@@ -704,18 +703,14 @@ public class RedisClusterClient extends AbstractRedisClient {
                 endpoint);
         Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = getSocketAddressSupplier(connection::getPartitions,
                 TopologyComparators::sortByClientCount);
-        Mono<StatefulRedisClusterConnectionImpl<K, V>> connectionMono = Mono
-                .defer(() -> connect(socketAddressSupplier, endpoint, connection, commandHandlerSupplier));
+        Supplier<CompletionStage<StatefulRedisClusterConnectionImpl<K, V>>> connectSupplier = () -> connect(
+                socketAddressSupplier, endpoint, connection, commandHandlerSupplier);
 
-        for (int i = 1; i < getConnectionAttempts(); i++) {
-            connectionMono = connectionMono
-                    .onErrorResume(t -> connect(socketAddressSupplier, endpoint, connection, commandHandlerSupplier));
-        }
-
-        return connectionMono
-                .doOnNext(
-                        c -> connection.registerCloseables(closeableResources, clusterWriter, pooledClusterConnectionProvider))
-                .map(it -> (StatefulRedisClusterConnection<K, V>) it).toFuture();
+        return Futures.firstSuccess(Collections.nCopies(getConnectionAttempts(), connectSupplier),
+                errors -> errors.get(errors.size() - 1)).thenApply(it -> {
+                    connection.registerCloseables(closeableResources, clusterWriter, pooledClusterConnectionProvider);
+                    return (StatefulRedisClusterConnection<K, V>) it;
+                });
     }
 
     /**
@@ -756,22 +751,32 @@ public class RedisClusterClient extends AbstractRedisClient {
         return new StatefulRedisClusterConnectionImpl(channelWriter, pushHandler, codec, timeout);
     }
 
-    private <T, K, V> Mono<T> connect(Supplier<CompletionStage<SocketAddress>> socketAddressSupplier, DefaultEndpoint endpoint,
-            StatefulRedisClusterConnectionImpl<K, V> connection, Supplier<CommandHandler> commandHandlerSupplier) {
+    private <T, K, V> CompletionStage<T> connect(Supplier<CompletionStage<SocketAddress>> socketAddressSupplier,
+            DefaultEndpoint endpoint, StatefulRedisClusterConnectionImpl<K, V> connection,
+            Supplier<CommandHandler> commandHandlerSupplier) {
 
         ConnectionFuture<T> future = connectStatefulAsync(connection, endpoint, getFirstUri(), socketAddressSupplier,
                 commandHandlerSupplier);
 
-        return Mono.fromCompletionStage(future).doOnError(t -> logger.warn(t.getMessage()));
+        return future.whenComplete((c, t) -> {
+            if (t != null) {
+                logger.warn(t.getMessage());
+            }
+        });
     }
 
-    private <T, K, V> Mono<T> connect(Supplier<CompletionStage<SocketAddress>> socketAddressSupplier, DefaultEndpoint endpoint,
-            StatefulRedisConnectionImpl<K, V> connection, Supplier<CommandHandler> commandHandlerSupplier) {
+    private <T, K, V> CompletionStage<T> connect(Supplier<CompletionStage<SocketAddress>> socketAddressSupplier,
+            DefaultEndpoint endpoint, StatefulRedisConnectionImpl<K, V> connection,
+            Supplier<CommandHandler> commandHandlerSupplier) {
 
         ConnectionFuture<T> future = connectStatefulAsync(connection, endpoint, getFirstUri(), socketAddressSupplier,
                 commandHandlerSupplier);
 
-        return Mono.fromCompletionStage(future).doOnError(t -> logger.warn(t.getMessage()));
+        return future.whenComplete((c, t) -> {
+            if (t != null) {
+                logger.warn(t.getMessage());
+            }
+        });
     }
 
     /**
@@ -823,18 +828,14 @@ public class RedisClusterClient extends AbstractRedisClient {
                 getResources(), codec, endpoint);
         Supplier<CompletionStage<SocketAddress>> socketAddressSupplier = getSocketAddressSupplier(connection::getPartitions,
                 TopologyComparators::sortByClientCount);
-        Mono<StatefulRedisClusterPubSubConnectionImpl<K, V>> connectionMono = Mono
-                .defer(() -> connect(socketAddressSupplier, endpoint, connection, commandHandlerSupplier));
+        Supplier<CompletionStage<StatefulRedisClusterPubSubConnectionImpl<K, V>>> connectSupplier = () -> connect(
+                socketAddressSupplier, endpoint, connection, commandHandlerSupplier);
 
-        for (int i = 1; i < getConnectionAttempts(); i++) {
-            connectionMono = connectionMono
-                    .onErrorResume(t -> connect(socketAddressSupplier, endpoint, connection, commandHandlerSupplier));
-        }
-
-        return connectionMono
-                .doOnNext(
-                        c -> connection.registerCloseables(closeableResources, clusterWriter, pooledClusterConnectionProvider))
-                .map(it -> (StatefulRedisClusterPubSubConnection<K, V>) it).toFuture();
+        return Futures.firstSuccess(Collections.nCopies(getConnectionAttempts(), connectSupplier),
+                errors -> errors.get(errors.size() - 1)).thenApply(it -> {
+                    connection.registerCloseables(closeableResources, clusterWriter, pooledClusterConnectionProvider);
+                    return (StatefulRedisClusterPubSubConnection<K, V>) it;
+                });
     }
 
     private int getConnectionAttempts() {

--- a/src/main/java/io/lettuce/core/internal/Futures.java
+++ b/src/main/java/io/lettuce/core/internal/Futures.java
@@ -1,8 +1,12 @@
 package io.lettuce.core.internal;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.*;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import io.lettuce.core.RedisFuture;
 import io.lettuce.core.resource.ClientResources;
@@ -301,6 +305,51 @@ public abstract class Futures {
         });
 
         return result;
+    }
+
+    /**
+     * Attempt a sequence of asynchronous operations in order, completing with the result of the first successful attempt. Each
+     * supplier is invoked lazily, only once the preceding attempt has failed. If every attempt fails, the returned future
+     * completes exceptionally with the result of applying {@code errorHandler} to the failures collected in attempt order.
+     *
+     * @param attempts the ordered attempts; must not be {@code null} and must not be empty.
+     * @param errorHandler produces the terminal failure from the collected errors; must not be {@code null}.
+     * @param <T> result type.
+     * @return a {@link CompletableFuture} completing with the first successful result or the aggregated failure.
+     */
+    public static <T> CompletableFuture<T> firstSuccess(List<? extends Supplier<? extends CompletionStage<T>>> attempts,
+            Function<List<Throwable>, Throwable> errorHandler) {
+
+        CompletableFuture<T> result = new CompletableFuture<>();
+        attempt(attempts, 0, new ArrayList<>(), errorHandler, result);
+        return result;
+    }
+
+    private static <T> void attempt(List<? extends Supplier<? extends CompletionStage<T>>> attempts, int index,
+            List<Throwable> errors, Function<List<Throwable>, Throwable> errorHandler, CompletableFuture<T> result) {
+
+        if (index >= attempts.size()) {
+            result.completeExceptionally(errorHandler.apply(errors));
+            return;
+        }
+
+        CompletionStage<T> stage;
+        try {
+            stage = attempts.get(index).get();
+        } catch (Throwable t) {
+            errors.add(t);
+            attempt(attempts, index + 1, errors, errorHandler, result);
+            return;
+        }
+
+        stage.whenComplete((value, error) -> {
+            if (error != null) {
+                errors.add(error);
+                attempt(attempts, index + 1, errors, errorHandler, result);
+            } else {
+                result.complete(value);
+            }
+        });
     }
 
 }

--- a/src/test/java/io/lettuce/core/internal/FuturesUnitTests.java
+++ b/src/test/java/io/lettuce/core/internal/FuturesUnitTests.java
@@ -7,13 +7,19 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -163,6 +169,65 @@ class FuturesUnitTests {
         RuntimeException boom = new RuntimeException("boom");
         source.completeExceptionally(boom);
         assertThatThrownBy(() -> result.get(2, SECONDS)).hasCause(boom);
+    }
+
+    @Test
+    void firstSuccessReturnsFirstResultAndSkipsRemainingAttempts() throws Exception {
+        AtomicInteger invocations = new AtomicInteger();
+        List<Supplier<CompletionStage<String>>> attempts = Arrays.asList(() -> {
+            invocations.incrementAndGet();
+            return CompletableFuture.completedFuture("first");
+        }, () -> {
+            invocations.incrementAndGet();
+            return CompletableFuture.completedFuture("second");
+        });
+
+        CompletableFuture<String> result = Futures.firstSuccess(attempts, errors -> new IllegalStateException());
+
+        assertThat(result.get(2, SECONDS)).isEqualTo("first");
+        assertThat(invocations).hasValue(1);
+    }
+
+    @Test
+    void firstSuccessFallsThroughToLaterAttempt() throws Exception {
+        List<Supplier<CompletionStage<String>>> attempts = Arrays.asList(() -> Futures.failed(new RuntimeException("nope")),
+                () -> CompletableFuture.completedFuture("recovered"));
+
+        CompletableFuture<String> result = Futures.firstSuccess(attempts, errors -> new IllegalStateException());
+
+        assertThat(result.get(2, SECONDS)).isEqualTo("recovered");
+    }
+
+    @Test
+    void firstSuccessAggregatesFailuresInOrderWhenAllFail() {
+        RuntimeException e1 = new RuntimeException("e1");
+        RuntimeException e2 = new RuntimeException("e2");
+        List<Supplier<CompletionStage<String>>> attempts = Arrays.asList(() -> Futures.failed(e1), () -> Futures.failed(e2));
+
+        Function<List<Throwable>, Throwable> aggregator = errors -> {
+            Throwable last = errors.get(errors.size() - 1);
+            RuntimeException aggregate = new RuntimeException("all failed", last);
+            for (Throwable t : errors) {
+                if (t != last) {
+                    aggregate.addSuppressed(t);
+                }
+            }
+            return aggregate;
+        };
+
+        CompletableFuture<String> result = Futures.firstSuccess(attempts, aggregator);
+
+        Throwable aggregate = null;
+        try {
+            result.get(2, SECONDS);
+        } catch (ExecutionException e) {
+            aggregate = e.getCause();
+        } catch (InterruptedException | TimeoutException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        assertThat(aggregate).hasMessage("all failed").hasCause(e2);
+        assertThat(aggregate.getSuppressed()).containsExactly(e1);
     }
 
 }


### PR DESCRIPTION
Follow up of #3697 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core connection establishment for Sentinel and Redis Cluster with behavioral parity intended, but retry/fallback timing and exception chaining differ from the previous Reactor implementation.
> 
> **Overview**
> Removes **Project Reactor `Mono`** from Sentinel and cluster connection setup, continuing the reactor-optional work from #3697.
> 
> Adds **`Futures.firstSuccess`**, which runs ordered async attempts lazily (next attempt only after the previous fails) and completes with the first success or an aggregated failure from a custom error handler.
> 
> **`RedisClient`** Sentinel multi-endpoint connect now builds per-URI `CompletionStage` suppliers and uses `firstSuccess` instead of chaining `onErrorResume` on a `Mono` loop; failure handling still wraps causes in `RedisConnectionException` and attaches suppressed errors from earlier attempts.
> 
> **`RedisClusterClient`** cluster and cluster pub/sub connect paths use the same helper with repeated connect suppliers (one per connection attempt). Internal `connect` helpers return **`CompletionStage`** directly with `whenComplete` for warn logging instead of `Mono.fromCompletionStage`.
> 
> Unit tests cover early success, fallback after failure, and ordered failure aggregation for `firstSuccess`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8128d3848cfa661dc3973157b1c0e8eccf3e09f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->