### PR TITLE
test: run the standard command integration tests against an external Redis Enterprise database

### DIFF
--- a/src/test/java/io/lettuce/core/commands/AclCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/AclCommandIntegrationTests.java
@@ -41,6 +41,7 @@ import io.lettuce.core.protocol.Command;
 import io.lettuce.core.protocol.CommandArgs;
 import io.lettuce.core.protocol.CommandType;
 import io.lettuce.test.LettuceExtension;
+import io.lettuce.test.condition.DisabledOnRedisEnterprise;
 import io.lettuce.test.condition.EnabledOnCommand;
 
 /**
@@ -53,6 +54,7 @@ import io.lettuce.test.condition.EnabledOnCommand;
 @ExtendWith(LettuceExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @EnabledOnCommand("ACL")
+@DisabledOnRedisEnterprise("ACL SETUSER / user management is not permitted for the default user on a managed Redis Enterprise database")
 public class AclCommandIntegrationTests extends TestSupport {
 
     private final RedisCommands<String, String> redis;

--- a/src/test/java/io/lettuce/core/commands/CommandInterfacesIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/CommandInterfacesIntegrationTests.java
@@ -28,6 +28,7 @@ import io.lettuce.core.dynamic.Commands;
 import io.lettuce.core.dynamic.RedisCommandFactory;
 import io.lettuce.core.dynamic.annotation.Command;
 import io.lettuce.core.dynamic.annotation.Param;
+import io.lettuce.test.condition.DisabledOnRedisEnterprise;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -46,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Tihomir Mateev
  */
 @Tag(INTEGRATION_TEST)
+@DisabledOnRedisEnterprise("Connects to a hardcoded localhost Redis Stack instance (127.0.0.1:16379), not the managed database")
 public class CommandInterfacesIntegrationTests {
 
     protected static RedisClient client;

--- a/src/test/java/io/lettuce/core/commands/ConsolidatedAclCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/ConsolidatedAclCommandIntegrationTests.java
@@ -22,6 +22,7 @@ package io.lettuce.core.commands;
 import io.lettuce.core.*;
 import io.lettuce.core.api.sync.RedisCommands;
 
+import io.lettuce.test.condition.DisabledOnRedisEnterprise;
 import io.lettuce.test.condition.RedisConditions;
 import org.junit.jupiter.api.*;
 
@@ -37,6 +38,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * @author M Sazzadul Hoque
  */
 @Tag(INTEGRATION_TEST)
+@DisabledOnRedisEnterprise("ACL SETUSER / user management is not permitted for the default user on a managed Redis Enterprise database")
 public class ConsolidatedAclCommandIntegrationTests {
 
     private static RedisClient client;

--- a/src/test/java/io/lettuce/core/commands/ConsolidatedConfigurationCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/ConsolidatedConfigurationCommandIntegrationTests.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.lettuce.core.*;
 import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.test.condition.DisabledOnRedisEnterprise;
 import io.lettuce.test.condition.RedisConditions;
 
 import org.junit.jupiter.api.*;
@@ -38,6 +39,7 @@ import java.util.Collections;
  * @author M Sazzadul Hoque
  */
 @Tag(INTEGRATION_TEST)
+@DisabledOnRedisEnterprise("CONFIG GET/SET of server parameters is not exposed the same way on a managed Redis Enterprise database")
 public class ConsolidatedConfigurationCommandIntegrationTests {
 
     private static RedisClient client;

--- a/src/test/java/io/lettuce/core/commands/GeoMasterReplicaIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/GeoMasterReplicaIntegrationTests.java
@@ -8,6 +8,7 @@ import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection;
 import io.lettuce.core.models.role.RedisInstance;
 import io.lettuce.core.models.role.RoleParser;
 import io.lettuce.test.LettuceExtension;
+import io.lettuce.test.condition.DisabledOnRedisEnterprise;
 import io.lettuce.test.condition.EnabledOnCommand;
 import io.lettuce.test.settings.TestSettings;
 import org.junit.jupiter.api.*;
@@ -28,6 +29,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 @ExtendWith(LettuceExtension.class)
 @EnabledOnCommand("GEOADD")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisabledOnRedisEnterprise("Requires a local master-replica topology with fixed ports that a single managed Redis Enterprise database does not provide")
 public class GeoMasterReplicaIntegrationTests extends AbstractRedisClientTest {
 
     private StatefulRedisMasterReplicaConnection<String, String> masterReplica;

--- a/src/test/java/io/lettuce/core/commands/HotkeysCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/HotkeysCommandIntegrationTests.java
@@ -26,6 +26,7 @@ import io.lettuce.core.HotkeysReply;
 import io.lettuce.core.TestSupport;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.test.LettuceExtension;
+import io.lettuce.test.condition.DisabledOnRedisEnterprise;
 import io.lettuce.test.condition.EnabledOnCommand;
 
 /**
@@ -37,6 +38,7 @@ import io.lettuce.test.condition.EnabledOnCommand;
 @ExtendWith(LettuceExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @EnabledOnCommand("HOTKEYS")
+@DisabledOnRedisEnterprise("HOTKEYS requires the maxmemory-policy to be configured via CONFIG, which is not permitted on a managed Redis Enterprise database")
 public class HotkeysCommandIntegrationTests extends TestSupport {
 
     protected RedisCommands<String, String> redis;

--- a/src/test/java/io/lettuce/core/commands/KeyCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/KeyCommandIntegrationTests.java
@@ -50,6 +50,7 @@ import io.lettuce.core.TestSupport;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.test.LettuceExtension;
 import io.lettuce.test.ListStreamingAdapter;
+import io.lettuce.test.condition.DisabledOnRedisEnterprise;
 import io.lettuce.test.condition.EnabledOnCommand;
 
 /**
@@ -116,6 +117,7 @@ public class KeyCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("COPY")
+    @DisabledOnRedisEnterprise("COPY across DB indexes is not supported on a managed Redis Enterprise database (single logical DB)")
     void copyWithDestinationDb() {
         redis.set(key, value);
         redis.copy(key, key, CopyArgs.Builder.destinationDb(2));
@@ -228,6 +230,7 @@ public class KeyCommandIntegrationTests extends TestSupport {
     }
 
     @Test
+    @DisabledOnRedisEnterprise("MOVE across DB indexes is not supported on a managed Redis Enterprise database (single logical DB)")
     public void move() {
         redis.set(key, value);
         redis.move(key, 1);
@@ -245,6 +248,7 @@ public class KeyCommandIntegrationTests extends TestSupport {
     }
 
     @Test
+    @DisabledOnRedisEnterprise("Requires switching maxmemory-policy to an LFU policy via CONFIG SET, which is not permitted on a managed Redis Enterprise database")
     void objectFreq() {
         String maxmemoryPolicy = redis.configGet("maxmemory-policy").get("maxmemory-policy");
         try {

--- a/src/test/java/io/lettuce/core/commands/ServerCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/ServerCommandIntegrationTests.java
@@ -52,6 +52,7 @@ import io.lettuce.core.models.role.RoleParser;
 import io.lettuce.core.protocol.CommandType;
 import io.lettuce.test.LettuceExtension;
 import io.lettuce.test.Wait;
+import io.lettuce.test.condition.DisabledOnRedisEnterprise;
 import io.lettuce.test.condition.EnabledOnCommand;
 import io.lettuce.test.settings.TestSettings;
 
@@ -73,6 +74,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 @Tag(INTEGRATION_TEST)
 @ExtendWith(LettuceExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisabledOnRedisEnterprise("Server administration commands (CONFIG, SLAVEOF/REPLICAOF, BGSAVE, LASTSAVE, SLOWLOG, CLIENT NO-EVICT, FLUSHDB ASYNC, ...) are not available to the default user on a managed Redis Enterprise database")
 public class ServerCommandIntegrationTests extends TestSupport {
 
     private final RedisClient client;

--- a/src/test/java/io/lettuce/core/commands/StringCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/StringCommandIntegrationTests.java
@@ -49,6 +49,7 @@ import io.lettuce.core.*;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.test.KeyValueStreamingAdapter;
 import io.lettuce.test.LettuceExtension;
+import io.lettuce.test.condition.DisabledOnRedisEnterprise;
 import io.lettuce.test.condition.EnabledOnCommand;
 
 /**
@@ -534,6 +535,7 @@ public class StringCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("INCREX")
+    @DisabledOnRedisEnterprise("INCREX is an OSS preview command not implemented on a managed Redis Enterprise database")
     void increxBasic() {
         IncrexValue<Long> res = redis.increx(key);
         assertThat(res.getValue()).isEqualTo(1L);
@@ -542,6 +544,7 @@ public class StringCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("INCREX")
+    @DisabledOnRedisEnterprise("INCREX is an OSS preview command not implemented on a managed Redis Enterprise database")
     void increxByIntWithBoundsAndExpiry() {
         redis.set(key, "10");
         IncrexArgs args = IncrexArgs.Builder.lbound(0).ubound(20).ex(60);
@@ -553,6 +556,7 @@ public class StringCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("INCREX")
+    @DisabledOnRedisEnterprise("INCREX is an OSS preview command not implemented on a managed Redis Enterprise database")
     void increxByFloatWithBoundsAndExpiry() {
         redis.set(key, "3.25");
         IncrexFloatArgs args = IncrexFloatArgs.Builder.lbound(-1.5).ubound(9.5).ex(60);
@@ -563,6 +567,7 @@ public class StringCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("INCREX")
+    @DisabledOnRedisEnterprise("INCREX is an OSS preview command not implemented on a managed Redis Enterprise database")
     void increxNegativeIncrement() {
         redis.set(key, "10");
         IncrexArgs args = new IncrexArgs();
@@ -573,6 +578,7 @@ public class StringCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("INCREX")
+    @DisabledOnRedisEnterprise("INCREX is an OSS preview command not implemented on a managed Redis Enterprise database")
     void increxDefaultRejectSilent() {
         redis.set(key, "0");
         IncrexArgs args = IncrexArgs.Builder.ubound(5);
@@ -583,6 +589,7 @@ public class StringCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("INCREX")
+    @DisabledOnRedisEnterprise("INCREX is an OSS preview command not implemented on a managed Redis Enterprise database")
     void increxSaturateUbound() {
         redis.set(key, "0");
         IncrexArgs args = IncrexArgs.Builder.ubound(5).saturate();
@@ -593,6 +600,7 @@ public class StringCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("INCREX")
+    @DisabledOnRedisEnterprise("INCREX is an OSS preview command not implemented on a managed Redis Enterprise database")
     void increxSaturateLbound() {
         redis.set(key, "5");
         IncrexArgs args = IncrexArgs.Builder.lbound(0).saturate();
@@ -603,6 +611,7 @@ public class StringCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("INCREX")
+    @DisabledOnRedisEnterprise("INCREX is an OSS preview command not implemented on a managed Redis Enterprise database")
     void increxSaturateStillAppliesExpiry() {
         redis.set(key, "5");
         IncrexArgs args = IncrexArgs.Builder.ubound(5).saturate().ex(60);
@@ -614,6 +623,7 @@ public class StringCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("INCREX")
+    @DisabledOnRedisEnterprise("INCREX is an OSS preview command not implemented on a managed Redis Enterprise database")
     void increxPersist() {
         redis.set(key, "5");
         redis.expire(key, 300);
@@ -626,6 +636,7 @@ public class StringCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("INCREX")
+    @DisabledOnRedisEnterprise("INCREX is an OSS preview command not implemented on a managed Redis Enterprise database")
     void increxEnxNoExistingTtl() {
         redis.set(key, "5");
         IncrexArgs args = IncrexArgs.Builder.ex(60).enx();
@@ -636,6 +647,7 @@ public class StringCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("INCREX")
+    @DisabledOnRedisEnterprise("INCREX is an OSS preview command not implemented on a managed Redis Enterprise database")
     void increxEnxWithExistingTtl() {
         redis.set(key, "5");
         redis.expire(key, 300);
@@ -648,6 +660,7 @@ public class StringCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("INCREX")
+    @DisabledOnRedisEnterprise("INCREX is an OSS preview command not implemented on a managed Redis Enterprise database")
     void increxNonExistentKey() {
         IncrexArgs args = new IncrexArgs();
         IncrexValue<Long> res = redis.increx(key, 5, args);
@@ -657,6 +670,7 @@ public class StringCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("INCREX")
+    @DisabledOnRedisEnterprise("INCREX is an OSS preview command not implemented on a managed Redis Enterprise database")
     void increxNonNumericKey() {
         redis.set(key, "hello");
         IncrexArgs args = new IncrexArgs();
@@ -665,6 +679,7 @@ public class StringCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("INCREX")
+    @DisabledOnRedisEnterprise("INCREX is an OSS preview command not implemented on a managed Redis Enterprise database")
     void increxSaturateFloat() {
         redis.set(key, "0.0");
         IncrexFloatArgs args = IncrexFloatArgs.Builder.ubound(5.0).saturate();
@@ -675,6 +690,7 @@ public class StringCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("INCREX")
+    @DisabledOnRedisEnterprise("INCREX is an OSS preview command not implemented on a managed Redis Enterprise database")
     void increxFloatThenIntFails() {
         redis.set(key, "1.5");
         IncrexArgs args = new IncrexArgs();

--- a/src/test/java/io/lettuce/test/condition/DisabledOnRedisEnterprise.java
+++ b/src/test/java/io/lettuce/test/condition/DisabledOnRedisEnterprise.java
@@ -1,0 +1,34 @@
+package io.lettuce.test.condition;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * {@code @DisabledOnRedisEnterprise} signals that the annotated test class or test method is <em>disabled</em> when the suite
+ * is running against a managed Redis Enterprise database ({@code RE_CLUSTER=true}).
+ *
+ * <p>
+ * Use it for specs that rely on behaviour a managed Enterprise deployment does not expose (OSS-only admin commands such as
+ * {@code CONFIG}/{@code ACL SETUSER}/{@code DEBUG}, OSS preview commands, or localhost-specific assumptions). When
+ * {@code RE_CLUSTER} is unset the annotation has no effect and the tests run normally.
+ * </p>
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@ExtendWith(DisabledOnRedisEnterpriseCondition.class)
+public @interface DisabledOnRedisEnterprise {
+
+    /**
+     * @return rationale describing why the annotated element cannot run against Redis Enterprise.
+     */
+    String value() default "";
+
+}

--- a/src/test/java/io/lettuce/test/condition/DisabledOnRedisEnterpriseCondition.java
+++ b/src/test/java/io/lettuce/test/condition/DisabledOnRedisEnterpriseCondition.java
@@ -1,0 +1,42 @@
+package io.lettuce.test.condition;
+
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.util.AnnotationUtils;
+
+import io.lettuce.test.settings.RedisEnterpriseSettings;
+
+/**
+ * {@link ExecutionCondition} for {@link DisabledOnRedisEnterprise @DisabledOnRedisEnterprise}.
+ *
+ * @see DisabledOnRedisEnterprise
+ */
+class DisabledOnRedisEnterpriseCondition implements ExecutionCondition {
+
+    private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled("@DisabledOnRedisEnterprise is not present");
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+
+        if (!RedisEnterpriseSettings.isEnabled()) {
+            return ENABLED_BY_DEFAULT;
+        }
+
+        Optional<DisabledOnRedisEnterprise> optional = AnnotationUtils.findAnnotation(context.getElement(),
+                DisabledOnRedisEnterprise.class);
+
+        if (optional.isPresent()) {
+            String reason = optional.get().value();
+            return disabled("Disabled on Redis Enterprise" + (reason.isEmpty() ? "" : ": " + reason));
+        }
+
+        return ENABLED_BY_DEFAULT;
+    }
+
+}

--- a/src/test/java/io/lettuce/test/resource/DefaultRedisClient.java
+++ b/src/test/java/io/lettuce/test/resource/DefaultRedisClient.java
@@ -2,6 +2,7 @@ package io.lettuce.test.resource;
 
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
+import io.lettuce.test.settings.RedisEnterpriseSettings;
 import io.lettuce.test.settings.TestSettings;
 
 /**
@@ -15,7 +16,16 @@ public class DefaultRedisClient {
     private final RedisClient redisClient;
 
     private DefaultRedisClient() {
-        redisClient = RedisClient.create(RedisURI.Builder.redis(TestSettings.host(), TestSettings.port()).build());
+        RedisURI.Builder builder = RedisURI.Builder.redis(TestSettings.host(), TestSettings.port());
+        // Against a managed Redis Enterprise database the default connection needs credentials and,
+        // optionally, TLS - the local defaults are passwordless plaintext.
+        if (RedisEnterpriseSettings.isEnabled()) {
+            builder = builder.withAuthentication(RedisEnterpriseSettings.username(), RedisEnterpriseSettings.password());
+            if (RedisEnterpriseSettings.tls()) {
+                builder = builder.withSsl(true).withVerifyPeer(false);
+            }
+        }
+        redisClient = RedisClient.create(builder.build());
         Runtime.getRuntime().addShutdownHook(new Thread(() -> FastShutdown.shutdown(redisClient)));
     }
 

--- a/src/test/java/io/lettuce/test/settings/RedisEnterpriseSettings.java
+++ b/src/test/java/io/lettuce/test/settings/RedisEnterpriseSettings.java
@@ -1,0 +1,66 @@
+package io.lettuce.test.settings;
+
+import io.lettuce.test.env.Endpoints;
+import io.lettuce.test.env.Endpoints.Endpoint;
+
+/**
+ * Resolves the managed Redis Enterprise database the standard integration suite should target.
+ *
+ * <p>
+ * When {@code RE_CLUSTER=true}, the database named by {@code RE_DB_NAME} (default {@code standalone}) is read from the
+ * endpoints config referenced by {@code REDIS_ENDPOINTS_CONFIG_PATH} - the same format consumed by the scenario tests - and its
+ * host, port, credentials and TLS flag are exposed to {@link TestSettings} and the default test client. When {@code RE_CLUSTER}
+ * is unset the suite behaves unchanged (localhost defaults, no auth).
+ * </p>
+ */
+public final class RedisEnterpriseSettings {
+
+    private RedisEnterpriseSettings() {
+    }
+
+    public static boolean isEnabled() {
+        return "true".equalsIgnoreCase(System.getenv("RE_CLUSTER"));
+    }
+
+    private static Endpoint endpoint() {
+        String name = System.getenv("RE_DB_NAME");
+        if (name == null || name.isEmpty()) {
+            name = "standalone";
+        }
+        Endpoint endpoint = Endpoints.DEFAULT.getEndpoint(name);
+        if (endpoint == null) {
+            throw new IllegalStateException(
+                    "RE_CLUSTER=true but database '" + name + "' was not found in REDIS_ENDPOINTS_CONFIG_PATH");
+        }
+        return endpoint;
+    }
+
+    public static String host() {
+        Endpoint endpoint = endpoint();
+        if (endpoint.getRawEndpoints() != null && !endpoint.getRawEndpoints().isEmpty()) {
+            return endpoint.getRawEndpoints().get(0).getDnsName();
+        }
+        throw new IllegalStateException("No raw_endpoints found for the Redis Enterprise database");
+    }
+
+    public static int port() {
+        Endpoint endpoint = endpoint();
+        if (endpoint.getRawEndpoints() != null && !endpoint.getRawEndpoints().isEmpty()) {
+            return endpoint.getRawEndpoints().get(0).getPort();
+        }
+        throw new IllegalStateException("No raw_endpoints found for the Redis Enterprise database");
+    }
+
+    public static String username() {
+        return endpoint().getUsername();
+    }
+
+    public static String password() {
+        return endpoint().getPassword();
+    }
+
+    public static boolean tls() {
+        return endpoint().isTls();
+    }
+
+}

--- a/src/test/java/io/lettuce/test/settings/TestSettings.java
+++ b/src/test/java/io/lettuce/test/settings/TestSettings.java
@@ -40,6 +40,9 @@ public class TestSettings {
      *         {@code -Dhost=YourHostName}
      */
     public static String host() {
+        if (RedisEnterpriseSettings.isEnabled()) {
+            return RedisEnterpriseSettings.host();
+        }
         return System.getProperty("host", "localhost");
     }
 
@@ -85,6 +88,9 @@ public class TestSettings {
      * @return default username of your redis instance.
      */
     public static String username() {
+        if (RedisEnterpriseSettings.isEnabled()) {
+            return RedisEnterpriseSettings.username();
+        }
         return "default";
     }
 
@@ -94,6 +100,9 @@ public class TestSettings {
      *         {@code -Dpassword=YourPassword}
      */
     public static CharSequence password() {
+        if (RedisEnterpriseSettings.isEnabled()) {
+            return RedisEnterpriseSettings.password();
+        }
         return System.getProperty("password", "foobared");
     }
 
@@ -120,6 +129,9 @@ public class TestSettings {
      * @return port of your redis instance. Defaults to {@literal 6479}. Can be overriden with {@code -Dport=1234}
      */
     public static int port() {
+        if (RedisEnterpriseSettings.isEnabled()) {
+            return RedisEnterpriseSettings.port();
+        }
         return Integer.parseInt(System.getProperty("port", "6479"));
     }
 


### PR DESCRIPTION
## Motivation

The standard `io.lettuce.core.commands.*IntegrationTests` assume a passwordless Redis reachable on localhost. This change lets the same tests also run against an **external / managed Redis Enterprise** database - remote host, authentication, and optional TLS - **without changing the existing local behaviour**.

## What changed

- **Opt-in endpoint discovery.** When `RE_CLUSTER=true`, a new `RedisEnterpriseSettings` resolves the target database (host, port, username, password, TLS) from `REDIS_ENDPOINTS_CONFIG_PATH` (the same endpoints-config format already consumed by the scenario tests; `RE_DB_NAME` selects a named database, default `standalone`). `TestSettings` and the default test client (`DefaultRedisClient`) route through it, so the injected connection targets the managed database with auth/TLS. **When `RE_CLUSTER` is unset, behaviour is unchanged** (localhost defaults, no auth).
- **`@DisabledOnRedisEnterprise`** - a new JUnit condition (active only when `RE_CLUSTER=true`) applied to the specs that cannot run against a managed Enterprise database, each with a rationale: ACL / ConsolidatedAcl (user management), ConsolidatedConfiguration and ServerCommand (CONFIG / SLAVEOF / BGSAVE / SLOWLOG / CLIENT NO-EVICT server-admin), Hotkeys (CONFIG-dependent), GeoMasterReplica (needs a local master-replica topology), CommandInterfaces#issue2612 (hardcoded localhost Stack instance), KeyCommand copy-across-db / move / objectFreq (cross-DB + CONFIG), and the StringCommand INCREX specs (OSS preview command).

## Validation

Ran the command integration suite against a managed Redis Enterprise 8.x database: **738 run, 0 failures, 0 errors, 148 skipped**. With `RE_CLUSTER` unset the suite still targets localhost unchanged.

---
This change was prepared with AI assistance and reviewed before submission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test infrastructure and conditional test skipping; production library code is untouched.
> 
> **Overview**
> Adds **opt-in Redis Enterprise targeting** for the standard command integration suite. When `RE_CLUSTER=true`, new `RedisEnterpriseSettings` loads host, port, credentials, and TLS from `REDIS_ENDPOINTS_CONFIG_PATH` (via `RE_DB_NAME`, default `standalone`). `TestSettings` and `DefaultRedisClient` use that endpoint and apply auth/TLS on the default client; without `RE_CLUSTER`, localhost behavior is unchanged.
> 
> Introduces **`@DisabledOnRedisEnterprise`** (JUnit `ExecutionCondition` gated on `RE_CLUSTER`) and applies it to specs that assume OSS-only admin, multi-DB, local topology, hardcoded Stack on `127.0.0.1:16379`, or OSS preview commands—whole classes (ACL, server admin, CONFIG, HOTKEYS, master-replica, etc.) and selective methods (cross-DB COPY/MOVE, `objectFreq`, all INCREX tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 564d78bb3cb861277d82a878450fb48fc8dd50d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->