### PR TITLE
Move coroutine API consistency checks to the Kotlin test sources

### DIFF
--- a/.agents/docs/api-consistency.md
+++ b/.agents/docs/api-consistency.md
@@ -61,8 +61,13 @@ intentionally not on sync.)
   suite also verifies **generic parameter signatures** (not just erased types)
   and **`@Deprecated` parity** with the sync method.
 
-All exceptions to these rules live in **one registry**:
-`src/test/java/io/lettuce/core/api/consistency/KnownApiDeviations.java`.
+All exceptions to these rules live in **two registries, split by flavor
+ownership**: the Java flavors in
+`src/test/java/io/lettuce/core/api/consistency/KnownApiDeviations.java`, the
+Kotlin coroutine flavor in
+`src/test/kotlin/io/lettuce/core/api/consistency/KnownKotlinApiDeviations.kt`
+(same key forms and matching helpers; the Java test sources carry no reference
+to the Kotlin flavor).
 
 ## The test suite
 
@@ -71,8 +76,9 @@ All exceptions to these rules live in **one registry**:
 
 | Class | Checks |
 |-------|--------|
-| `CommandInterfaces` | the catalog: one enum entry per command group → its six flavor classes |
-| `KnownApiDeviations` | the exceptions registry (ported from the former generators) |
+| `CommandInterfaces` | the catalog: one enum entry per command group → its five Java flavor classes (the coroutine flavor is derived by naming convention via the Kotlin `coroutines()` extension) |
+| `KnownApiDeviations` | the exceptions registry for the Java flavors (ported from the former generators) |
+| `KnownKotlinApiDeviations` (Kotlin) | the exceptions registry for the coroutine flavor + the `CommandInterfaces.coroutines()` extension |
 | `TypeSignatures` | shared reflection/normalization helpers |
 | `SyncAsyncConsistencyUnitTests` | presence both directions + `RedisFuture` wrapping |
 | `SyncReactiveConsistencyUnitTests` | presence both directions + `Mono`/`Flux` mapping + streaming deprecation |

--- a/src/test/java/io/lettuce/core/api/consistency/AggregateInterfaceConsistencyUnitTests.java
+++ b/src/test/java/io/lettuce/core/api/consistency/AggregateInterfaceConsistencyUnitTests.java
@@ -22,7 +22,6 @@ import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.cluster.api.async.NodeSelectionAsyncCommands;
 import io.lettuce.core.cluster.api.async.RedisAdvancedClusterAsyncCommands;
 import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
-import io.lettuce.core.cluster.api.coroutines.RedisClusterCoroutinesCommands;
 import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
 import io.lettuce.core.cluster.api.reactive.RedisClusterReactiveCommands;
 import io.lettuce.core.cluster.api.sync.NodeSelectionCommands;
@@ -34,6 +33,9 @@ import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
  * cover, so that a newly registered command group cannot be forgotten on the umbrella interfaces — and that the methods
  * declared directly on the aggregates ({@code auth}, {@code select}, the {@code CLUSTER} commands, …) stay in lockstep across
  * the sync, async and reactive flavors.
+ * <p>
+ * The Kotlin coroutine aggregates are covered by {@code KotlinCoroutinesConsistencyUnitTests} so that these Java test sources
+ * stay free of compile-time references to Kotlin types.
  */
 @Tag(UNIT_TEST)
 class AggregateInterfaceConsistencyUnitTests {
@@ -53,7 +55,6 @@ class AggregateInterfaceConsistencyUnitTests {
             assertExtends(softly, RedisCommands.class, group.sync());
             assertExtends(softly, RedisAsyncCommands.class, group.async());
             assertExtends(softly, RedisReactiveCommands.class, group.reactive());
-            assertExtends(softly, io.lettuce.core.api.coroutines.RedisCoroutinesCommands.class, group.coroutines());
         }
 
         softly.assertAll();
@@ -68,7 +69,6 @@ class AggregateInterfaceConsistencyUnitTests {
             assertExtends(softly, RedisClusterCommands.class, group.sync());
             assertExtends(softly, RedisClusterAsyncCommands.class, group.async());
             assertExtends(softly, RedisClusterReactiveCommands.class, group.reactive());
-            assertExtends(softly, RedisClusterCoroutinesCommands.class, group.coroutines());
         }
 
         softly.assertAll();

--- a/src/test/java/io/lettuce/core/api/consistency/CommandInterfaces.java
+++ b/src/test/java/io/lettuce/core/api/consistency/CommandInterfaces.java
@@ -28,28 +28,6 @@ import io.lettuce.core.api.async.RedisStringAsyncCommands;
 import io.lettuce.core.api.async.RedisTopKAsyncCommands;
 import io.lettuce.core.api.async.RedisTransactionalAsyncCommands;
 import io.lettuce.core.api.async.RedisVectorSetAsyncCommands;
-import io.lettuce.core.api.coroutines.BaseRedisCoroutinesCommands;
-import io.lettuce.core.api.coroutines.RedisAclCoroutinesCommands;
-import io.lettuce.core.api.coroutines.RedisArrayCoroutinesCommands;
-import io.lettuce.core.api.coroutines.RedisBloomFilterCoroutinesCommands;
-import io.lettuce.core.api.coroutines.RedisCuckooFilterCoroutinesCommands;
-import io.lettuce.core.api.coroutines.RediSearchCoroutinesCommands;
-import io.lettuce.core.api.coroutines.RedisFunctionCoroutinesCommands;
-import io.lettuce.core.api.coroutines.RedisGeoCoroutinesCommands;
-import io.lettuce.core.api.coroutines.RedisHLLCoroutinesCommands;
-import io.lettuce.core.api.coroutines.RedisHashCoroutinesCommands;
-import io.lettuce.core.api.coroutines.RedisJsonCoroutinesCommands;
-import io.lettuce.core.api.coroutines.RedisKeyCoroutinesCommands;
-import io.lettuce.core.api.coroutines.RedisListCoroutinesCommands;
-import io.lettuce.core.api.coroutines.RedisScriptingCoroutinesCommands;
-import io.lettuce.core.api.coroutines.RedisServerCoroutinesCommands;
-import io.lettuce.core.api.coroutines.RedisSetCoroutinesCommands;
-import io.lettuce.core.api.coroutines.RedisSortedSetCoroutinesCommands;
-import io.lettuce.core.api.coroutines.RedisStreamCoroutinesCommands;
-import io.lettuce.core.api.coroutines.RedisStringCoroutinesCommands;
-import io.lettuce.core.api.coroutines.RedisTopKCoroutinesCommands;
-import io.lettuce.core.api.coroutines.RedisTransactionalCoroutinesCommands;
-import io.lettuce.core.api.coroutines.RedisVectorSetCoroutinesCommands;
 import io.lettuce.core.api.reactive.BaseRedisReactiveCommands;
 import io.lettuce.core.api.reactive.RedisAclReactiveCommands;
 import io.lettuce.core.api.reactive.RedisArrayReactiveCommands;
@@ -137,7 +115,6 @@ import io.lettuce.core.cluster.api.sync.NodeSelectionStringCommands;
 import io.lettuce.core.cluster.api.sync.NodeSelectionTopKCommands;
 import io.lettuce.core.cluster.api.sync.NodeSelectionVectorSetCommands;
 import io.lettuce.core.sentinel.api.async.RedisSentinelAsyncCommands;
-import io.lettuce.core.sentinel.api.coroutines.RedisSentinelCoroutinesCommands;
 import io.lettuce.core.sentinel.api.reactive.RedisSentinelReactiveCommands;
 import io.lettuce.core.sentinel.api.sync.RedisSentinelCommands;
 
@@ -148,83 +125,81 @@ import io.lettuce.core.sentinel.api.sync.RedisSentinelCommands;
  * <p>
  * This catalog is the single place where a new command group must be registered so that the API consistency test suite covers
  * it.
+ * <p>
+ * The Kotlin coroutine flavor is owned entirely by the Kotlin side of the suite so that the Java test sources carry no
+ * reference to it: the {@code CommandInterfaces.coroutines()} extension function (see {@code KnownKotlinApiDeviations.kt})
+ * derives the coroutine interface from the sync interface by naming convention.
  */
 public enum CommandInterfaces {
 
     BASE(BaseRedisCommands.class, BaseRedisAsyncCommands.class, BaseRedisReactiveCommands.class,
-            BaseRedisCoroutinesCommands.class, BaseNodeSelectionCommands.class, BaseNodeSelectionAsyncCommands.class),
+            BaseNodeSelectionCommands.class, BaseNodeSelectionAsyncCommands.class),
 
-    ACL(RedisAclCommands.class, RedisAclAsyncCommands.class, RedisAclReactiveCommands.class, RedisAclCoroutinesCommands.class,
-            NodeSelectionAclCommands.class, NodeSelectionAclAsyncCommands.class),
+    ACL(RedisAclCommands.class, RedisAclAsyncCommands.class, RedisAclReactiveCommands.class, NodeSelectionAclCommands.class,
+            NodeSelectionAclAsyncCommands.class),
 
     ARRAY(RedisArrayCommands.class, RedisArrayAsyncCommands.class, RedisArrayReactiveCommands.class,
-            RedisArrayCoroutinesCommands.class, NodeSelectionArrayCommands.class, NodeSelectionArrayAsyncCommands.class),
+            NodeSelectionArrayCommands.class, NodeSelectionArrayAsyncCommands.class),
 
     BLOOM_FILTER(RedisBloomFilterCommands.class, RedisBloomFilterAsyncCommands.class, RedisBloomFilterReactiveCommands.class,
-            RedisBloomFilterCoroutinesCommands.class, NodeSelectionBloomFilterCommands.class,
-            NodeSelectionBloomFilterAsyncCommands.class),
+            NodeSelectionBloomFilterCommands.class, NodeSelectionBloomFilterAsyncCommands.class),
 
     CUCKOO_FILTER(RedisCuckooFilterCommands.class, RedisCuckooFilterAsyncCommands.class,
-            RedisCuckooFilterReactiveCommands.class, RedisCuckooFilterCoroutinesCommands.class,
-            NodeSelectionCuckooFilterCommands.class, NodeSelectionCuckooFilterAsyncCommands.class),
+            RedisCuckooFilterReactiveCommands.class, NodeSelectionCuckooFilterCommands.class,
+            NodeSelectionCuckooFilterAsyncCommands.class),
 
     FUNCTION(RedisFunctionCommands.class, RedisFunctionAsyncCommands.class, RedisFunctionReactiveCommands.class,
-            RedisFunctionCoroutinesCommands.class, NodeSelectionFunctionCommands.class,
-            NodeSelectionFunctionAsyncCommands.class),
+            NodeSelectionFunctionCommands.class, NodeSelectionFunctionAsyncCommands.class),
 
-    GEO(RedisGeoCommands.class, RedisGeoAsyncCommands.class, RedisGeoReactiveCommands.class, RedisGeoCoroutinesCommands.class,
-            NodeSelectionGeoCommands.class, NodeSelectionGeoAsyncCommands.class),
+    GEO(RedisGeoCommands.class, RedisGeoAsyncCommands.class, RedisGeoReactiveCommands.class, NodeSelectionGeoCommands.class,
+            NodeSelectionGeoAsyncCommands.class),
 
     HASH(RedisHashCommands.class, RedisHashAsyncCommands.class, RedisHashReactiveCommands.class,
-            RedisHashCoroutinesCommands.class, NodeSelectionHashCommands.class, NodeSelectionHashAsyncCommands.class),
+            NodeSelectionHashCommands.class, NodeSelectionHashAsyncCommands.class),
 
-    HLL(RedisHLLCommands.class, RedisHLLAsyncCommands.class, RedisHLLReactiveCommands.class, RedisHLLCoroutinesCommands.class,
-            NodeSelectionHLLCommands.class, NodeSelectionHLLAsyncCommands.class),
+    HLL(RedisHLLCommands.class, RedisHLLAsyncCommands.class, RedisHLLReactiveCommands.class, NodeSelectionHLLCommands.class,
+            NodeSelectionHLLAsyncCommands.class),
 
     JSON(RedisJsonCommands.class, RedisJsonAsyncCommands.class, RedisJsonReactiveCommands.class,
-            RedisJsonCoroutinesCommands.class, NodeSelectionJsonCommands.class, NodeSelectionJsonAsyncCommands.class),
+            NodeSelectionJsonCommands.class, NodeSelectionJsonAsyncCommands.class),
 
-    KEY(RedisKeyCommands.class, RedisKeyAsyncCommands.class, RedisKeyReactiveCommands.class, RedisKeyCoroutinesCommands.class,
-            NodeSelectionKeyCommands.class, NodeSelectionKeyAsyncCommands.class),
+    KEY(RedisKeyCommands.class, RedisKeyAsyncCommands.class, RedisKeyReactiveCommands.class, NodeSelectionKeyCommands.class,
+            NodeSelectionKeyAsyncCommands.class),
 
     LIST(RedisListCommands.class, RedisListAsyncCommands.class, RedisListReactiveCommands.class,
-            RedisListCoroutinesCommands.class, NodeSelectionListCommands.class, NodeSelectionListAsyncCommands.class),
+            NodeSelectionListCommands.class, NodeSelectionListAsyncCommands.class),
 
     SCRIPTING(RedisScriptingCommands.class, RedisScriptingAsyncCommands.class, RedisScriptingReactiveCommands.class,
-            RedisScriptingCoroutinesCommands.class, NodeSelectionScriptingCommands.class,
-            NodeSelectionScriptingAsyncCommands.class),
+            NodeSelectionScriptingCommands.class, NodeSelectionScriptingAsyncCommands.class),
 
     SEARCH(RediSearchCommands.class, RediSearchAsyncCommands.class, RediSearchReactiveCommands.class,
-            RediSearchCoroutinesCommands.class, NodeSelectionSearchCommands.class, NodeSelectionSearchAsyncCommands.class),
+            NodeSelectionSearchCommands.class, NodeSelectionSearchAsyncCommands.class),
 
-    SENTINEL(RedisSentinelCommands.class, RedisSentinelAsyncCommands.class, RedisSentinelReactiveCommands.class,
-            RedisSentinelCoroutinesCommands.class, null, null),
+    SENTINEL(RedisSentinelCommands.class, RedisSentinelAsyncCommands.class, RedisSentinelReactiveCommands.class, null, null),
 
     SERVER(RedisServerCommands.class, RedisServerAsyncCommands.class, RedisServerReactiveCommands.class,
-            RedisServerCoroutinesCommands.class, NodeSelectionServerCommands.class, NodeSelectionServerAsyncCommands.class),
+            NodeSelectionServerCommands.class, NodeSelectionServerAsyncCommands.class),
 
-    SET(RedisSetCommands.class, RedisSetAsyncCommands.class, RedisSetReactiveCommands.class, RedisSetCoroutinesCommands.class,
-            NodeSelectionSetCommands.class, NodeSelectionSetAsyncCommands.class),
+    SET(RedisSetCommands.class, RedisSetAsyncCommands.class, RedisSetReactiveCommands.class, NodeSelectionSetCommands.class,
+            NodeSelectionSetAsyncCommands.class),
 
     SORTED_SET(RedisSortedSetCommands.class, RedisSortedSetAsyncCommands.class, RedisSortedSetReactiveCommands.class,
-            RedisSortedSetCoroutinesCommands.class, NodeSelectionSortedSetCommands.class,
-            NodeSelectionSortedSetAsyncCommands.class),
+            NodeSelectionSortedSetCommands.class, NodeSelectionSortedSetAsyncCommands.class),
 
     STREAM(RedisStreamCommands.class, RedisStreamAsyncCommands.class, RedisStreamReactiveCommands.class,
-            RedisStreamCoroutinesCommands.class, NodeSelectionStreamCommands.class, NodeSelectionStreamAsyncCommands.class),
+            NodeSelectionStreamCommands.class, NodeSelectionStreamAsyncCommands.class),
 
     STRING(RedisStringCommands.class, RedisStringAsyncCommands.class, RedisStringReactiveCommands.class,
-            RedisStringCoroutinesCommands.class, NodeSelectionStringCommands.class, NodeSelectionStringAsyncCommands.class),
+            NodeSelectionStringCommands.class, NodeSelectionStringAsyncCommands.class),
 
     TOP_K(RedisTopKCommands.class, RedisTopKAsyncCommands.class, RedisTopKReactiveCommands.class,
-            RedisTopKCoroutinesCommands.class, NodeSelectionTopKCommands.class, NodeSelectionTopKAsyncCommands.class),
+            NodeSelectionTopKCommands.class, NodeSelectionTopKAsyncCommands.class),
 
     TRANSACTIONAL(RedisTransactionalCommands.class, RedisTransactionalAsyncCommands.class,
-            RedisTransactionalReactiveCommands.class, RedisTransactionalCoroutinesCommands.class, null, null),
+            RedisTransactionalReactiveCommands.class, null, null),
 
     VECTOR_SET(RedisVectorSetCommands.class, RedisVectorSetAsyncCommands.class, RedisVectorSetReactiveCommands.class,
-            RedisVectorSetCoroutinesCommands.class, NodeSelectionVectorSetCommands.class,
-            NodeSelectionVectorSetAsyncCommands.class);
+            NodeSelectionVectorSetCommands.class, NodeSelectionVectorSetAsyncCommands.class);
 
     private final Class<?> sync;
 
@@ -232,18 +207,15 @@ public enum CommandInterfaces {
 
     private final Class<?> reactive;
 
-    private final Class<?> coroutines;
-
     private final Class<?> nodeSelectionSync;
 
     private final Class<?> nodeSelectionAsync;
 
-    CommandInterfaces(Class<?> sync, Class<?> async, Class<?> reactive, Class<?> coroutines, Class<?> nodeSelectionSync,
+    CommandInterfaces(Class<?> sync, Class<?> async, Class<?> reactive, Class<?> nodeSelectionSync,
             Class<?> nodeSelectionAsync) {
         this.sync = sync;
         this.async = async;
         this.reactive = reactive;
-        this.coroutines = coroutines;
         this.nodeSelectionSync = nodeSelectionSync;
         this.nodeSelectionAsync = nodeSelectionAsync;
     }
@@ -258,10 +230,6 @@ public enum CommandInterfaces {
 
     public Class<?> reactive() {
         return reactive;
-    }
-
-    public Class<?> coroutines() {
-        return coroutines;
     }
 
     /**

--- a/src/test/java/io/lettuce/core/api/consistency/KnownApiDeviations.java
+++ b/src/test/java/io/lettuce/core/api/consistency/KnownApiDeviations.java
@@ -22,8 +22,10 @@ import java.util.StringJoiner;
  * <p>
  * The tables were ported verbatim from the former {@code io.lettuce.apigenerator} generators
  * ({@code CreateSyncApi#FILTER_METHODS}, {@code CreateAsyncApi#KEEP_METHOD_RESULT_TYPE},
- * {@code CreateReactiveApi#KEEP_METHOD_RESULT_TYPE/FORCE_FLUX_RESULT/VALUE_WRAP/RESULT_SPEC},
- * {@code Create*NodeSelectionClusterApi#FILTER_METHODS} and {@code KotlinCompilationUnitFactory}).
+ * {@code CreateReactiveApi#KEEP_METHOD_RESULT_TYPE/FORCE_FLUX_RESULT/VALUE_WRAP/RESULT_SPEC} and
+ * {@code Create*NodeSelectionClusterApi#FILTER_METHODS}). The deviations of the Kotlin coroutine flavor live on the Kotlin side
+ * of the suite, in {@code KnownKotlinApiDeviations} (Kotlin test sources); the key forms and matching helpers below are shared
+ * by both registries.
  * <p>
  * Keys may take three forms, checked from most to least specific:
  * <ul>
@@ -136,46 +138,6 @@ public final class KnownApiDeviations {
     public static final Set<String> NODE_SELECTION_AGGREGATE_PENDING = setOf("ACL", "ARRAY", "STREAM");
 
     /**
-     * Sync methods with no coroutine counterpart. From {@code KotlinCompilationUnitFactory#SKIP_METHODS}.
-     */
-    public static final Set<String> COROUTINES_SKIP = setOf("getStatefulConnection");
-
-    /**
-     * Coroutine methods that are plain functions instead of {@code suspend} functions. From
-     * {@code KotlinCompilationUnitFactory#NON_SUSPENDABLE_METHODS}.
-     */
-    public static final Set<String> COROUTINES_NON_SUSPENDABLE = setOf("isOpen", "flushCommands", "setAutoFlushCommands");
-
-    /**
-     * Coroutine methods returning {@code Flow} instead of a suspended scalar/collection. From
-     * {@code KotlinCompilationUnitFactory#FLOW_METHODS}.
-     */
-    public static final Set<String> COROUTINES_FLOW = setOf("aclList", "aclLog", "dispatch", "geohash", "georadius",
-            "georadiusbymember", "geosearch", "hgetall", "hkeys", "hmget", "hvals", "keys", "mget", "sdiff", "sinter",
-            "smembers", "smismember", "sort", "sortReadOnly", "sunion", "xclaim", "xrange", "xread", "xreadgroup", "xrevrange",
-            "zdiff", "zdiffWithScores", "zinter", "zinterWithScores", "zrange", "zrangeWithScores", "zrangebylex",
-            "zrangebyscore", "zrangebyscoreWithScores", "zrevrange", "zrevrangeWithScores", "zrevrangebylex",
-            "zrevrangebyscore", "zrevrangebyscoreWithScores", "zunion", "zunionWithScores",
-            // calibration 2026-07: only the multi-element overloads stream; the single-element overloads suspend
-            "srandmember(K, long)", "zpopmax(K, long)", "zpopmin(K, long)", "xpending(K, K, Range, Limit)",
-            "xpending(K, Consumer, Range, Limit)", "xpending(K, XPendingArgs)",
-            // calibration 2026-07: multi-element commands added after the generators stopped being used
-            "hgetdel", "hgetex", "xackdel", "xdelex");
-
-    /**
-     * Deprecated sync methods that are still exposed on the coroutine API. From
-     * {@code KotlinCompilationUnitFactory#KEEP_DEPRECATED_METHODS}.
-     */
-    public static final Set<String> COROUTINES_KEEP_DEPRECATED = setOf("flushallAsync", "flushdbAsync", "slaveof",
-            "slaveofNoOne", "slaves");
-
-    /**
-     * Coroutine methods with a fully overridden return type (normalized, package-less Kotlin rendering). From
-     * {@code KotlinCompilationUnitFactory#RESULT_SPEC}.
-     */
-    public static final Map<String, String> COROUTINES_RESULT_OVERRIDES;
-
-    /**
      * Interface methods that do not correspond to any command-builder method: connection control, locally computed values
      * ({@code digest}), generic dispatch and transaction plumbing ({@code exec} builds its command in the transaction
      * machinery, not in the builder).
@@ -215,11 +177,6 @@ public final class KnownApiDeviations {
         reactive.put("clusterLinks", "Mono<List<Map<String, Object>>>");
         reactive.put("clusterShards", "Mono<List<Object>>");
         REACTIVE_RESULT_OVERRIDES = Collections.unmodifiableMap(reactive);
-
-        Map<String, String> coroutines = new HashMap<>();
-        coroutines.put("hgetall", "Flow<KeyValue<K, V>>");
-        coroutines.put("zmscore", "List<Double?>");
-        COROUTINES_RESULT_OVERRIDES = Collections.unmodifiableMap(coroutines);
 
         Map<String, String> builderAliases = new HashMap<>();
         builderAliases.put("waitForReplication", "wait");

--- a/src/test/kotlin/io/lettuce/core/api/consistency/KnownKotlinApiDeviations.kt
+++ b/src/test/kotlin/io/lettuce/core/api/consistency/KnownKotlinApiDeviations.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2011-Present, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ */
+package io.lettuce.core.api.consistency
+
+/**
+ * The Kotlin coroutines interface of this command group, derived from the sync interface by naming convention (`api.sync`
+ * package → sibling `api.coroutines` package, `*Commands` → `*CoroutinesCommands`) and resolved reflectively. Everything
+ * coroutine-flavored lives on the Kotlin side of the suite, so the Java test sources carry no reference to the Kotlin flavor;
+ * the derivation also verifies the naming convention itself — a coroutine interface that exists under an unconventional name
+ * fails resolution.
+ *
+ * @throws IllegalStateException if the coroutine flavor does not exist under the conventional name.
+ */
+fun CommandInterfaces.coroutines(): Class<*> {
+    val name = sync().name.replace(".api.sync.", ".api.coroutines.").replace(Regex("Commands$"), "CoroutinesCommands")
+    try {
+        return Class.forName(name)
+    } catch (e: ClassNotFoundException) {
+        throw IllegalStateException("Coroutines flavor of $this not found under conventional name $name", e)
+    }
+}
+
+/**
+ * Registry of all known, intentional deviations of the Kotlin coroutine interfaces from the sync reference — the Kotlin
+ * counterpart of [KnownApiDeviations], kept in the Kotlin test sources because only the coroutine flavor consults it.
+ * Key forms and matching rules are those of [KnownApiDeviations.contains] and [KnownApiDeviations.lookup].
+ *
+ * The tables were ported verbatim from the former `io.lettuce.apigenerator.KotlinCompilationUnitFactory` generator.
+ */
+object KnownKotlinApiDeviations {
+
+    /**
+     * Sync methods with no coroutine counterpart. From `KotlinCompilationUnitFactory#SKIP_METHODS`.
+     */
+    val SKIP = setOf("getStatefulConnection")
+
+    /**
+     * Coroutine methods that are plain functions instead of `suspend` functions. From
+     * `KotlinCompilationUnitFactory#NON_SUSPENDABLE_METHODS`.
+     */
+    val NON_SUSPENDABLE = setOf("isOpen", "flushCommands", "setAutoFlushCommands")
+
+    /**
+     * Coroutine methods returning `Flow` instead of a suspended scalar/collection. From
+     * `KotlinCompilationUnitFactory#FLOW_METHODS`.
+     */
+    val FLOW = setOf(
+        "aclList", "aclLog", "dispatch", "geohash", "georadius", "georadiusbymember", "geosearch", "hgetall", "hkeys",
+        "hmget", "hvals", "keys", "mget", "sdiff", "sinter", "smembers", "smismember", "sort", "sortReadOnly", "sunion",
+        "xclaim", "xrange", "xread", "xreadgroup", "xrevrange", "zdiff", "zdiffWithScores", "zinter", "zinterWithScores",
+        "zrange", "zrangeWithScores", "zrangebylex", "zrangebyscore", "zrangebyscoreWithScores", "zrevrange",
+        "zrevrangeWithScores", "zrevrangebylex", "zrevrangebyscore", "zrevrangebyscoreWithScores", "zunion",
+        "zunionWithScores",
+        // calibration 2026-07: only the multi-element overloads stream; the single-element overloads suspend
+        "srandmember(K, long)", "zpopmax(K, long)", "zpopmin(K, long)", "xpending(K, K, Range, Limit)",
+        "xpending(K, Consumer, Range, Limit)", "xpending(K, XPendingArgs)",
+        // calibration 2026-07: multi-element commands added after the generators stopped being used
+        "hgetdel", "hgetex", "xackdel", "xdelex"
+    )
+
+    /**
+     * Deprecated sync methods that are still exposed on the coroutine API. From
+     * `KotlinCompilationUnitFactory#KEEP_DEPRECATED_METHODS`.
+     */
+    val KEEP_DEPRECATED = setOf("flushallAsync", "flushdbAsync", "slaveof", "slaveofNoOne", "slaves")
+
+    /**
+     * Coroutine methods with a fully overridden return type (normalized, package-less Kotlin rendering). From
+     * `KotlinCompilationUnitFactory#RESULT_SPEC`.
+     */
+    val RESULT_OVERRIDES = mapOf(
+        "hgetall" to "Flow<KeyValue<K, V>>",
+        "zmscore" to "List<Double?>"
+    )
+
+}

--- a/src/test/kotlin/io/lettuce/core/api/consistency/KotlinCoroutinesConsistencyUnitTests.kt
+++ b/src/test/kotlin/io/lettuce/core/api/consistency/KotlinCoroutinesConsistencyUnitTests.kt
@@ -7,7 +7,10 @@
 package io.lettuce.core.api.consistency
 
 import io.lettuce.TestTags.UNIT_TEST
+import io.lettuce.core.api.coroutines.RedisCoroutinesCommands
+import io.lettuce.core.cluster.api.coroutines.RedisClusterCoroutinesCommands
 import java.lang.reflect.Method
+import java.util.EnumSet
 import kotlin.reflect.KFunction
 import kotlin.reflect.KType
 import kotlin.reflect.full.declaredMemberFunctions
@@ -15,6 +18,7 @@ import kotlin.reflect.jvm.javaMethod
 import kotlinx.coroutines.flow.Flow
 import org.assertj.core.api.SoftAssertions
 import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 
@@ -23,7 +27,12 @@ import org.junit.jupiter.params.provider.EnumSource
  * streaming-channel and explicitly skipped methods) must exist as a `suspend fun`, or as a plain function when it is
  * non-suspendable or returns a [Flow]. Return-type details beyond the Flow/suspend shape (element nullability) are not
  * verified.
+ *
+ * Also verifies that the coroutine aggregate interfaces extend the coroutine interface of every command group they are
+ * supposed to cover — the coroutine counterpart of `AggregateInterfaceConsistencyUnitTests`, kept here so the Java test
+ * sources stay free of compile-time references to Kotlin types.
  */
+@OptIn(io.lettuce.core.ExperimentalLettuceCoroutinesApi::class)
 @Tag(UNIT_TEST)
 class KotlinCoroutinesConsistencyUnitTests {
 
@@ -55,6 +64,35 @@ class KotlinCoroutinesConsistencyUnitTests {
         softly.assertAll()
     }
 
+    @Test
+    fun standaloneAggregateCoversAllGroups() {
+
+        val softly = SoftAssertions()
+
+        for (group in EnumSet.complementOf(EnumSet.of(CommandInterfaces.SENTINEL))) {
+            assertExtends(softly, RedisCoroutinesCommands::class.java, group.coroutines())
+        }
+
+        softly.assertAll()
+    }
+
+    @Test
+    fun clusterAggregateCoversAllClusterGroups() {
+
+        val softly = SoftAssertions()
+
+        for (group in EnumSet.complementOf(EnumSet.of(CommandInterfaces.SENTINEL, CommandInterfaces.TRANSACTIONAL))) {
+            assertExtends(softly, RedisClusterCoroutinesCommands::class.java, group.coroutines())
+        }
+
+        softly.assertAll()
+    }
+
+    private fun assertExtends(softly: SoftAssertions, aggregate: Class<*>, groupInterface: Class<*>) {
+        softly.assertThat(groupInterface.isAssignableFrom(aggregate))
+            .describedAs("%s must extend %s", aggregate.simpleName, groupInterface.simpleName).isTrue
+    }
+
     @ParameterizedTest
     @EnumSource(CommandInterfaces::class)
     fun coroutinesMethodsExistOnSyncOrAsyncApi(group: CommandInterfaces) {
@@ -79,12 +117,12 @@ class KotlinCoroutinesConsistencyUnitTests {
 
     private fun verifyShape(softly: SoftAssertions, group: CommandInterfaces, syncMethod: Method, function: KFunction<*>) {
 
-        val override = KnownApiDeviations.lookup(KnownApiDeviations.COROUTINES_RESULT_OVERRIDES, syncMethod, group.sync())
+        val override = KnownApiDeviations.lookup(KnownKotlinApiDeviations.RESULT_OVERRIDES, syncMethod, group.sync())
         val expectFlow = override?.startsWith("Flow<") ?: KnownApiDeviations.contains(
-            KnownApiDeviations.COROUTINES_FLOW, syncMethod, group.sync()
+            KnownKotlinApiDeviations.FLOW, syncMethod, group.sync()
         )
         val expectSuspend = !expectFlow &&
-            !KnownApiDeviations.contains(KnownApiDeviations.COROUTINES_NON_SUSPENDABLE, syncMethod, group.sync())
+            !KnownApiDeviations.contains(KnownKotlinApiDeviations.NON_SUSPENDABLE, syncMethod, group.sync())
 
         val description = "${group.coroutines().simpleName}.${KnownApiDeviations.signatureKey(syncMethod)}"
 
@@ -125,14 +163,14 @@ class KotlinCoroutinesConsistencyUnitTests {
 
     private fun isSkippedOnCoroutinesApi(syncMethod: Method, group: CommandInterfaces): Boolean {
 
-        if (KnownApiDeviations.contains(KnownApiDeviations.COROUTINES_SKIP, syncMethod, group.sync())) {
+        if (KnownApiDeviations.contains(KnownKotlinApiDeviations.SKIP, syncMethod, group.sync())) {
             return true
         }
         if (TypeSignatures.isStreamingChannelMethod(syncMethod)) {
             return true
         }
         return syncMethod.isAnnotationPresent(java.lang.Deprecated::class.java) &&
-            !KnownApiDeviations.contains(KnownApiDeviations.COROUTINES_KEEP_DEPRECATED, syncMethod, group.sync())
+            !KnownApiDeviations.contains(KnownKotlinApiDeviations.KEEP_DEPRECATED, syncMethod, group.sync())
     }
 
     /**


### PR DESCRIPTION
## Summary

Relocates everything coroutine-flavored in the API consistency suite from the Java test sources to the Kotlin side, so the Java tests carry no compile-time references to Kotlin types. The `CommandInterfaces` catalog now lists only the five Java flavors; the coroutine interface is derived from the sync interface by naming convention via a new Kotlin `CommandInterfaces.coroutines()` extension.

## Motivation

- **Clean direction of dependency.** The Kotlin coroutine API is a layer on top of the Java API, and the test suite now mirrors that: Kotlin test sources depend on the Java ones, never the reverse. Previously the Java catalog, deviations registry and aggregate tests all had compile-time references to Kotlin coroutine types.
- **Ownership by flavor.** Only the coroutine consistency test consults the coroutine deviation tables, so they belong in the Kotlin sources next to that test. The registries are now split by language side — the Java flavors stay together in `KnownApiDeviations`, the coroutine flavor lives in `KnownKotlinApiDeviations` — while the key-matching helpers remain shared from the Java side.
- **Less manual registration.** Deriving the coroutine interface by naming convention removes a per-group catalog entry and turns the convention itself into a checked invariant.

## Key Decisions & Assumptions

- The coroutine interface is resolved reflectively from the sync interface name (`api.sync` → `api.coroutines`, `*Commands` → `*CoroutinesCommands`) instead of being registered explicitly — this also makes the naming convention itself enforced: a coroutine interface under an unconventional name fails resolution.
- Coroutine deviations (`SKIP`, `NON_SUSPENDABLE`, `FLOW`, `KEEP_DEPRECATED`, `RESULT_OVERRIDES`) move verbatim from `KnownApiDeviations` into a new Kotlin registry, `KnownKotlinApiDeviations`, splitting the exceptions by flavor ownership. Key forms and matching helpers stay shared via the Java class.

## Behavioral / Conceptual Changes

- The coroutine aggregate-coverage checks (standalone and cluster umbrella interfaces extending each group's coroutine interface) move from `AggregateInterfaceConsistencyUnitTests` to `KotlinCoroutinesConsistencyUnitTests`; overall coverage is unchanged.
- Registering a new command group no longer requires naming its coroutine interface in the catalog — it only has to exist under the conventional name.

## Testing

Test-only change. The suite's assertions are preserved one-for-one; the two aggregate checks were rewritten as plain Kotlin tests excluding SENTINEL (and TRANSACTIONAL for cluster), matching the Java originals. `.agents/docs/api-consistency.md` is updated to describe the two-registry split.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with preserved assertions; no production or runtime behavior changes.
> 
> **Overview**
> Moves **coroutine-flavored API consistency checks** out of the Java test tree so Java tests no longer compile against Kotlin coroutine types. Production APIs are unchanged; this is test and documentation layout only.
> 
> **`CommandInterfaces`** now catalogs only the five Java flavors (sync, async, reactive, node-selection sync/async). Coroutine group interfaces are resolved via a new Kotlin **`CommandInterfaces.coroutines()`** extension that maps sync class names (`api.sync` → `api.coroutines`, `*Commands` → `*CoroutinesCommands`) and fails if the conventional class is missing.
> 
> Coroutine exception tables (`SKIP`, `NON_SUSPENDABLE`, `FLOW`, `KEEP_DEPRECATED`, `RESULT_OVERRIDES`) move from **`KnownApiDeviations`** into **`KnownKotlinApiDeviations`**, while Java tests keep using the shared key-matching helpers on the Java registry. **`KotlinCoroutinesConsistencyUnitTests`** now owns standalone/cluster **aggregate extends** checks that were removed from **`AggregateInterfaceConsistencyUnitTests`**. **`.agents/docs/api-consistency.md`** documents the two-registry split and the convention-based coroutine catalog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d34ed4490bdd2994fb964a06160d2f822b65846. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->