### PR TITLE
Prefer topology views with full slot coverage during topology refresh…

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
+++ b/src/main/java/io/lettuce/core/cluster/RedisClusterClient.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -148,6 +149,7 @@ import static io.lettuce.core.RedisAuthenticationHandler.createHandler;
  * possible.
  *
  * @author Mark Paluch
+ * @author Tony Zhang
  * @since 3.0
  * @see RedisURI
  * @see StatefulRedisClusterConnection
@@ -1119,7 +1121,8 @@ public class RedisClusterClient extends AbstractRedisClient {
     }
 
     /**
-     * Determines a {@link Partitions topology view} based on the current and the obtain topology views.
+     * Determines a {@link Partitions topology view} based on the current and the obtain topology views. Topology views without
+     * full slot coverage are only considered if no view provides full slot coverage.
      *
      * @param current the current topology view. May be {@code null} if {@link RedisClusterClient} has no topology view yet.
      * @param topologyViews the obtain topology views
@@ -1127,11 +1130,35 @@ public class RedisClusterClient extends AbstractRedisClient {
      */
     protected Partitions determinePartitions(Partitions current, Map<RedisURI, Partitions> topologyViews) {
 
+        Map<RedisURI, Partitions> preferredViews = getViewsWithFullSlotCoverage(topologyViews);
+
         if (current == null) {
-            return PartitionsConsensus.HEALTHY_MAJORITY.getPartitions(null, topologyViews);
+            return PartitionsConsensus.HEALTHY_MAJORITY.getPartitions(null, preferredViews);
         }
 
-        return PartitionsConsensus.KNOWN_MAJORITY.getPartitions(current, topologyViews);
+        return PartitionsConsensus.KNOWN_MAJORITY.getPartitions(current, preferredViews);
+    }
+
+    private static Map<RedisURI, Partitions> getViewsWithFullSlotCoverage(Map<RedisURI, Partitions> topologyViews) {
+
+        Map<RedisURI, Partitions> result = new LinkedHashMap<>(topologyViews);
+        result.entrySet().removeIf(entry -> !hasFullSlotCoverage(entry.getValue()));
+
+        if (result.isEmpty() || result.size() == topologyViews.size()) {
+            return topologyViews;
+        }
+
+        return result;
+    }
+
+    private static boolean hasFullSlotCoverage(Partitions partitions) {
+
+        int slots = 0;
+        for (RedisClusterNode node : partitions) {
+            slots += node.getSlotCount();
+        }
+
+        return slots == SlotHash.SLOT_COUNT;
     }
 
     /**

--- a/src/main/java/io/lettuce/core/cluster/models/partitions/RedisClusterNode.java
+++ b/src/main/java/io/lettuce/core/cluster/models/partitions/RedisClusterNode.java
@@ -305,6 +305,22 @@ public class RedisClusterNode implements Serializable, RedisNodeDescription {
     }
 
     /**
+     * Return the number of slots assigned to this node. Unlike {@link #getSlots()}, this method does not allocate a
+     * {@link List}.
+     *
+     * @return the number of assigned slots, {@code 0} if no slots are assigned.
+     * @since 7.7
+     */
+    public int getSlotCount() {
+
+        if (slots == null) {
+            return 0;
+        }
+
+        return slots.cardinality();
+    }
+
+    /**
      * Performs the given action for each slot of this {@link RedisClusterNode} until all elements have been processed or the
      * action throws an exception. Unless otherwise specified by the implementing class, actions are performed in the order of
      * iteration (if an iteration order is specified). Exceptions thrown by the action are relayed to the caller.

--- a/src/main/java/io/lettuce/core/cluster/models/partitions/RedisClusterNode.java
+++ b/src/main/java/io/lettuce/core/cluster/models/partitions/RedisClusterNode.java
@@ -305,6 +305,22 @@ public class RedisClusterNode implements Serializable, RedisNodeDescription {
     }
 
     /**
+     * Return the number of slots assigned to this node. Unlike {@link #getSlots()}, this method does not allocate a
+     * {@link List}.
+     *
+     * @return the number of assigned slots, {@code 0} if no slots are assigned.
+     * @since 7.8
+     */
+    public int getSlotCount() {
+
+        if (slots == null) {
+            return 0;
+        }
+
+        return slots.cardinality();
+    }
+
+    /**
      * Performs the given action for each slot of this {@link RedisClusterNode} until all elements have been processed or the
      * action throws an exception. Unless otherwise specified by the implementing class, actions are performed in the order of
      * iteration (if an iteration order is specified). Exceptions thrown by the action are relayed to the caller.

--- a/src/test/java/io/lettuce/core/cluster/PartitionsConsensusTestSupport.java
+++ b/src/test/java/io/lettuce/core/cluster/PartitionsConsensusTestSupport.java
@@ -16,8 +16,21 @@ import static io.lettuce.TestTags.INTEGRATION_TEST;
 class PartitionsConsensusTestSupport {
 
     static RedisClusterNode createNode(int nodeId) {
-        return new RedisClusterNode(RedisURI.create("localhost", 6379 - 2020 + nodeId), "" + nodeId, true, "", 0, 0, 0,
-                Collections.emptyList(), new HashSet<>());
+        return createNode(nodeId, Collections.emptyList());
+    }
+
+    static RedisClusterNode createNode(int nodeId, List<Integer> slots) {
+        return new RedisClusterNode(RedisURI.create("localhost", 6379 - 2020 + nodeId), "" + nodeId, true, "", 0, 0, 0, slots,
+                new HashSet<>());
+    }
+
+    static List<Integer> createSlots(int fromInclusive, int toExclusive) {
+
+        List<Integer> slots = new ArrayList<>();
+        for (int slot = fromInclusive; slot < toExclusive; slot++) {
+            slots.add(slot);
+        }
+        return slots;
     }
 
     static Partitions createPartitions(RedisClusterNode... nodes) {

--- a/src/test/java/io/lettuce/core/cluster/RedisClusterClientDeterminePartitionsUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisClusterClientDeterminePartitionsUnitTests.java
@@ -1,0 +1,99 @@
+package io.lettuce.core.cluster;
+
+import static io.lettuce.TestTags.UNIT_TEST;
+import static io.lettuce.core.cluster.PartitionsConsensusTestSupport.createMap;
+import static io.lettuce.core.cluster.PartitionsConsensusTestSupport.createNode;
+import static io.lettuce.core.cluster.PartitionsConsensusTestSupport.createPartitions;
+import static io.lettuce.core.cluster.PartitionsConsensusTestSupport.createSlots;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.cluster.models.partitions.Partitions;
+import io.lettuce.core.resource.ClientResources;
+import io.lettuce.test.resource.FastShutdown;
+
+/**
+ * Unit tests for {@link RedisClusterClient#determinePartitions}.
+ *
+ * @author Tony Zhang
+ */
+@Tag(UNIT_TEST)
+class RedisClusterClientDeterminePartitionsUnitTests {
+
+    private final ClientResources clientResources = ClientResources.builder().build();
+
+    private final RedisClusterClient client = RedisClusterClient.create(clientResources, RedisURI.create("localhost", 6379));
+
+    @AfterEach
+    void tearDown() {
+        FastShutdown.shutdown(client);
+        FastShutdown.shutdown(clientResources);
+    }
+
+    @Test
+    void shouldNotConsiderViewsWithoutFullSlotCoverage() {
+
+        Partitions current = createPartitions(createNode(1), createNode(2), createNode(3));
+
+        Partitions fullCoverage = createPartitions(createNode(1, createSlots(0, SlotHash.SLOT_COUNT / 2)),
+                createNode(2, createSlots(SlotHash.SLOT_COUNT / 2, SlotHash.SLOT_COUNT)), createNode(3));
+
+        // View as reported by a node that just joined the cluster: same nodes, but a master without slots.
+        Partitions partialCoverage = createPartitions(createNode(1, createSlots(0, SlotHash.SLOT_COUNT / 2)), createNode(2),
+                createNode(3));
+
+        Map<RedisURI, Partitions> topologyViews = createMap(partialCoverage, fullCoverage);
+
+        for (int i = 0; i < 10; i++) {
+            assertThat(client.determinePartitions(current, topologyViews)).isSameAs(fullCoverage);
+        }
+    }
+
+    @Test
+    void shouldNotConsiderViewsWithoutFullSlotCoverageOnInitialLoad() {
+
+        Partitions fullCoverage = createPartitions(createNode(1, createSlots(0, SlotHash.SLOT_COUNT)), createNode(2),
+                createNode(3));
+
+        Partitions partialCoverage = createPartitions(createNode(1, createSlots(0, 100)), createNode(2), createNode(3));
+
+        Map<RedisURI, Partitions> topologyViews = createMap(partialCoverage, fullCoverage);
+
+        for (int i = 0; i < 10; i++) {
+            assertThat(client.determinePartitions(null, topologyViews)).isSameAs(fullCoverage);
+        }
+    }
+
+    @Test
+    void shouldConsiderAllViewsIfNoneHasFullSlotCoverage() {
+
+        Partitions current = createPartitions(createNode(1), createNode(2));
+
+        Partitions partitions1 = createPartitions(createNode(1, createSlots(0, 100)), createNode(2));
+        Partitions partitions2 = createPartitions(createNode(1), createNode(2, createSlots(100, 200)));
+
+        Map<RedisURI, Partitions> topologyViews = createMap(partitions1, partitions2);
+
+        Partitions result = client.determinePartitions(current, topologyViews);
+
+        assertThat(Arrays.asList(partitions1, partitions2)).contains(result);
+    }
+
+    @Test
+    void shouldReturnViewWithoutFullSlotCoverageOnInitialLoad() {
+
+        Partitions partialCoverage = createPartitions(createNode(1, createSlots(0, 100)), createNode(2));
+
+        Map<RedisURI, Partitions> topologyViews = createMap(partialCoverage);
+
+        assertThat(client.determinePartitions(null, topologyViews)).isSameAs(partialCoverage);
+    }
+
+}

--- a/src/test/java/io/lettuce/core/cluster/models/partitions/RedisClusterNodeUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/models/partitions/RedisClusterNodeUnitTests.java
@@ -174,4 +174,31 @@ class RedisClusterNodeUnitTests {
         assertThat(node.hasNoSlots()).isFalse();
     }
 
+    @Test
+    void shouldReturnSlotCount() {
+
+        BitSet slots = new BitSet();
+        slots.set(1);
+        slots.set(2);
+        slots.set(SlotHash.SLOT_COUNT - 1);
+        RedisClusterNode node = new RedisClusterNode(RedisURI.create("localhost", 6379), "1", true, null, 0, 0, 0, slots,
+                Collections.emptySet());
+
+        assertThat(node.getSlotCount()).isEqualTo(3);
+        assertThat(node.getSlotCount()).isEqualTo(node.getSlots().size());
+    }
+
+    @Test
+    void shouldReturnZeroSlotCountWithoutSlots() {
+
+        BitSet nullSlots = null;
+        RedisClusterNode nodeWithoutSlots = new RedisClusterNode(RedisURI.create("localhost", 6379), "1", true, null, 0, 0, 0,
+                nullSlots, Collections.emptySet());
+        RedisClusterNode nodeWithEmptySlots = new RedisClusterNode(RedisURI.create("localhost", 6379), "2", true, null, 0, 0, 0,
+                new BitSet(), Collections.emptySet());
+
+        assertThat(nodeWithoutSlots.getSlotCount()).isZero();
+        assertThat(nodeWithEmptySlots.getSlotCount()).isZero();
+    }
+
 }


### PR DESCRIPTION
Make sure that:
- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.


## Summary

Follow-up to the discussion in #2769 (reported by me). When a node joins a cluster (e.g. adding a replica), it briefly acts as a master without slots and has not yet synchronized the cluster topology. If a topology refresh queries such a node, it returns a view in which itself and some actual masters carry no slots. `KnownMajority` counts only how many known nodes a view contains, so this incorrect view ties with healthy views and can be adopted by the random tie-break — leaving the client throwing `PartitionSelectorException: Cannot determine a partition for slot ...` for a full refresh period.

`determinePartitions` now drops topology views without full slot coverage before consensus, as long as at least one view covers all 16384 slots.

## Key Decisions & Assumptions

- In #2769 I initially proposed discarding views that contain a master without slots, and @mp911de rightly objected that such a node can be legitimate (e.g. Pub/Sub usage). The check is therefore per view (total covered slots), not per node: a legitimate slotless master does not reduce the coverage of an otherwise complete view, so no view is discarded because of it.
- If no view provides full slot coverage (clusters running with `cluster-require-full-coverage no`, bootstrap, lost slots), all views are retained and behavior is unchanged, so partial-coverage clusters keep working and the filter can never produce an empty candidate set.
- `PartitionsConsensus` is intentionally untouched: it remains solely responsible for split-brain arbitration; view validation happens before consensus in `determinePartitions`. Network partitions do not unassign slots, so slot coverage is orthogonal to the split-brain signal that `KNOWN_MAJORITY` evaluates.
- Adds `RedisClusterNode#getSlotCount()` (backed by `BitSet.cardinality()`) to compute coverage without materializing a slot `List` per node, following up on `hasNoSlots()` (#3014).

## Behavioral / Conceptual Changes

- Both refresh paths are protected: `KNOWN_MAJORITY` (periodic/adaptive refresh) and `HEALTHY_MAJORITY` (initial topology load).
- A view with partial slot coverage is now only adopted when every retrieved view has partial coverage. In the rare case of deliberately unassigning slots (`CLUSTER DELSLOTS`, forgetting a slot-holding node), clients may keep a stale full-coverage view for up to one additional refresh period until all views reflect the new state.
- Subclasses overriding `determinePartitions` bypass the filter (unchanged extension point).

## Testing

New unit tests cover `determinePartitions` directly: an incomplete view (as reported by a just-joined node) loses against a full-coverage view on both the known-majority and initial-load paths, all views are retained when none has full coverage, and a single partial view is still returned on initial load. Each assertion runs 10 iterations to rule out shuffle luck. `getSlotCount()` is covered for assigned, empty, and `null` slot sets.

We have also been running an equivalent filter in production since early 2024 (via a `RedisClusterClient` subclass overriding `determinePartitions`, as suggested in #2769) across a 30-shard cluster with frequent replica-scaling operations, with no recurrence of the exception. The original failure was reproducible by repeatedly re-adding a replica (`del-node` + `add-node --cluster-slave`) under a 1s refresh period, as described in #2769.

## Notes

- If a configurable strategy is preferred over a default behavior change, this filter could alternatively be exposed via `ClusterClientOptions` (as you suggested in #2769); happy to adjust.

Fixes #2769.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default cluster topology selection on every refresh path; low risk when full coverage exists, with a possible one-refresh delay after deliberate slot removal if some nodes still report full coverage.
> 
> **Overview**
> Fixes intermittent `PartitionSelectorException` when topology refresh hits a **newly joined node** that still reports masters without slots: incomplete views can tie in `KNOWN_MAJORITY` and win a random tie-break.
> 
> **`determinePartitions`** now passes only views whose nodes sum to **16384 slots** into `HEALTHY_MAJORITY` / `KNOWN_MAJORITY` when at least one such view exists; if every view is partial (e.g. `cluster-require-full-coverage no`), behavior is unchanged.
> 
> Adds **`RedisClusterNode#getSlotCount()`** (BitSet cardinality) for coverage checks without allocating slot lists, plus unit tests for `determinePartitions` and slot count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c06220e75223aeb6c4d05d5c7717f84886c927bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->