### PR TITLE
Fix visibility of partitions, readFrom, autoFlushCommands (#3777)

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/PooledClusterConnectionProvider.java
+++ b/src/main/java/io/lettuce/core/cluster/PooledClusterConnectionProvider.java
@@ -98,11 +98,11 @@ class PooledClusterConnectionProvider<K, V>
 
     private final AsyncConnectionProvider<ConnectionKey, StatefulRedisConnection<K, V>, ConnectionFuture<StatefulRedisConnection<K, V>>> connectionProvider;
 
-    private Partitions partitions;
+    private volatile Partitions partitions;
 
-    private boolean autoFlushCommands = true;
+    private volatile boolean autoFlushCommands = true;
 
-    private ReadFrom readFrom;
+    private volatile ReadFrom readFrom;
 
     public PooledClusterConnectionProvider(RedisClusterClient redisClusterClient, RedisChannelWriter clusterWriter,
             RedisCodec<K, V> redisCodec, ClusterEventListener clusterEventListener) {

--- a/src/test/java/io/lettuce/core/cluster/PooledClusterConnectionProviderUnitTests.java
+++ b/src/test/java/io/lettuce/core/cluster/PooledClusterConnectionProviderUnitTests.java
@@ -461,4 +461,16 @@ class PooledClusterConnectionProviderUnitTests {
         verify(clusterEventListener).onUncoveredSlot(anyInt());
     }
 
+    @Test
+    void shouldHaveVolatileFields() throws Exception {
+        java.lang.reflect.Field partitionsField = PooledClusterConnectionProvider.class.getDeclaredField("partitions");
+        java.lang.reflect.Field readFromField = PooledClusterConnectionProvider.class.getDeclaredField("readFrom");
+        java.lang.reflect.Field autoFlushCommandsField = PooledClusterConnectionProvider.class
+                .getDeclaredField("autoFlushCommands");
+
+        assertThat(java.lang.reflect.Modifier.isVolatile(partitionsField.getModifiers())).isTrue();
+        assertThat(java.lang.reflect.Modifier.isVolatile(readFromField.getModifiers())).isTrue();
+        assertThat(java.lang.reflect.Modifier.isVolatile(autoFlushCommandsField.getModifiers())).isTrue();
+    }
+
 }


### PR DESCRIPTION
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small concurrency-hardening change with no API or behavior change beyond correct visibility; low blast radius in cluster connection pooling.
> 
> **Overview**
> **Fixes cross-thread visibility** for cluster routing state in `PooledClusterConnectionProvider` by declaring `partitions`, `readFrom`, and `autoFlushCommands` as `volatile`.
> 
> Those fields are updated under `stateLock` but read on connection/async paths (slot lookup, `ReadFrom` selection, auto-flush on new connections) without always holding the lock; `volatile` matches how other cluster types already expose `Partitions` and ensures threads see topology and routing updates promptly.
> 
> A unit test uses reflection to assert all three fields remain `volatile`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef6fd82d4d1a664b7949e38f6ae3ee69834432c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->