### PR TITLE
test(scenario): drive in-flight traffic during MOVING relaxed-timeout test

### DIFF
--- a/src/test/java/io/lettuce/scenario/RelaxedTimeoutConfigurationTest.java
+++ b/src/test/java/io/lettuce/scenario/RelaxedTimeoutConfigurationTest.java
@@ -586,6 +586,28 @@ public class RelaxedTimeoutConfigurationTest {
         log.info("test timeoutUnrelaxedOnMovingTest started");
         TimeoutTestContext context = setupTimeoutTestForMovingUnrelaxed();
 
+        // Keep commands in flight for the duration of the maintenance operation. Timeout
+        // relaxation protects in-flight commands: on a MOVING/re-bind with an empty command
+        // stack the client reconnects immediately without relaxing (see
+        // MaintenanceAwareConnectionWatchdog#rebind), so a test that only issues a single
+        // reactive command sees the normal timeout. Real workloads have traffic in flight
+        // across the re-bind; drive continuous traffic so relaxation is exercised as designed.
+        final AtomicBoolean keepBackgroundTraffic = new AtomicBoolean(true);
+        Thread backgroundTraffic = new Thread(() -> {
+            long i = 0;
+            while (keepBackgroundTraffic.get()) {
+                try {
+                    context.connection.async().set("moving-inflight-key-" + (i % 50), "v" + i);
+                    i++;
+                    Thread.sleep(1);
+                } catch (Exception ignored) {
+                    // Errors during the re-bind window are expected; keep the stack busy.
+                }
+            }
+        }, "moving-inflight-traffic");
+        backgroundTraffic.setDaemon(true);
+        backgroundTraffic.start();
+
         try {
             log.info("=== MOVING Un-relaxed Timeout Test: Starting maintenance operation ===");
 
@@ -626,6 +648,8 @@ public class RelaxedTimeoutConfigurationTest {
             context.capture.throwIfAssertionFailed();
 
         } finally {
+            keepBackgroundTraffic.set(false);
+            backgroundTraffic.join(Duration.ofSeconds(5).toMillis());
             context.capture.endTestPhase();
             cleanupTimeoutTest(context);
         }


### PR DESCRIPTION
## Summary

`RelaxedTimeoutConfigurationTest.timeoutUnrelaxedOnMovingTest` intermittently
failed with "expected at least one relaxed timeout … but was 0". The test issued
only a single reactive command around the MOVING/re-bind. When the command stack
is empty on a MOVING re-bind, the client reconnects immediately **without**
relaxing the timeout (by design — see `MaintenanceAwareConnectionWatchdog#rebind`),
so the single command observes the normal timeout and the assertion never sees a
relaxed one.

Real workloads have commands in flight across the re-bind, which is exactly when
timeout relaxation is meant to kick in.

## What changed

- Drive continuous background traffic for the duration of the maintenance
  operation so the re-bind happens with a non-empty command stack and the
  relaxation path is exercised as designed. Traffic is stopped and joined in a
  `finally` block.

Test-only change.

## Test plan

- [x] `RelaxedTimeoutConfigurationTest#timeoutUnrelaxedOnMovingTest` against a
      server that emits MOVING notifications during a re-bind.

---
_Prepared with AI assistance and reviewed under my account._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to scenario coverage; no production code paths modified.
> 
> **Overview**
> Fixes flaky **`timeoutUnrelaxedOnMovingTest`** failures where no relaxed timeout was observed (`expected at least one relaxed timeout … but was 0`).
> 
> The test now runs a **daemon background thread** that continuously issues async `SET` commands (with a short sleep) for the whole maintenance window, then stops and joins it in **`finally`**. That mirrors real workloads: when the command stack is empty on a MOVING re-bind, **`MaintenanceAwareConnectionWatchdog#rebind`** reconnects without relaxing timeouts, so a single reactive command could miss the relaxation path the test is meant to validate.
> 
> **Production client behavior is unchanged** — test-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c22759311b9ad77710f9f49378d8e52f42f96914. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->