### PR TITLE
[reactor-optional] Credentials as adapter 8x

### DIFF
--- a/src/main/java/io/lettuce/authx/TokenBasedRedisCredentialsProvider.java
+++ b/src/main/java/io/lettuce/authx/TokenBasedRedisCredentialsProvider.java
@@ -11,6 +11,7 @@ import io.lettuce.core.RedisCredentialsProvider;
 import io.lettuce.core.internal.LettuceAssert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
 import redis.clients.authentication.core.Token;
 import redis.clients.authentication.core.TokenAuthConfig;
 import redis.clients.authentication.core.TokenListener;
@@ -205,7 +206,7 @@ public class TokenBasedRedisCredentialsProvider implements RedisCredentialsProvi
      * @return a {@link CompletionStage} that completes with the latest Redis credentials
      */
     @Override
-    public CompletionStage<RedisCredentials> resolveCredentials() {
+    public CompletionStage<RedisCredentials> resolveCredentialsAsync() {
         CompletableFuture<RedisCredentials> result = new CompletableFuture<>();
         credentialsFutureRef.get().whenComplete((creds, throwable) -> {
             if (throwable != null) {
@@ -215,6 +216,17 @@ public class TokenBasedRedisCredentialsProvider implements RedisCredentialsProvi
             }
         });
         return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Reactive view over {@link #resolveCredentialsAsync()}, retained for the deprecated {@link RedisCredentialsProvider}
+     * contract. The reactor-free {@link #resolveCredentialsAsync()} is used on the driver's authentication path.
+     */
+    @Override
+    public Mono<RedisCredentials> resolveCredentials() {
+        return Mono.fromCompletionStage(resolveCredentialsAsync());
     }
 
     @Override
@@ -280,7 +292,7 @@ public class TokenBasedRedisCredentialsProvider implements RedisCredentialsProvi
      * <ul>
      * <li>Subscriber {@code onNext}/{@code onError} callbacks for live token renewals run on the {@link TokenManager}'s renewal
      * thread. A slow or blocking subscriber can delay or miss subsequent renewals.</li>
-     * <li>Continuations chained off {@link #resolveCredentials()} run on the renewal thread when the initial future
+     * <li>Continuations chained off {@link #resolveCredentialsAsync()} run on the renewal thread when the initial future
      * completes.</li>
      * <li>Replay deliveries to a newly subscribing consumer run on the subscribing thread.</li>
      * </ul>
@@ -323,7 +335,7 @@ public class TokenBasedRedisCredentialsProvider implements RedisCredentialsProvi
      * <ul>
      * <li>Subscriber {@code onNext}/{@code onError} callbacks for live token renewals run on the {@link TokenManager}'s renewal
      * thread. A slow or blocking subscriber can delay or miss subsequent renewals.</li>
-     * <li>Continuations chained off {@link #resolveCredentials()} run on the renewal thread when the initial future
+     * <li>Continuations chained off {@link #resolveCredentialsAsync()} run on the renewal thread when the initial future
      * completes.</li>
      * <li>Replay deliveries to a newly subscribing consumer run on the subscribing thread.</li>
      * </ul>

--- a/src/main/java/io/lettuce/authx/TokenBasedRedisCredentialsProvider.java
+++ b/src/main/java/io/lettuce/authx/TokenBasedRedisCredentialsProvider.java
@@ -6,13 +6,12 @@
  */
 package io.lettuce.authx;
 
+import io.lettuce.core.CredentialsProvider;
 import io.lettuce.core.RedisCredentials;
-import io.lettuce.core.RedisCredentialsProvider;
 import io.lettuce.core.Subscription;
 import io.lettuce.core.internal.LettuceAssert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.core.publisher.Mono;
 import redis.clients.authentication.core.Token;
 import redis.clients.authentication.core.TokenAuthConfig;
 import redis.clients.authentication.core.TokenListener;
@@ -27,7 +26,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 /**
- * A {@link RedisCredentialsProvider} implementation that supports token-based authentication for Redis.
+ * A {@link CredentialsProvider} implementation that supports token-based authentication for Redis.
  * <p>
  * This provider uses a {@link TokenManager} to manage and renew tokens, ensuring that the Redis client can authenticate with
  * Redis using a dynamically updated token. This is particularly useful in scenarios where Redis access is controlled via
@@ -50,7 +49,7 @@ import java.util.function.Consumer;
  *
  * @since 6.6
  */
-public class TokenBasedRedisCredentialsProvider implements RedisCredentialsProvider, AutoCloseable {
+public class TokenBasedRedisCredentialsProvider implements CredentialsProvider, AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(TokenBasedRedisCredentialsProvider.class);
 
@@ -217,17 +216,6 @@ public class TokenBasedRedisCredentialsProvider implements RedisCredentialsProvi
             }
         });
         return result;
-    }
-
-    /**
-     * {@inheritDoc}
-     * <p>
-     * Reactive view over {@link #resolveCredentialsAsync()}, retained for the deprecated {@link RedisCredentialsProvider}
-     * contract. The reactor-free {@link #resolveCredentialsAsync()} is used on the driver's authentication path.
-     */
-    @Override
-    public Mono<RedisCredentials> resolveCredentials() {
-        return Mono.fromCompletionStage(resolveCredentialsAsync());
     }
 
     @Override

--- a/src/main/java/io/lettuce/authx/TokenBasedRedisCredentialsProvider.java
+++ b/src/main/java/io/lettuce/authx/TokenBasedRedisCredentialsProvider.java
@@ -8,6 +8,7 @@ package io.lettuce.authx;
 
 import io.lettuce.core.RedisCredentials;
 import io.lettuce.core.RedisCredentialsProvider;
+import io.lettuce.core.Subscription;
 import io.lettuce.core.internal.LettuceAssert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,7 +54,7 @@ public class TokenBasedRedisCredentialsProvider implements RedisCredentialsProvi
 
     private static final Logger log = LoggerFactory.getLogger(TokenBasedRedisCredentialsProvider.class);
 
-    private static class SimpleSubscription implements CredentialsSubscription {
+    private static class SimpleSubscription implements Subscription {
 
         private final TokenBasedRedisCredentialsProvider provider;
 
@@ -230,7 +231,7 @@ public class TokenBasedRedisCredentialsProvider implements RedisCredentialsProvi
     }
 
     @Override
-    public CredentialsSubscription subscribeToCredentials(Consumer<RedisCredentials> onNext, Consumer<Throwable> onError) {
+    public Subscription subscribeToCredentials(Consumer<RedisCredentials> onNext, Consumer<Throwable> onError) {
         if (isClosed) {
             throw new IllegalStateException("Credentials provider closed");
         }

--- a/src/main/java/io/lettuce/core/AsyncCredentialsProviderAdapter.java
+++ b/src/main/java/io/lettuce/core/AsyncCredentialsProviderAdapter.java
@@ -42,7 +42,7 @@ class AsyncCredentialsProviderAdapter implements RedisCredentialsProvider {
     }
 
     @Override
-    public CredentialsSubscription subscribeToCredentials(Consumer<RedisCredentials> onNext, Consumer<Throwable> onError) {
+    public Subscription subscribeToCredentials(Consumer<RedisCredentials> onNext, Consumer<Throwable> onError) {
         return delegate.subscribeToCredentials(onNext, onError);
     }
 

--- a/src/main/java/io/lettuce/core/AsyncCredentialsProviderAdapter.java
+++ b/src/main/java/io/lettuce/core/AsyncCredentialsProviderAdapter.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026-Present, Redis Ltd. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+package io.lettuce.core;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.Consumer;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Adapts a reactor-free {@link CredentialsProvider} to the deprecated reactive {@link RedisCredentialsProvider}, so
+ * {@link RedisURI#getCredentialsProvider()} can keep returning a {@link RedisCredentialsProvider} while credentials are stored
+ * internally as a {@link CredentialsProvider}. Only {@link #resolveCredentials()} materialises a {@link Mono}; the async and
+ * streaming paths delegate directly and stay reactor-free.
+ *
+ * @author Aleksandar Todorov
+ * @since 7.7
+ */
+class AsyncCredentialsProviderAdapter implements RedisCredentialsProvider {
+
+    private final CredentialsProvider delegate;
+
+    AsyncCredentialsProviderAdapter(CredentialsProvider delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Mono<RedisCredentials> resolveCredentials() {
+        return Mono.fromCompletionStage(delegate.resolveCredentialsAsync());
+    }
+
+    @Override
+    public CompletionStage<RedisCredentials> resolveCredentialsAsync() {
+        return delegate.resolveCredentialsAsync();
+    }
+
+    @Override
+    public boolean supportsStreaming() {
+        return delegate.supportsStreaming();
+    }
+
+    @Override
+    public CredentialsSubscription subscribeToCredentials(Consumer<RedisCredentials> onNext, Consumer<Throwable> onError) {
+        return delegate.subscribeToCredentials(onNext, onError);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof AsyncCredentialsProviderAdapter)) {
+            return false;
+        }
+        return delegate.equals(((AsyncCredentialsProviderAdapter) o).delegate);
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+
+}

--- a/src/main/java/io/lettuce/core/ConnectionState.java
+++ b/src/main/java/io/lettuce/core/ConnectionState.java
@@ -35,7 +35,7 @@ public class ConnectionState {
 
     private volatile HandshakeResponse handshakeResponse;
 
-    private volatile RedisCredentialsProvider credentialsProvider;
+    private volatile CredentialsProvider credentialsProvider;
 
     private volatile int db;
 
@@ -51,7 +51,7 @@ public class ConnectionState {
     public void apply(RedisURI redisURI) {
 
         connectionMetadata.apply(redisURI);
-        setCredentialsProvider(redisURI.getCredentialsProvider());
+        setCredentialsProvider(redisURI.getCredentialsProviderAsync());
     }
 
     void apply(ConnectionMetadata metadata) {
@@ -129,11 +129,11 @@ public class ConnectionState {
         }
     }
 
-    protected void setCredentialsProvider(RedisCredentialsProvider credentialsProvider) {
+    protected void setCredentialsProvider(CredentialsProvider credentialsProvider) {
         this.credentialsProvider = credentialsProvider;
     }
 
-    public RedisCredentialsProvider getCredentialsProvider() {
+    public CredentialsProvider getCredentialsProvider() {
         return credentialsProvider;
     }
 

--- a/src/main/java/io/lettuce/core/CredentialsProvider.java
+++ b/src/main/java/io/lettuce/core/CredentialsProvider.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026-Present, Redis Ltd. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+package io.lettuce.core;
+
+import java.io.Closeable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import io.lettuce.core.internal.Futures;
+import io.lettuce.core.internal.LettuceAssert;
+
+/**
+ * Interface for loading {@link RedisCredentials} used to authenticate a Redis connection, resolving credentials asynchronously
+ * as a {@link CompletionStage}. Replaces {@link RedisCredentialsProvider}.
+ * <p>
+ * Credentials are requested by the driver after connecting to the server. Therefore, credential retrieval is subject to
+ * complete within the connection creation timeout to avoid connection failures.
+ *
+ * @author Aleksandar Todorov
+ * @since 7.7
+ */
+@FunctionalInterface
+public interface CredentialsProvider {
+
+    /**
+     * Handle to a subscription created by {@link #subscribeToCredentials(Consumer, Consumer)}. Closing the subscription stops
+     * the provider from delivering further credential updates to the registered consumers.
+     */
+    interface CredentialsSubscription extends Closeable {
+
+        @Override
+        void close();
+
+    }
+
+    /**
+     * Returns {@link RedisCredentials} that can be used to authorize a Redis connection. Each implementation of
+     * {@code CredentialsProvider} can choose its own strategy for loading credentials. For example, an implementation might
+     * load credentials from an existing key management system, or load new credentials when credentials are rotated. If an
+     * error occurs during the loading of credentials or credentials could not be found, the returned {@link CompletionStage}
+     * completes exceptionally.
+     *
+     * @return a {@link CompletionStage} that completes with the {@link RedisCredentials} used to authorize a Redis connection.
+     */
+    CompletionStage<RedisCredentials> resolveCredentialsAsync();
+
+    /**
+     * Creates a new {@link CredentialsProvider} from a given {@link Supplier}.
+     *
+     * @param supplier must not be {@code null}.
+     * @return a {@link CredentialsProvider} resolving the {@link RedisCredentials} produced by the {@link Supplier}.
+     */
+    static CredentialsProvider from(Supplier<RedisCredentials> supplier) {
+
+        LettuceAssert.notNull(supplier, "Supplier must not be null");
+
+        return () -> {
+            try {
+                RedisCredentials credentials = supplier.get();
+                if (credentials == null) {
+                    return Futures.failed(new IllegalStateException("Provided RedisCredentials supplier returned null"));
+                }
+                return CompletableFuture.completedFuture(credentials);
+            } catch (Exception e) {
+                return Futures.failed(e);
+            }
+        };
+    }
+
+    /**
+     * Some implementations of the {@link CredentialsProvider} may support streaming new credentials, based on some event that
+     * originates outside the driver. In this case they should indicate that so the {@link RedisAuthenticationHandler} is able
+     * to process these new credentials.
+     *
+     * @return whether the {@link CredentialsProvider} supports streaming credentials.
+     */
+    default boolean supportsStreaming() {
+        return false;
+    }
+
+    /**
+     * Subscribe to credential updates produced by this provider.
+     * <p>
+     * For implementations that support streaming credentials (as indicated by {@link #supportsStreaming()} returning
+     * {@code true}), the {@code onNext} consumer is invoked whenever new credentials become available, typically as a result of
+     * external events such as token renewal or rotation. The {@code onError} consumer is invoked when the provider observes a
+     * failure while obtaining new credentials.
+     * <p>
+     * Replay semantics on subscription are defined by the implementation and callers should consult the concrete provider's
+     * documentation. Subscribers must not assume any specific replay behaviour from this interface alone.
+     * <p>
+     * Implementations that do not support streaming credentials (where {@link #supportsStreaming()} returns {@code false})
+     * throw an {@link UnsupportedOperationException} by default.
+     *
+     * @param onNext consumer invoked with each new {@link RedisCredentials} value, must not be {@code null}.
+     * @param onError consumer invoked with errors observed while producing credentials, must not be {@code null}.
+     * @return a {@link CredentialsSubscription} that can be used to stop receiving updates.
+     * @throws UnsupportedOperationException if the provider does not support streaming credentials.
+     */
+    default CredentialsSubscription subscribeToCredentials(Consumer<RedisCredentials> onNext, Consumer<Throwable> onError) {
+        throw new UnsupportedOperationException("Streaming credentials are not supported by this provider.");
+    }
+
+    /**
+     * Extension to {@link CredentialsProvider} that resolves credentials immediately without the need to defer the credential
+     * resolution.
+     */
+    @FunctionalInterface
+    interface ImmediateCredentialsProvider extends CredentialsProvider {
+
+        @Override
+        default CompletionStage<RedisCredentials> resolveCredentialsAsync() {
+            try {
+                RedisCredentials credentials = resolveCredentialsNow();
+                if (credentials == null) {
+                    return Futures.failed(new IllegalStateException("RedisCredentials resolved to null"));
+                }
+                return CompletableFuture.completedFuture(credentials);
+            } catch (Exception e) {
+                return Futures.failed(e);
+            }
+        }
+
+        /**
+         * Returns {@link RedisCredentials} that can be used to authorize a Redis connection. Each implementation of
+         * {@code CredentialsProvider} can choose its own strategy for loading credentials. For example, an implementation might
+         * load credentials from an existing key management system, or load new credentials when credentials are rotated. If an
+         * error occurs during the loading of credentials or credentials could not be found, a runtime exception will be raised.
+         *
+         * @return the resolved {@link RedisCredentials} that can be used to authorize a Redis connection.
+         */
+        RedisCredentials resolveCredentialsNow();
+
+    }
+
+}

--- a/src/main/java/io/lettuce/core/CredentialsProvider.java
+++ b/src/main/java/io/lettuce/core/CredentialsProvider.java
@@ -4,7 +4,6 @@
  */
 package io.lettuce.core;
 
-import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
@@ -25,17 +24,6 @@ import io.lettuce.core.internal.LettuceAssert;
  */
 @FunctionalInterface
 public interface CredentialsProvider {
-
-    /**
-     * Handle to a subscription created by {@link #subscribeToCredentials(Consumer, Consumer)}. Closing the subscription stops
-     * the provider from delivering further credential updates to the registered consumers.
-     */
-    interface CredentialsSubscription extends Closeable {
-
-        @Override
-        void close();
-
-    }
 
     /**
      * Returns {@link RedisCredentials} that can be used to authorize a Redis connection. Each implementation of
@@ -98,10 +86,10 @@ public interface CredentialsProvider {
      *
      * @param onNext consumer invoked with each new {@link RedisCredentials} value, must not be {@code null}.
      * @param onError consumer invoked with errors observed while producing credentials, must not be {@code null}.
-     * @return a {@link CredentialsSubscription} that can be used to stop receiving updates.
+     * @return a {@link Subscription} that can be used to stop receiving updates.
      * @throws UnsupportedOperationException if the provider does not support streaming credentials.
      */
-    default CredentialsSubscription subscribeToCredentials(Consumer<RedisCredentials> onNext, Consumer<Throwable> onError) {
+    default Subscription subscribeToCredentials(Consumer<RedisCredentials> onNext, Consumer<Throwable> onError) {
         throw new UnsupportedOperationException("Streaming credentials are not supported by this provider.");
     }
 

--- a/src/main/java/io/lettuce/core/RedisAuthenticationHandler.java
+++ b/src/main/java/io/lettuce/core/RedisAuthenticationHandler.java
@@ -6,7 +6,6 @@
  */
 package io.lettuce.core;
 
-import io.lettuce.core.CredentialsProvider.CredentialsSubscription;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.event.connection.ReauthenticationEvent;
@@ -48,7 +47,7 @@ public class RedisAuthenticationHandler<K, V> {
 
     private final RedisCredentialsProvider credentialsProvider;
 
-    private final AtomicReference<CredentialsSubscription> credentialsSubscription = new AtomicReference<>();
+    private final AtomicReference<Subscription> credentialsSubscription = new AtomicReference<>();
 
     private final Boolean isPubSubConnection;
 
@@ -128,10 +127,9 @@ public class RedisAuthenticationHandler<K, V> {
             return;
         }
 
-        CredentialsSubscription credentialsSub = credentialsProvider.subscribeToCredentials(this::reauthenticate,
-                this::onError);
+        Subscription credentialsSub = credentialsProvider.subscribeToCredentials(this::reauthenticate, this::onError);
 
-        CredentialsSubscription oldSub = credentialsSubscription.getAndSet(credentialsSub);
+        Subscription oldSub = credentialsSubscription.getAndSet(credentialsSub);
         if (oldSub != null) {
             try {
                 oldSub.close();
@@ -145,7 +143,7 @@ public class RedisAuthenticationHandler<K, V> {
      * Unsubscribes from the current credentials stream.
      */
     public void unsubscribe() {
-        CredentialsSubscription sub = credentialsSubscription.getAndSet(null);
+        Subscription sub = credentialsSubscription.getAndSet(null);
         if (sub != null) {
             try {
                 sub.close();

--- a/src/main/java/io/lettuce/core/RedisAuthenticationHandler.java
+++ b/src/main/java/io/lettuce/core/RedisAuthenticationHandler.java
@@ -45,7 +45,7 @@ public class RedisAuthenticationHandler<K, V> {
 
     private final StatefulRedisConnectionImpl<K, V> connection;
 
-    private final RedisCredentialsProvider credentialsProvider;
+    private final CredentialsProvider credentialsProvider;
 
     private final AtomicReference<Subscription> credentialsSubscription = new AtomicReference<>();
 
@@ -61,11 +61,11 @@ public class RedisAuthenticationHandler<K, V> {
      * Creates a new {@link RedisAuthenticationHandler}.
      *
      * @param connection the connection to authenticate
-     * @param credentialsProvider the implementation of {@link RedisCredentialsProvider} to use
+     * @param credentialsProvider the implementation of {@link CredentialsProvider} to use
      * @param isPubSubConnection {@code true} if the connection is a pub/sub connection
      */
-    public RedisAuthenticationHandler(StatefulRedisConnectionImpl<K, V> connection,
-            RedisCredentialsProvider credentialsProvider, Boolean isPubSubConnection) {
+    public RedisAuthenticationHandler(StatefulRedisConnectionImpl<K, V> connection, CredentialsProvider credentialsProvider,
+            Boolean isPubSubConnection) {
         this.connection = connection;
         this.credentialsProvider = credentialsProvider;
         this.isPubSubConnection = isPubSubConnection;
@@ -75,16 +75,16 @@ public class RedisAuthenticationHandler<K, V> {
      * Creates a new {@link RedisAuthenticationHandler} if the connection supports re-authentication.
      *
      * @param connection the connection to authenticate
-     * @param credentialsProvider the implementation of {@link RedisCredentialsProvider} to use
+     * @param credentialsProvider the implementation of {@link CredentialsProvider} to use
      * @param isPubSubConnection {@code true} if the connection is a pub/sub connection
      * @param options the {@link ClientOptions} to use
      * @return a new {@link RedisAuthenticationHandler} if the connection supports re-authentication, otherwise an
      *         implementation of the {@link RedisAuthenticationHandler} that does nothing
      * @since 6.6.0
-     * @see RedisCredentialsProvider
+     * @see CredentialsProvider
      */
     public static <K, V> RedisAuthenticationHandler<K, V> createHandler(StatefulRedisConnectionImpl<K, V> connection,
-            RedisCredentialsProvider credentialsProvider, Boolean isPubSubConnection, ClientOptions options) {
+            CredentialsProvider credentialsProvider, Boolean isPubSubConnection, ClientOptions options) {
 
         if (isSupported(options)) {
 
@@ -106,7 +106,7 @@ public class RedisAuthenticationHandler<K, V> {
      *
      * @return a new {@link RedisAuthenticationHandler}
      * @since 6.6.0
-     * @see RedisCredentialsProvider
+     * @see CredentialsProvider
      */
     public static <K, V> RedisAuthenticationHandler<K, V> createDefaultAuthenticationHandler() {
         return new DisabledAuthenticationHandler<>();
@@ -163,7 +163,7 @@ public class RedisAuthenticationHandler<K, V> {
     }
 
     /**
-     * Handles errors observed by the underlying {@link RedisCredentialsProvider} while producing credentials.
+     * Handles errors observed by the underlying {@link CredentialsProvider} while producing credentials.
      *
      * @param e the error reported by the credentials provider
      */
@@ -359,7 +359,7 @@ public class RedisAuthenticationHandler<K, V> {
     private static final class DisabledAuthenticationHandler<K, V> extends RedisAuthenticationHandler<K, V> {
 
         public DisabledAuthenticationHandler(StatefulRedisConnectionImpl<K, V> connection,
-                RedisCredentialsProvider credentialsProvider, Boolean isPubSubConnection) {
+                CredentialsProvider credentialsProvider, Boolean isPubSubConnection) {
             super(null, null, null);
         }
 

--- a/src/main/java/io/lettuce/core/RedisAuthenticationHandler.java
+++ b/src/main/java/io/lettuce/core/RedisAuthenticationHandler.java
@@ -6,7 +6,7 @@
  */
 package io.lettuce.core;
 
-import io.lettuce.core.RedisCredentialsProvider.CredentialsSubscription;
+import io.lettuce.core.CredentialsProvider.CredentialsSubscription;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.event.connection.ReauthenticationEvent;

--- a/src/main/java/io/lettuce/core/RedisClient.java
+++ b/src/main/java/io/lettuce/core/RedisClient.java
@@ -321,8 +321,8 @@ public class RedisClient extends AbstractRedisClient {
         ConnectionState state = connection.getConnectionState();
         state.apply(redisURI);
         state.setDb(redisURI.getDatabase());
-        connection
-                .setAuthenticationHandler(createHandler(connection, redisURI.getCredentialsProvider(), isPubSub, getOptions()));
+        connection.setAuthenticationHandler(
+                createHandler(connection, redisURI.getCredentialsProviderAsync(), isPubSub, getOptions()));
         connectionBuilder.connection(connection);
         connectionBuilder.clientOptions(getOptions());
         connectionBuilder.clientResources(getResources());

--- a/src/main/java/io/lettuce/core/RedisCredentialsProvider.java
+++ b/src/main/java/io/lettuce/core/RedisCredentialsProvider.java
@@ -1,6 +1,5 @@
 package io.lettuce.core;
 
-import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
@@ -8,6 +7,9 @@ import java.util.function.Supplier;
 
 import io.lettuce.core.internal.Futures;
 import io.lettuce.core.internal.LettuceAssert;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * Interface for loading {@link RedisCredentials} that are used for authentication. A commonly-used implementation is
@@ -18,20 +20,11 @@ import io.lettuce.core.internal.LettuceAssert;
  *
  * @author Mark Paluch
  * @since 6.2
+ * @deprecated since 7.7, use {@link CredentialsProvider} instead; scheduled for removal in a future major release.
  */
+@Deprecated
 @FunctionalInterface
-public interface RedisCredentialsProvider {
-
-    /**
-     * Handle to a subscription created by {@link #subscribeToCredentials(Consumer, Consumer)}. Closing the subscription stops
-     * the provider from delivering further credential updates to the registered consumers.
-     */
-    interface CredentialsSubscription extends Closeable {
-
-        @Override
-        void close();
-
-    }
+public interface RedisCredentialsProvider extends CredentialsProvider {
 
     /**
      * Returns {@link RedisCredentials} that can be used to authorize a Redis connection. Each implementation of
@@ -39,9 +32,20 @@ public interface RedisCredentialsProvider {
      * might load credentials from an existing key management system, or load new credentials when credentials are rotated. If
      * an error occurs during the loading of credentials or credentials could not be found, a runtime exception will be raised.
      *
-     * @return a {@link CompletionStage} emitting {@link RedisCredentials} that can be used to authorize a Redis connection.
+     * @return a {@link Mono} emitting {@link RedisCredentials} that can be used to authorize a Redis connection.
      */
-    CompletionStage<RedisCredentials> resolveCredentials();
+    Mono<RedisCredentials> resolveCredentials();
+
+    /**
+     * Resolves the latest available credentials as a {@link CompletionStage}, adapting {@link #resolveCredentials()}.
+     *
+     * @return a {@link CompletionStage} that completes with the {@link RedisCredentials} used to authorize a Redis connection.
+     * @since 7.7
+     */
+    @Override
+    default CompletionStage<RedisCredentials> resolveCredentialsAsync() {
+        return resolveCredentials().toFuture();
+    }
 
     /**
      * Creates a new {@link RedisCredentialsProvider} from a given {@link Supplier}.
@@ -53,59 +57,49 @@ public interface RedisCredentialsProvider {
 
         LettuceAssert.notNull(supplier, "Supplier must not be null");
 
-        return () -> {
-            try {
-                RedisCredentials credentials = supplier.get();
-                if (credentials == null) {
-                    return Futures.failed(new IllegalStateException("Provided RedisCredentials supplier returned null"));
-                }
-                return CompletableFuture.completedFuture(credentials);
-            } catch (Exception e) {
-                return Futures.failed(e);
-            }
-        };
+        return () -> Mono.fromSupplier(supplier);
     }
 
     /**
      * Some implementations of the {@link RedisCredentialsProvider} may support streaming new credentials, based on some event
      * that originates outside the driver. In this case they should indicate that so the {@link RedisAuthenticationHandler} is
      * able to process these new credentials.
-     * 
+     *
      * @return whether the {@link RedisCredentialsProvider} supports streaming credentials.
      */
+    @Override
     default boolean supportsStreaming() {
         return false;
     }
 
     /**
-     * Subscribe to credential updates produced by this provider.
-     * <p>
-     * For implementations that support streaming credentials (as indicated by {@link #supportsStreaming()} returning
-     * {@code true}), the {@code onNext} consumer is invoked whenever new credentials become available, typically as a result of
-     * external events such as token renewal or rotation. The {@code onError} consumer is invoked when the provider observes a
-     * failure while obtaining new credentials.
-     * <p>
-     * Replay semantics on subscription are defined by the implementation and callers should consult the concrete provider's
-     * documentation. Typical aspects an implementation may choose to specify include:
-     * <ul>
-     * <li>whether the most recently known credentials are delivered to {@code onNext} immediately on subscription;</li>
-     * <li>whether prior errors observed before subscription are delivered to {@code onError}, or are silently dropped in favour
-     * of waiting for the next credentials or next error event;</li>
-     * <li>the threading context on which {@code onNext} and {@code onError} are invoked, and any ordering guarantees between
-     * replay deliveries and live updates.</li>
-     * </ul>
-     * Subscribers must not assume any specific replay behaviour from this interface alone.
-     * <p>
-     * Implementations that do not support streaming credentials (where {@link #supportsStreaming()} returns {@code false})
-     * throw an {@link UnsupportedOperationException} by default.
+     * Returns a {@link Flux} emitting {@link RedisCredentials} that can be used to authorize a Redis connection.
      *
-     * @param onNext consumer invoked with each new {@link RedisCredentials} value, must not be {@code null}.
-     * @param onError consumer invoked with errors observed while producing credentials, must not be {@code null}.
-     * @return a {@link CredentialsSubscription} that can be used to stop receiving updates.
+     * For implementations that support streaming credentials (as indicated by {@link #supportsStreaming()} returning
+     * {@code true}), this method can emit multiple credentials over time, typically based on external events like token renewal
+     * or rotation.
+     *
+     * For implementations that do not support streaming credentials (where {@link #supportsStreaming()} returns {@code false}),
+     * this method throws an {@link UnsupportedOperationException} by default.
+     *
+     * @return a {@link Flux} emitting {@link RedisCredentials}, or throws an exception if streaming is not supported.
      * @throws UnsupportedOperationException if the provider does not support streaming credentials.
      */
-    default CredentialsSubscription subscribeToCredentials(Consumer<RedisCredentials> onNext, Consumer<Throwable> onError) {
+    default Flux<RedisCredentials> credentials() {
         throw new UnsupportedOperationException("Streaming credentials are not supported by this provider.");
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Bridges the reactive {@link #credentials()} stream to the callback-based {@link CredentialsProvider} contract.
+     *
+     * @since 7.7
+     */
+    @Override
+    default CredentialsSubscription subscribeToCredentials(Consumer<RedisCredentials> onNext, Consumer<Throwable> onError) {
+        Disposable disposable = credentials().subscribe(onNext, onError);
+        return disposable::dispose;
     }
 
     /**
@@ -116,7 +110,12 @@ public interface RedisCredentialsProvider {
     interface ImmediateRedisCredentialsProvider extends RedisCredentialsProvider {
 
         @Override
-        default CompletionStage<RedisCredentials> resolveCredentials() {
+        default Mono<RedisCredentials> resolveCredentials() {
+            return Mono.just(resolveCredentialsNow());
+        }
+
+        @Override
+        default CompletionStage<RedisCredentials> resolveCredentialsAsync() {
             try {
                 RedisCredentials credentials = resolveCredentialsNow();
                 if (credentials == null) {

--- a/src/main/java/io/lettuce/core/RedisCredentialsProvider.java
+++ b/src/main/java/io/lettuce/core/RedisCredentialsProvider.java
@@ -97,7 +97,7 @@ public interface RedisCredentialsProvider extends CredentialsProvider {
      * @since 7.7
      */
     @Override
-    default CredentialsSubscription subscribeToCredentials(Consumer<RedisCredentials> onNext, Consumer<Throwable> onError) {
+    default Subscription subscribeToCredentials(Consumer<RedisCredentials> onNext, Consumer<Throwable> onError) {
         Disposable disposable = credentials().subscribe(onNext, onError);
         return disposable::dispose;
     }

--- a/src/main/java/io/lettuce/core/RedisHandshake.java
+++ b/src/main/java/io/lettuce/core/RedisHandshake.java
@@ -210,7 +210,8 @@ class RedisHandshake implements ConnectionInitializer {
                     ((RedisCredentialsProvider.ImmediateRedisCredentialsProvider) credentialsProvider).resolveCredentialsNow());
         }
 
-        CompletableFuture<RedisCredentials> credentialsFuture = credentialsProvider.resolveCredentials().toCompletableFuture();
+        CompletableFuture<RedisCredentials> credentialsFuture = credentialsProvider.resolveCredentialsAsync()
+                .toCompletableFuture();
 
         return credentialsFuture.thenComposeAsync(credentials -> dispatchAuthOrPing(channel, credentials));
     }
@@ -243,7 +244,8 @@ class RedisHandshake implements ConnectionInitializer {
                     ((RedisCredentialsProvider.ImmediateRedisCredentialsProvider) credentialsProvider).resolveCredentialsNow());
         }
 
-        CompletableFuture<RedisCredentials> credentialsFuture = credentialsProvider.resolveCredentials().toCompletableFuture();
+        CompletableFuture<RedisCredentials> credentialsFuture = credentialsProvider.resolveCredentialsAsync()
+                .toCompletableFuture();
 
         return credentialsFuture.thenComposeAsync(credentials -> dispatchHello(channel, credentials));
     }

--- a/src/main/java/io/lettuce/core/RedisHandshake.java
+++ b/src/main/java/io/lettuce/core/RedisHandshake.java
@@ -203,11 +203,11 @@ class RedisHandshake implements ConnectionInitializer {
      * @param credentialsProvider
      * @return
      */
-    private CompletableFuture<?> initiateHandshakeResp2(Channel channel, RedisCredentialsProvider credentialsProvider) {
+    private CompletableFuture<?> initiateHandshakeResp2(Channel channel, CredentialsProvider credentialsProvider) {
 
-        if (credentialsProvider instanceof RedisCredentialsProvider.ImmediateRedisCredentialsProvider) {
+        if (credentialsProvider instanceof CredentialsProvider.ImmediateCredentialsProvider) {
             return dispatchAuthOrPing(channel,
-                    ((RedisCredentialsProvider.ImmediateRedisCredentialsProvider) credentialsProvider).resolveCredentialsNow());
+                    ((CredentialsProvider.ImmediateCredentialsProvider) credentialsProvider).resolveCredentialsNow());
         }
 
         CompletableFuture<RedisCredentials> credentialsFuture = credentialsProvider.resolveCredentialsAsync()
@@ -237,11 +237,11 @@ class RedisHandshake implements ConnectionInitializer {
      * @return
      */
     private CompletionStage<Map<String, Object>> initiateHandshakeResp3(Channel channel,
-            RedisCredentialsProvider credentialsProvider) {
+            CredentialsProvider credentialsProvider) {
 
-        if (credentialsProvider instanceof RedisCredentialsProvider.ImmediateRedisCredentialsProvider) {
+        if (credentialsProvider instanceof CredentialsProvider.ImmediateCredentialsProvider) {
             return dispatchHello(channel,
-                    ((RedisCredentialsProvider.ImmediateRedisCredentialsProvider) credentialsProvider).resolveCredentialsNow());
+                    ((CredentialsProvider.ImmediateCredentialsProvider) credentialsProvider).resolveCredentialsNow());
         }
 
         CompletableFuture<RedisCredentials> credentialsFuture = credentialsProvider.resolveCredentialsAsync()

--- a/src/main/java/io/lettuce/core/RedisURI.java
+++ b/src/main/java/io/lettuce/core/RedisURI.java
@@ -547,12 +547,27 @@ public class RedisURI implements Serializable, ConnectionPoint {
      *
      * @return the {@link RedisCredentialsProvider} to use to authenticate Redis connections
      * @since 6.2
+     * @deprecated since 7.7, use {@link #getCredentialsProviderAsync()} instead; scheduled for removal in a future major
+     *             release.
      */
+    @Deprecated
     public RedisCredentialsProvider getCredentialsProvider() {
         if (this.credentialsProvider instanceof RedisCredentialsProvider) {
             return (RedisCredentialsProvider) this.credentialsProvider;
         }
         return new AsyncCredentialsProviderAdapter(this.credentialsProvider);
+    }
+
+    /**
+     * Returns the reactor-free {@link CredentialsProvider} configured on this URI. In contrast to
+     * {@link #getCredentialsProvider()}, the provider is returned as-is without adapting it to the deprecated reactive
+     * {@link RedisCredentialsProvider}; this is the accessor used on the driver's reactor-free authentication path.
+     *
+     * @return the {@link CredentialsProvider} to use to authenticate Redis connections.
+     * @since 7.7
+     */
+    public CredentialsProvider getCredentialsProviderAsync() {
+        return this.credentialsProvider;
     }
 
     /**

--- a/src/main/java/io/lettuce/core/RedisURI.java
+++ b/src/main/java/io/lettuce/core/RedisURI.java
@@ -243,7 +243,7 @@ public class RedisURI implements Serializable, ConnectionPoint {
 
     private String libraryVersion = LettuceVersion.getVersion();
 
-    private RedisCredentialsProvider credentialsProvider = new StaticCredentialsProvider(null, null);
+    private CredentialsProvider credentialsProvider = new StaticCredentialsProvider(null, null);
 
     private boolean ssl = false;
 
@@ -471,7 +471,7 @@ public class RedisURI implements Serializable, ConnectionPoint {
         LettuceAssert.notNull(source, "Source RedisURI must not be null");
 
         if (source.credentialsProvider != null) {
-            setCredentialsProvider(source.getCredentialsProvider());
+            setCredentialsProvider(source.credentialsProvider);
         }
     }
 
@@ -482,7 +482,7 @@ public class RedisURI implements Serializable, ConnectionPoint {
      * username and the provided password.
      *
      * @param password the password to use to authenticate Redis connections.
-     * @see #setCredentialsProvider(RedisCredentialsProvider)
+     * @see #setCredentialsProvider(CredentialsProvider)
      * @since 7.0
      */
     public void setAuthentication(CharSequence password) {
@@ -498,7 +498,7 @@ public class RedisURI implements Serializable, ConnectionPoint {
      * username and the provided password.
      *
      * @param password the password to use to authenticate Redis connections.
-     * @see #setCredentialsProvider(RedisCredentialsProvider)
+     * @see #setCredentialsProvider(CredentialsProvider)
      * @since 7.0
      */
     public void setAuthentication(char[] password) {
@@ -515,7 +515,7 @@ public class RedisURI implements Serializable, ConnectionPoint {
      *
      * @param username the username to use to authenticate Redis connections.
      * @param password the password to use to authenticate Redis connections.
-     * @see #setCredentialsProvider(RedisCredentialsProvider)
+     * @see #setCredentialsProvider(CredentialsProvider)
      * @since 7.0
      */
     public void setAuthentication(String username, char[] password) {
@@ -532,7 +532,7 @@ public class RedisURI implements Serializable, ConnectionPoint {
      *
      * @param username the username to use to authenticate Redis connections.
      * @param password the password to use to authenticate Redis connections.
-     * @see #setCredentialsProvider(RedisCredentialsProvider)
+     * @see #setCredentialsProvider(CredentialsProvider)
      * @since 7.0
      */
     public void setAuthentication(String username, CharSequence password) {
@@ -549,19 +549,23 @@ public class RedisURI implements Serializable, ConnectionPoint {
      * @since 6.2
      */
     public RedisCredentialsProvider getCredentialsProvider() {
-        return this.credentialsProvider;
+        if (this.credentialsProvider instanceof RedisCredentialsProvider) {
+            return (RedisCredentialsProvider) this.credentialsProvider;
+        }
+        return new AsyncCredentialsProviderAdapter(this.credentialsProvider);
     }
 
     /**
-     * Sets the {@link RedisCredentialsProvider}. Configuring a credentials provider resets the configured static
-     * username/password.
+     * Sets the {@link CredentialsProvider}. Configuring a credentials provider resets the configured static username/password.
+     * Accepts the deprecated {@link RedisCredentialsProvider} as well; {@link #getCredentialsProvider()} keeps returning a
+     * {@link RedisCredentialsProvider} view for backward compatibility.
      *
      * @param credentialsProvider the credentials provider to use when authenticating a Redis connection.
      * @since 6.2
      */
-    public void setCredentialsProvider(RedisCredentialsProvider credentialsProvider) {
+    public void setCredentialsProvider(CredentialsProvider credentialsProvider) {
 
-        LettuceAssert.notNull(credentialsProvider, "RedisCredentialsProvider must not be null");
+        LettuceAssert.notNull(credentialsProvider, "CredentialsProvider must not be null");
 
         this.credentialsProvider = credentialsProvider;
     }
@@ -976,7 +980,7 @@ public class RedisURI implements Serializable, ConnectionPoint {
                 // would get asterix for each character of the password.
                 RedisCredentials creds;
                 try {
-                    creds = credentialsProvider.resolveCredentials().toCompletableFuture().join();
+                    creds = credentialsProvider.resolveCredentialsAsync().toCompletableFuture().join();
                 } catch (Exception e) {
                     throw Exceptions.bubble(e);
                 }
@@ -1361,7 +1365,7 @@ public class RedisURI implements Serializable, ConnectionPoint {
 
         private DriverInfo driverInfo = DriverInfo.builder().build();
 
-        private RedisCredentialsProvider credentialsProvider;
+        private CredentialsProvider credentialsProvider;
 
         private boolean ssl = false;
 
@@ -1770,7 +1774,7 @@ public class RedisURI implements Serializable, ConnectionPoint {
 
             LettuceAssert.notNull(source, "Source RedisURI must not be null");
 
-            return withAuthentication(source.getCredentialsProvider());
+            return withAuthentication(source.credentialsProvider);
         }
 
         /**
@@ -1795,7 +1799,7 @@ public class RedisURI implements Serializable, ConnectionPoint {
          * @param credentialsProvider the credentials provider to use
          * @since 6.2
          */
-        public Builder withAuthentication(RedisCredentialsProvider credentialsProvider) {
+        public Builder withAuthentication(CredentialsProvider credentialsProvider) {
             this.credentialsProvider = credentialsProvider;
             return this;
         }

--- a/src/main/java/io/lettuce/core/StaticCredentialsProvider.java
+++ b/src/main/java/io/lettuce/core/StaticCredentialsProvider.java
@@ -6,13 +6,12 @@ import java.util.concurrent.CompletionStage;
 import io.lettuce.core.internal.LettuceAssert;
 
 /**
- * Static implementation of {@link RedisCredentialsProvider}.
+ * Static implementation of {@link CredentialsProvider}.
  *
  * @author Mark Paluch
  * @since 6.2
  */
-public class StaticCredentialsProvider
-        implements RedisCredentialsProvider, RedisCredentialsProvider.ImmediateRedisCredentialsProvider {
+public class StaticCredentialsProvider implements CredentialsProvider.ImmediateCredentialsProvider {
 
     private final RedisCredentials credentials;
 

--- a/src/main/java/io/lettuce/core/StaticCredentialsProvider.java
+++ b/src/main/java/io/lettuce/core/StaticCredentialsProvider.java
@@ -44,7 +44,7 @@ public class StaticCredentialsProvider
     }
 
     @Override
-    public CompletionStage<RedisCredentials> resolveCredentials() {
+    public CompletionStage<RedisCredentials> resolveCredentialsAsync() {
         return future;
     }
 

--- a/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
@@ -559,7 +559,7 @@ public class RedisClusterClient extends AbstractRedisClient {
                 getFirstUri().getTimeout(), getClusterClientOptions().getJsonParser());
 
         connection.setAuthenticationHandler(
-                createHandler(connection, getFirstUri().getCredentialsProvider(), false, getOptions()));
+                createHandler(connection, getFirstUri().getCredentialsProviderAsync(), false, getOptions()));
 
         ConnectionFuture<StatefulRedisConnection<K, V>> connectionFuture = connectStatefulAsync(connection, endpoint,
                 getFirstUri(), socketAddressSupplier,
@@ -644,7 +644,7 @@ public class RedisClusterClient extends AbstractRedisClient {
         StatefulRedisPubSubConnectionImpl<K, V> connection = new StatefulRedisPubSubConnectionImpl<>(endpoint, writer, codec,
                 getFirstUri().getTimeout());
         connection.setAuthenticationHandler(
-                createHandler(connection, getFirstUri().getCredentialsProvider(), true, getOptions()));
+                createHandler(connection, getFirstUri().getCredentialsProviderAsync(), true, getOptions()));
 
         ConnectionFuture<StatefulRedisPubSubConnection<K, V>> connectionFuture = connectStatefulAsync(connection, endpoint,
                 getFirstUri(), socketAddressSupplier,
@@ -817,7 +817,7 @@ public class RedisClusterClient extends AbstractRedisClient {
         clusterWriter.setClusterConnectionProvider(pooledClusterConnectionProvider);
         connection.setPartitions(partitions);
         connection.setAuthenticationHandler(
-                createHandler(connection, getFirstUri().getCredentialsProvider(), true, getOptions()));
+                createHandler(connection, getFirstUri().getCredentialsProviderAsync(), true, getOptions()));
 
         Supplier<CommandHandler> commandHandlerSupplier = () -> new PubSubCommandHandler<>(getClusterClientOptions(),
                 getResources(), codec, endpoint);

--- a/src/main/java/io/lettuce/core/failover/api/ImmutableRedisURI.java
+++ b/src/main/java/io/lettuce/core/failover/api/ImmutableRedisURI.java
@@ -5,8 +5,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import io.lettuce.core.CredentialsProvider;
 import io.lettuce.core.DriverInfo;
-import io.lettuce.core.RedisCredentialsProvider;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.SslVerifyMode;
 import io.lettuce.core.annotations.Experimental;
@@ -72,7 +72,7 @@ public class ImmutableRedisURI extends RedisURI {
     }
 
     @Override
-    public void setCredentialsProvider(RedisCredentialsProvider credentialsProvider) {
+    public void setCredentialsProvider(CredentialsProvider credentialsProvider) {
         throw new UnsupportedOperationException("ImmutableRedisURI cannot be modified");
     }
 

--- a/src/test/java/io/lettuce/authx/DefaultAzureCredentialsIntegrationTests.java
+++ b/src/test/java/io/lettuce/authx/DefaultAzureCredentialsIntegrationTests.java
@@ -79,7 +79,8 @@ public class DefaultAzureCredentialsIntegrationTests {
     @Test
     public void azureTokenAuthWithDefaultAzureCredentials() throws ExecutionException, InterruptedException, TimeoutException {
 
-        RedisCredentials credentials = credentialsProvider.resolveCredentials().toCompletableFuture().get(5, TimeUnit.SECONDS);
+        RedisCredentials credentials = credentialsProvider.resolveCredentialsAsync().toCompletableFuture().get(5,
+                TimeUnit.SECONDS);
         assertThat(credentials).isNotNull();
 
         String key = UUID.randomUUID().toString();

--- a/src/test/java/io/lettuce/authx/EntraIdIntegrationTests.java
+++ b/src/test/java/io/lettuce/authx/EntraIdIntegrationTests.java
@@ -1,7 +1,7 @@
 package io.lettuce.authx;
 
 import io.lettuce.core.*;
-import io.lettuce.core.CredentialsProvider.CredentialsSubscription;
+import io.lettuce.core.Subscription;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.api.reactive.RedisReactiveCommands;
@@ -116,7 +116,7 @@ public class EntraIdIntegrationTests {
         commandThread.start();
 
         CountDownLatch latch = new CountDownLatch(10); // Wait for at least 10 token renewalss
-        CredentialsSubscription subscription = credentialsProvider.subscribeToCredentials(cred -> latch.countDown(), t -> {
+        Subscription subscription = credentialsProvider.subscribeToCredentials(cred -> latch.countDown(), t -> {
         });
         try {
             assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue(); // Wait to reach 10 renewals
@@ -150,7 +150,7 @@ public class EntraIdIntegrationTests {
             pubsubThread.start();
 
             CountDownLatch latch = new CountDownLatch(10);
-            CredentialsSubscription subscription = credentialsProvider.subscribeToCredentials(cred -> latch.countDown(), t -> {
+            Subscription subscription = credentialsProvider.subscribeToCredentials(cred -> latch.countDown(), t -> {
             });
             try {
                 assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue(); // Wait for at least 10 token renewals

--- a/src/test/java/io/lettuce/authx/EntraIdIntegrationTests.java
+++ b/src/test/java/io/lettuce/authx/EntraIdIntegrationTests.java
@@ -1,7 +1,7 @@
 package io.lettuce.authx;
 
 import io.lettuce.core.*;
-import io.lettuce.core.RedisCredentialsProvider.CredentialsSubscription;
+import io.lettuce.core.CredentialsProvider.CredentialsSubscription;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.api.reactive.RedisReactiveCommands;

--- a/src/test/java/io/lettuce/authx/TokenBasedRedisCredentialsProviderTest.java
+++ b/src/test/java/io/lettuce/authx/TokenBasedRedisCredentialsProviderTest.java
@@ -2,7 +2,7 @@ package io.lettuce.authx;
 
 import io.lettuce.TestTags;
 import io.lettuce.core.RedisCredentials;
-import io.lettuce.core.CredentialsProvider.CredentialsSubscription;
+import io.lettuce.core.Subscription;
 import io.lettuce.core.TestTokenManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -104,12 +104,12 @@ public class TokenBasedRedisCredentialsProviderTest {
         List<RedisCredentials> received2 = new CopyOnWriteArrayList<>();
         CountDownLatch firstTokenLatch = new CountDownLatch(2);
 
-        CredentialsSubscription sub1 = credentialsProvider.subscribeToCredentials(c -> {
+        Subscription sub1 = credentialsProvider.subscribeToCredentials(c -> {
             received1.add(c);
             firstTokenLatch.countDown();
         }, t -> {
         });
-        CredentialsSubscription sub2 = credentialsProvider.subscribeToCredentials(c -> {
+        Subscription sub2 = credentialsProvider.subscribeToCredentials(c -> {
             received2.add(c);
             firstTokenLatch.countDown();
         }, t -> {
@@ -140,7 +140,7 @@ public class TokenBasedRedisCredentialsProviderTest {
         List<RedisCredentials> received = new CopyOnWriteArrayList<>();
         CountDownLatch latch = new CountDownLatch(2);
 
-        CredentialsSubscription sub = credentialsProvider.subscribeToCredentials(c -> {
+        Subscription sub = credentialsProvider.subscribeToCredentials(c -> {
             received.add(c);
             latch.countDown();
         }, t -> {
@@ -166,7 +166,7 @@ public class TokenBasedRedisCredentialsProviderTest {
         AtomicReference<RedisCredentials> received = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
 
-        CredentialsSubscription sub = credentialsProvider.subscribeToCredentials(c -> {
+        Subscription sub = credentialsProvider.subscribeToCredentials(c -> {
             received.set(c);
             latch.countDown();
         }, t -> {
@@ -187,7 +187,7 @@ public class TokenBasedRedisCredentialsProviderTest {
         CountDownLatch tokensLatch = new CountDownLatch(2);
         CountDownLatch errorLatch = new CountDownLatch(1);
 
-        CredentialsSubscription sub = credentialsProvider.subscribeToCredentials(c -> {
+        Subscription sub = credentialsProvider.subscribeToCredentials(c -> {
             received.add(c);
             tokensLatch.countDown();
         }, t -> {

--- a/src/test/java/io/lettuce/authx/TokenBasedRedisCredentialsProviderTest.java
+++ b/src/test/java/io/lettuce/authx/TokenBasedRedisCredentialsProviderTest.java
@@ -44,7 +44,7 @@ public class TokenBasedRedisCredentialsProviderTest {
     public void shouldReturnPreviouslyEmittedTokenWhenResolved() {
         tokenManager.emitToken(testToken("test-user", "token-1"));
 
-        Mono<RedisCredentials> credentials = credentialsProvider.resolveCredentials();
+        Mono<RedisCredentials> credentials = Mono.fromCompletionStage(credentialsProvider.resolveCredentialsAsync());
 
         StepVerifier.create(credentials).assertNext(actual -> {
             assertThat(actual.getUsername()).isEqualTo("test-user");
@@ -57,7 +57,7 @@ public class TokenBasedRedisCredentialsProviderTest {
         tokenManager.emitToken(testToken("test-user", "token-2"));
         tokenManager.emitToken(testToken("test-user", "token-3")); // Latest token
 
-        Mono<RedisCredentials> credentials = credentialsProvider.resolveCredentials();
+        Mono<RedisCredentials> credentials = Mono.fromCompletionStage(credentialsProvider.resolveCredentialsAsync());
 
         StepVerifier.create(credentials).assertNext(actual -> {
             assertThat(actual.getUsername()).isEqualTo("test-user");
@@ -71,7 +71,7 @@ public class TokenBasedRedisCredentialsProviderTest {
         tokenManager.emitToken(testToken("test-user", "token-1"));
 
         // Test resolveCredentials
-        Mono<RedisCredentials> credentials1 = credentialsProvider.resolveCredentials();
+        Mono<RedisCredentials> credentials1 = Mono.fromCompletionStage(credentialsProvider.resolveCredentialsAsync());
 
         StepVerifier.create(credentials1).assertNext(actual -> {
             assertThat(actual.getUsername()).isEqualTo("test-user");
@@ -81,7 +81,7 @@ public class TokenBasedRedisCredentialsProviderTest {
         // Emit second token and subscribe another
         tokenManager.emitToken(testToken("test-user", "token-2"));
         tokenManager.emitToken(testToken("test-user", "token-3"));
-        Mono<RedisCredentials> credentials2 = credentialsProvider.resolveCredentials();
+        Mono<RedisCredentials> credentials2 = Mono.fromCompletionStage(credentialsProvider.resolveCredentialsAsync());
         StepVerifier.create(credentials2).assertNext(actual -> {
             assertThat(actual.getUsername()).isEqualTo("test-user");
             assertThat(new String(actual.getPassword())).isEqualTo("token-3");
@@ -90,7 +90,7 @@ public class TokenBasedRedisCredentialsProviderTest {
 
     @Test
     public void shouldWaitForAndReturnTokenWhenEmittedLater() {
-        Mono<RedisCredentials> result = credentialsProvider.resolveCredentials();
+        Mono<RedisCredentials> result = Mono.fromCompletionStage(credentialsProvider.resolveCredentialsAsync());
 
         tokenManager.emitTokenWithDelay(testToken("test-user", "delayed-token"), 100); // Emit token after 100ms
         StepVerifier.create(result)

--- a/src/test/java/io/lettuce/authx/TokenBasedRedisCredentialsProviderTest.java
+++ b/src/test/java/io/lettuce/authx/TokenBasedRedisCredentialsProviderTest.java
@@ -2,7 +2,7 @@ package io.lettuce.authx;
 
 import io.lettuce.TestTags;
 import io.lettuce.core.RedisCredentials;
-import io.lettuce.core.RedisCredentialsProvider.CredentialsSubscription;
+import io.lettuce.core.CredentialsProvider.CredentialsSubscription;
 import io.lettuce.core.TestTokenManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -44,7 +44,7 @@ public class TokenBasedRedisCredentialsProviderTest {
     public void shouldReturnPreviouslyEmittedTokenWhenResolved() {
         tokenManager.emitToken(testToken("test-user", "token-1"));
 
-        Mono<RedisCredentials> credentials = Mono.fromCompletionStage(credentialsProvider.resolveCredentials());
+        Mono<RedisCredentials> credentials = credentialsProvider.resolveCredentials();
 
         StepVerifier.create(credentials).assertNext(actual -> {
             assertThat(actual.getUsername()).isEqualTo("test-user");
@@ -57,7 +57,7 @@ public class TokenBasedRedisCredentialsProviderTest {
         tokenManager.emitToken(testToken("test-user", "token-2"));
         tokenManager.emitToken(testToken("test-user", "token-3")); // Latest token
 
-        Mono<RedisCredentials> credentials = Mono.fromCompletionStage(credentialsProvider.resolveCredentials());
+        Mono<RedisCredentials> credentials = credentialsProvider.resolveCredentials();
 
         StepVerifier.create(credentials).assertNext(actual -> {
             assertThat(actual.getUsername()).isEqualTo("test-user");
@@ -71,7 +71,7 @@ public class TokenBasedRedisCredentialsProviderTest {
         tokenManager.emitToken(testToken("test-user", "token-1"));
 
         // Test resolveCredentials
-        Mono<RedisCredentials> credentials1 = Mono.fromCompletionStage(credentialsProvider.resolveCredentials());
+        Mono<RedisCredentials> credentials1 = credentialsProvider.resolveCredentials();
 
         StepVerifier.create(credentials1).assertNext(actual -> {
             assertThat(actual.getUsername()).isEqualTo("test-user");
@@ -81,7 +81,7 @@ public class TokenBasedRedisCredentialsProviderTest {
         // Emit second token and subscribe another
         tokenManager.emitToken(testToken("test-user", "token-2"));
         tokenManager.emitToken(testToken("test-user", "token-3"));
-        Mono<RedisCredentials> credentials2 = Mono.fromCompletionStage(credentialsProvider.resolveCredentials());
+        Mono<RedisCredentials> credentials2 = credentialsProvider.resolveCredentials();
         StepVerifier.create(credentials2).assertNext(actual -> {
             assertThat(actual.getUsername()).isEqualTo("test-user");
             assertThat(new String(actual.getPassword())).isEqualTo("token-3");
@@ -90,7 +90,7 @@ public class TokenBasedRedisCredentialsProviderTest {
 
     @Test
     public void shouldWaitForAndReturnTokenWhenEmittedLater() {
-        Mono<RedisCredentials> result = Mono.fromCompletionStage(credentialsProvider.resolveCredentials());
+        Mono<RedisCredentials> result = credentialsProvider.resolveCredentials();
 
         tokenManager.emitTokenWithDelay(testToken("test-user", "delayed-token"), 100); // Emit token after 100ms
         StepVerifier.create(result)

--- a/src/test/java/io/lettuce/core/ConnectionCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/ConnectionCommandIntegrationTests.java
@@ -285,8 +285,8 @@ class ConnectionCommandIntegrationTests extends TestSupport {
         } catch (RedisException e) {
             assertThat(e.getMessage()).startsWith("ERR").contains("AUTH");
             StatefulRedisConnectionImpl<String, String> connectionImpl = (StatefulRedisConnectionImpl<String, String>) connection;
-            assertThat(connectionImpl.getConnectionState().getCredentialsProvider().resolveCredentials().toCompletableFuture()
-                    .join().getPassword()).isNull();
+            assertThat(connectionImpl.getConnectionState().getCredentialsProvider().resolveCredentialsAsync()
+                    .toCompletableFuture().join().getPassword()).isNull();
         } finally {
             connection.close();
         }

--- a/src/test/java/io/lettuce/core/MyStreamingRedisCredentialsProvider.java
+++ b/src/test/java/io/lettuce/core/MyStreamingRedisCredentialsProvider.java
@@ -36,7 +36,7 @@ public class MyStreamingRedisCredentialsProvider implements RedisCredentialsProv
     }
 
     @Override
-    public CredentialsSubscription subscribeToCredentials(Consumer<RedisCredentials> onNext, Consumer<Throwable> onError) {
+    public Subscription subscribeToCredentials(Consumer<RedisCredentials> onNext, Consumer<Throwable> onError) {
         LettuceAssert.notNull(onNext, "onNext consumer must not be null");
         LettuceAssert.notNull(onError, "onError consumer must not be null");
         Listener listener = new Listener(onNext, onError);

--- a/src/test/java/io/lettuce/core/MyStreamingRedisCredentialsProvider.java
+++ b/src/test/java/io/lettuce/core/MyStreamingRedisCredentialsProvider.java
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import io.lettuce.core.internal.LettuceAssert;
+import reactor.core.publisher.Mono;
 
 /**
  * A provider for streaming credentials that can be used to authorize a Redis connection
@@ -30,8 +31,8 @@ public class MyStreamingRedisCredentialsProvider implements RedisCredentialsProv
     }
 
     @Override
-    public CompletionStage<RedisCredentials> resolveCredentials() {
-        return credentialsFutureRef.get();
+    public Mono<RedisCredentials> resolveCredentials() {
+        return Mono.fromCompletionStage(credentialsFutureRef.get());
     }
 
     @Override

--- a/src/test/java/io/lettuce/core/RedisHandshakeUnitTests.java
+++ b/src/test/java/io/lettuce/core/RedisHandshakeUnitTests.java
@@ -15,6 +15,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
 import io.lettuce.core.output.CommandOutput;
 import io.lettuce.core.protocol.AsyncCommand;
@@ -359,8 +360,8 @@ class RedisHandshakeUnitTests {
         private final Sinks.One<RedisCredentials> credentialsSink = Sinks.one();
 
         @Override
-        public CompletionStage<RedisCredentials> resolveCredentials() {
-            return credentialsSink.asMono().toFuture();
+        public Mono<RedisCredentials> resolveCredentials() {
+            return credentialsSink.asMono();
         }
 
         public void completeCredentials(RedisCredentials credentials) {

--- a/src/test/java/io/lettuce/core/RedisURIBuilderUnitTests.java
+++ b/src/test/java/io/lettuce/core/RedisURIBuilderUnitTests.java
@@ -171,11 +171,10 @@ class RedisURIBuilderUnitTests {
         assertThat(result.getSentinels()).isEmpty();
         assertThat(result.getHost()).isEqualTo("localhost");
         assertThat(result.getPort()).isEqualTo(RedisURI.DEFAULT_REDIS_PORT);
-        StepVerifier.create(Mono.fromCompletionStage(result.getCredentialsProvider().resolveCredentials()))
-                .assertNext(credentials -> {
-                    assertThat(credentials.getUsername()).isNull();
-                    assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
-                }).verifyComplete();
+        StepVerifier.create(result.getCredentialsProvider().resolveCredentials()).assertNext(credentials -> {
+            assertThat(credentials.getUsername()).isNull();
+            assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
+        }).verifyComplete();
         assertThat(result.getDatabase()).isEqualTo(21);
         assertThat(result.isSsl()).isFalse();
     }
@@ -183,29 +182,26 @@ class RedisURIBuilderUnitTests {
     @Test
     void redisFromUrlNoPassword() {
         RedisURI redisURI = RedisURI.create("redis://localhost:1234/5");
-        StepVerifier.create(Mono.fromCompletionStage(redisURI.getCredentialsProvider().resolveCredentials()))
-                .assertNext(credentials -> {
-                    assertThat(credentials.getUsername()).isNull();
-                    assertThat(credentials.getPassword()).isNull();
-                }).verifyComplete();
+        StepVerifier.create(redisURI.getCredentialsProvider().resolveCredentials()).assertNext(credentials -> {
+            assertThat(credentials.getUsername()).isNull();
+            assertThat(credentials.getPassword()).isNull();
+        }).verifyComplete();
 
         redisURI = RedisURI.create("redis://h:@localhost.com:14589");
-        StepVerifier.create(Mono.fromCompletionStage(redisURI.getCredentialsProvider().resolveCredentials()))
-                .assertNext(credentials -> {
-                    assertThat(credentials.getUsername()).isNull();
-                    assertThat(credentials.getPassword()).isNull();
-                }).verifyComplete();
+        StepVerifier.create(redisURI.getCredentialsProvider().resolveCredentials()).assertNext(credentials -> {
+            assertThat(credentials.getUsername()).isNull();
+            assertThat(credentials.getPassword()).isNull();
+        }).verifyComplete();
     }
 
     @Test
     void redisFromUrlPassword() {
         RedisURI redisURI = RedisURI.create("redis://h:password@localhost.com:14589");
 
-        StepVerifier.create(Mono.fromCompletionStage(redisURI.getCredentialsProvider().resolveCredentials()))
-                .assertNext(credentials -> {
-                    assertThat(credentials.getUsername()).isEqualTo("h");
-                    assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
-                }).verifyComplete();
+        StepVerifier.create(redisURI.getCredentialsProvider().resolveCredentials()).assertNext(credentials -> {
+            assertThat(credentials.getUsername()).isEqualTo("h");
+            assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
+        }).verifyComplete();
     }
 
     @Test
@@ -236,11 +232,10 @@ class RedisURIBuilderUnitTests {
         assertThat(result.getSentinels()).isEmpty();
         assertThat(result.getHost()).isEqualTo("localhost");
         assertThat(result.getPort()).isEqualTo(RedisURI.DEFAULT_REDIS_PORT);
-        StepVerifier.create(Mono.fromCompletionStage(result.getCredentialsProvider().resolveCredentials()))
-                .assertNext(credentials -> {
-                    assertThat(credentials.getUsername()).isNull();
-                    assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
-                }).verifyComplete();
+        StepVerifier.create(result.getCredentialsProvider().resolveCredentials()).assertNext(credentials -> {
+            assertThat(credentials.getUsername()).isNull();
+            assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
+        }).verifyComplete();
 
         assertThat(result.isSsl()).isTrue();
     }
@@ -254,11 +249,10 @@ class RedisURIBuilderUnitTests {
         assertThat(result.getPort()).isEqualTo(RedisURI.DEFAULT_REDIS_PORT);
         assertThat(result.getSentinelMasterId()).isEqualTo("master");
         assertThat(result.toString()).contains("master");
-        StepVerifier.create(Mono.fromCompletionStage(result.getCredentialsProvider().resolveCredentials()))
-                .assertNext(credentials -> {
-                    assertThat(credentials.getUsername()).isNull();
-                    assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
-                }).verifyComplete();
+        StepVerifier.create(result.getCredentialsProvider().resolveCredentials()).assertNext(credentials -> {
+            assertThat(credentials.getUsername()).isNull();
+            assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
+        }).verifyComplete();
 
         result = RedisURI.create(RedisURI.URI_SCHEME_REDIS_SENTINEL + "://password@host1:1,host2:3423,host3/1#master");
 
@@ -266,11 +260,10 @@ class RedisURIBuilderUnitTests {
         assertThat(result.getHost()).isNull();
         assertThat(result.getPort()).isEqualTo(RedisURI.DEFAULT_REDIS_PORT);
         assertThat(result.getSentinelMasterId()).isEqualTo("master");
-        StepVerifier.create(Mono.fromCompletionStage(result.getCredentialsProvider().resolveCredentials()))
-                .assertNext(credentials -> {
-                    assertThat(credentials.getUsername()).isNull();
-                    assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
-                }).verifyComplete();
+        StepVerifier.create(result.getCredentialsProvider().resolveCredentials()).assertNext(credentials -> {
+            assertThat(credentials.getUsername()).isNull();
+            assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
+        }).verifyComplete();
 
         RedisURI sentinel1 = result.getSentinels().get(0);
         assertThat(sentinel1.getPort()).isEqualTo(1);
@@ -291,11 +284,10 @@ class RedisURIBuilderUnitTests {
         RedisURI result = RedisURI.Builder.sentinel("host", 1234, "master", "foo").build();
 
         RedisURI sentinel = result.getSentinels().get(0);
-        StepVerifier.create(Mono.fromCompletionStage(sentinel.getCredentialsProvider().resolveCredentials()))
-                .assertNext(credentials -> {
-                    assertThat(credentials.getUsername()).isNull();
-                    assertThat(credentials.getPassword()).isEqualTo("foo".toCharArray());
-                }).verifyComplete();
+        StepVerifier.create(sentinel.getCredentialsProvider().resolveCredentials()).assertNext(credentials -> {
+            assertThat(credentials.getUsername()).isNull();
+            assertThat(credentials.getPassword()).isEqualTo("foo".toCharArray());
+        }).verifyComplete();
     }
 
     @Test
@@ -309,11 +301,10 @@ class RedisURIBuilderUnitTests {
         assertThat(sentinel.isStartTls()).isTrue();
         assertThat(sentinel.isVerifyPeer()).isFalse();
 
-        StepVerifier.create(Mono.fromCompletionStage(sentinel.getCredentialsProvider().resolveCredentials()))
-                .assertNext(credentials -> {
-                    assertThat(credentials.getUsername()).isNull();
-                    assertThat(credentials.getPassword()).isEqualTo("foo".toCharArray());
-                }).verifyComplete();
+        StepVerifier.create(sentinel.getCredentialsProvider().resolveCredentials()).assertNext(credentials -> {
+            assertThat(credentials.getUsername()).isNull();
+            assertThat(credentials.getPassword()).isEqualTo("foo".toCharArray());
+        }).verifyComplete();
     }
 
     @Test
@@ -323,15 +314,13 @@ class RedisURIBuilderUnitTests {
         sentinel.setAuthentication("bar".toCharArray());
         RedisURI result = RedisURI.Builder.sentinel("host", 1234, "master").withSentinel(sentinel).build();
 
-        StepVerifier
-                .create(Mono.fromCompletionStage(result.getSentinels().get(0).getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(result.getSentinels().get(0).getCredentialsProvider().resolveCredentials())
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isNull();
                 }).verifyComplete();
 
-        StepVerifier
-                .create(Mono.fromCompletionStage(result.getSentinels().get(1).getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(result.getSentinels().get(1).getCredentialsProvider().resolveCredentials())
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isEqualTo("bar".toCharArray());
@@ -343,15 +332,13 @@ class RedisURIBuilderUnitTests {
 
         RedisURI result = RedisURI.Builder.sentinel("host", 1234, "master", "foo").withSentinel("bar").build();
 
-        StepVerifier
-                .create(Mono.fromCompletionStage(result.getSentinels().get(0).getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(result.getSentinels().get(0).getCredentialsProvider().resolveCredentials())
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isEqualTo("foo".toCharArray());
                 }).verifyComplete();
 
-        StepVerifier
-                .create(Mono.fromCompletionStage(result.getSentinels().get(1).getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(result.getSentinels().get(1).getCredentialsProvider().resolveCredentials())
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isNull();
@@ -360,15 +347,13 @@ class RedisURIBuilderUnitTests {
         result = RedisURI.Builder.sentinel("host", 1234, "master").withPassword("foo".toCharArray())
                 .withSentinel("bar", 1234, "baz").build();
 
-        StepVerifier
-                .create(Mono.fromCompletionStage(result.getSentinels().get(0).getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(result.getSentinels().get(0).getCredentialsProvider().resolveCredentials())
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isNull();
                 }).verifyComplete();
 
-        StepVerifier
-                .create(Mono.fromCompletionStage(result.getSentinels().get(1).getCredentialsProvider().resolveCredentials()))
+        StepVerifier.create(result.getSentinels().get(1).getCredentialsProvider().resolveCredentials())
                 .assertNext(credentials -> {
                     assertThat(credentials.getUsername()).isNull();
                     assertThat(credentials.getPassword()).isEqualTo("baz".toCharArray());
@@ -425,11 +410,10 @@ class RedisURIBuilderUnitTests {
         assertThat(result.getPort()).isEqualTo(RedisURI.DEFAULT_REDIS_PORT);
         assertThat(result.isSsl()).isFalse();
 
-        StepVerifier.create(Mono.fromCompletionStage(result.getCredentialsProvider().resolveCredentials()))
-                .assertNext(credentials -> {
-                    assertThat(credentials.getUsername()).isNull();
-                    assertThat(credentials.getPassword()).isNull();
-                }).verifyComplete();
+        StepVerifier.create(result.getCredentialsProvider().resolveCredentials()).assertNext(credentials -> {
+            assertThat(credentials.getUsername()).isNull();
+            assertThat(credentials.getPassword()).isNull();
+        }).verifyComplete();
     }
 
     @Test
@@ -444,11 +428,10 @@ class RedisURIBuilderUnitTests {
         assertThat(result.getPort()).isEqualTo(RedisURI.DEFAULT_REDIS_PORT);
         assertThat(result.isSsl()).isFalse();
 
-        StepVerifier.create(Mono.fromCompletionStage(result.getCredentialsProvider().resolveCredentials()))
-                .assertNext(credentials -> {
-                    assertThat(credentials.getUsername()).isNull();
-                    assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
-                }).verifyComplete();
+        StepVerifier.create(result.getCredentialsProvider().resolveCredentials()).assertNext(credentials -> {
+            assertThat(credentials.getUsername()).isNull();
+            assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
+        }).verifyComplete();
     }
 
     @Test
@@ -497,11 +480,10 @@ class RedisURIBuilderUnitTests {
         assertThat(target.isSsl()).isEqualTo(source.isSsl());
         assertThat(target.isVerifyPeer()).isEqualTo(source.isVerifyPeer());
 
-        StepVerifier.create(Mono.fromCompletionStage(target.getCredentialsProvider().resolveCredentials()))
-                .assertNext(credentials -> {
-                    assertThat(credentials.getUsername()).isNull();
-                    assertThat(credentials.getPassword()).isEqualTo("baz".toCharArray());
-                }).verifyComplete();
+        StepVerifier.create(target.getCredentialsProvider().resolveCredentials()).assertNext(credentials -> {
+            assertThat(credentials.getUsername()).isNull();
+            assertThat(credentials.getPassword()).isEqualTo("baz".toCharArray());
+        }).verifyComplete();
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/RedisURIUnitTests.java
+++ b/src/test/java/io/lettuce/core/RedisURIUnitTests.java
@@ -90,7 +90,7 @@ class RedisURIUnitTests {
     void toStringShouldUnwrapCredentialsProviderFailure() {
 
         RedisException cause = new RedisException("auth failed");
-        RedisCredentialsProvider failing = () -> {
+        CredentialsProvider failing = () -> {
             CompletableFuture<RedisCredentials> f = new CompletableFuture<>();
             f.completeExceptionally(cause);
             return f;
@@ -106,7 +106,7 @@ class RedisURIUnitTests {
     void toStringShouldUnwrapCredentialsProviderRuntimeFailure() {
 
         IllegalStateException cause = new IllegalStateException("boom");
-        RedisCredentialsProvider failing = () -> {
+        CredentialsProvider failing = () -> {
             CompletableFuture<RedisCredentials> f = new CompletableFuture<>();
             f.completeExceptionally(cause);
             return f;
@@ -284,21 +284,19 @@ class RedisURIUnitTests {
         String uri = "redis-sentinel://" + translatedPassword + "@h1:1234,h2:1234,h3:1234/0?sentinelMasterId=masterId";
         RedisURI redisURI = RedisURI.create(uri);
         assertThat(redisURI.getSentinels().get(0).getHost()).isEqualTo("h1");
-        StepVerifier.create(Mono.fromCompletionStage(redisURI.getCredentialsProvider().resolveCredentials()))
-                .assertNext(credentials -> {
-                    assertThat(credentials.getUsername()).isNull();
-                    assertThat(credentials.getPassword()).isEqualTo(password.toCharArray());
-                }).verifyComplete();
+        StepVerifier.create(redisURI.getCredentialsProvider().resolveCredentials()).assertNext(credentials -> {
+            assertThat(credentials.getUsername()).isNull();
+            assertThat(credentials.getPassword()).isEqualTo(password.toCharArray());
+        }).verifyComplete();
 
         // redis standalone
         uri = "redis://" + translatedPassword + "@h1:1234/0";
         redisURI = RedisURI.create(uri);
         assertThat(redisURI.getHost()).isEqualTo("h1");
-        StepVerifier.create(Mono.fromCompletionStage(redisURI.getCredentialsProvider().resolveCredentials()))
-                .assertNext(credentials -> {
-                    assertThat(credentials.getUsername()).isNull();
-                    assertThat(credentials.getPassword()).isEqualTo(password.toCharArray());
-                }).verifyComplete();
+        StepVerifier.create(redisURI.getCredentialsProvider().resolveCredentials()).assertNext(credentials -> {
+            assertThat(credentials.getUsername()).isNull();
+            assertThat(credentials.getPassword()).isEqualTo(password.toCharArray());
+        }).verifyComplete();
     }
 
     @Test
@@ -427,22 +425,20 @@ class RedisURIUnitTests {
         RedisURI target = new RedisURI();
         target.applyAuthentication(source);
 
-        StepVerifier.create(Mono.fromCompletionStage(target.getCredentialsProvider().resolveCredentials()))
-                .assertNext(credentials -> {
-                    assertThat(credentials.getUsername()).isEqualTo("foo");
-                    assertThat(credentials.getPassword()).isEqualTo("bar".toCharArray());
-                }).verifyComplete();
+        StepVerifier.create(target.getCredentialsProvider().resolveCredentials()).assertNext(credentials -> {
+            assertThat(credentials.getUsername()).isEqualTo("foo");
+            assertThat(credentials.getPassword()).isEqualTo("bar".toCharArray());
+        }).verifyComplete();
 
         source.setCredentialsProvider(new StaticCredentialsProvider(null, "bar".toCharArray()));
         target.applyAuthentication(source);
 
-        StepVerifier.create(Mono.fromCompletionStage(target.getCredentialsProvider().resolveCredentials()))
-                .assertNext(credentials -> {
-                    assertThat(credentials.getUsername()).isNull();
-                    assertThat(credentials.getPassword()).isEqualTo("bar".toCharArray());
-                }).verifyComplete();
+        StepVerifier.create(target.getCredentialsProvider().resolveCredentials()).assertNext(credentials -> {
+            assertThat(credentials.getUsername()).isNull();
+            assertThat(credentials.getPassword()).isEqualTo("bar".toCharArray());
+        }).verifyComplete();
 
-        RedisCredentialsProvider provider = () -> CompletableFuture
+        CredentialsProvider provider = () -> CompletableFuture
                 .completedFuture(RedisCredentials.just("suppliedUsername", "suppliedPassword".toCharArray()));
 
         RedisURI sourceCp = new RedisURI();
@@ -451,11 +447,10 @@ class RedisURIUnitTests {
         RedisURI targetCp = new RedisURI();
         targetCp.applyAuthentication(sourceCp);
 
-        StepVerifier.create(Mono.fromCompletionStage(targetCp.getCredentialsProvider().resolveCredentials()))
-                .assertNext(credentials -> {
-                    assertThat(credentials.getUsername()).isEqualTo("suppliedUsername");
-                    assertThat(credentials.getPassword()).isEqualTo("suppliedPassword".toCharArray());
-                }).verifyComplete();
+        StepVerifier.create(targetCp.getCredentialsProvider().resolveCredentials()).assertNext(credentials -> {
+            assertThat(credentials.getUsername()).isEqualTo("suppliedUsername");
+            assertThat(credentials.getPassword()).isEqualTo("suppliedPassword".toCharArray());
+        }).verifyComplete();
         assertThat(sourceCp.getCredentialsProvider()).isEqualTo(targetCp.getCredentialsProvider());
     }
 

--- a/src/test/java/io/lettuce/core/cluster/RedisClusterURIUtilUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisClusterURIUtilUnitTests.java
@@ -75,11 +75,10 @@ class RedisClusterURIUtilUnitTests {
         assertThat(host1.isStartTls()).isTrue();
         assertThat(host1.getHost()).isEqualTo("host1");
         assertThat(host1.getPort()).isEqualTo(6379);
-        StepVerifier.create(Mono.fromCompletionStage(host1.getCredentialsProvider().resolveCredentials()))
-                .assertNext(credentials -> {
-                    assertThat(credentials.getUsername()).isNull();
-                    assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
-                }).verifyComplete();
+        StepVerifier.create(host1.getCredentialsProvider().resolveCredentials()).assertNext(credentials -> {
+            assertThat(credentials.getUsername()).isNull();
+            assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
+        }).verifyComplete();
     }
 
     @Test
@@ -94,22 +93,20 @@ class RedisClusterURIUtilUnitTests {
         assertThat(host1.isStartTls()).isTrue();
         assertThat(host1.getHost()).isEqualTo("host1");
         assertThat(host1.getPort()).isEqualTo(6379);
-        StepVerifier.create(Mono.fromCompletionStage(host1.getCredentialsProvider().resolveCredentials()))
-                .assertNext(credentials -> {
-                    assertThat(credentials.getUsername()).isNull();
-                    assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
-                }).verifyComplete();
+        StepVerifier.create(host1.getCredentialsProvider().resolveCredentials()).assertNext(credentials -> {
+            assertThat(credentials.getUsername()).isNull();
+            assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
+        }).verifyComplete();
 
         RedisURI host2 = redisURIs.get(1);
         assertThat(host2.isSsl()).isTrue();
         assertThat(host2.isStartTls()).isTrue();
         assertThat(host2.getHost()).isEqualTo("host2");
         assertThat(host2.getPort()).isEqualTo(6380);
-        StepVerifier.create(Mono.fromCompletionStage(host2.getCredentialsProvider().resolveCredentials()))
-                .assertNext(credentials -> {
-                    assertThat(credentials.getUsername()).isNull();
-                    assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
-                }).verifyComplete();
+        StepVerifier.create(host2.getCredentialsProvider().resolveCredentials()).assertNext(credentials -> {
+            assertThat(credentials.getUsername()).isNull();
+            assertThat(credentials.getPassword()).isEqualTo("password".toCharArray());
+        }).verifyComplete();
     }
 
 }


### PR DESCRIPTION
alternative of #3838 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection handshake and re-authentication credential resolution across the client; behavior should stay equivalent via adapters, but any custom `RedisCredentialsProvider` or streaming semantics need careful migration to `CredentialsProvider`.
> 
> **Overview**
> Introduces a **reactor-free** `CredentialsProvider` API (`resolveCredentialsAsync()`, callback-based `subscribeToCredentials()` returning `Subscription`) as the primary credential contract, and **deprecates** `RedisCredentialsProvider` while keeping it as a reactive extension (`Mono`/`Flux`) for backward compatibility.
> 
> **`RedisURI`** now stores `CredentialsProvider` internally; connection setup (`RedisHandshake`, `RedisAuthenticationHandler`, `ConnectionState`, cluster/standalone clients) uses **`getCredentialsProviderAsync()`** so handshake and re-auth avoid Reactor unless needed. Legacy **`getCredentialsProvider()`** wraps non-reactive providers via **`AsyncCredentialsProviderAdapter`**.
> 
> Implementations move to the new model: **`StaticCredentialsProvider`** and **`TokenBasedRedisCredentialsProvider`** implement `CredentialsProvider` (renamed async method, `Subscription` instead of nested `CredentialsSubscription`). Tests call `resolveCredentialsAsync()` or reactive `resolveCredentials()` where appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88b3ed6c108fb4d75fdd07b7fbc72f5417f698de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->