### PR TITLE
Disable broken FT.HYBRID tests

### DIFF
--- a/src/test/java/io/lettuce/core/search/RediSearchIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/search/RediSearchIntegrationTests.java
@@ -52,6 +52,7 @@ import io.lettuce.test.condition.EnabledOnCommand;
 import io.lettuce.test.condition.RedisConditions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -1640,6 +1641,7 @@ public class RediSearchIntegrationTests {
      * error rather than partial results. See CAE-3003.
      */
     @Test
+    @Disabled("re-enable once MOD-17316 is fixed")
     void testHybridOnTimeoutFailReturnsError() {
         assumeTrue(RedisConditions.of(redis).hasVersionGreaterOrEqualsTo("8.10"));
 
@@ -1661,6 +1663,7 @@ public class RediSearchIntegrationTests {
      * See CAE-3003.
      */
     @Test
+    @Disabled("re-enable once MOD-17316 is fixed")
     void testHybridOnTimeoutReturnPopulatesWarnings() {
         assumeTrue(RedisConditions.of(redis).hasVersionGreaterOrEqualsTo("8.10"));
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change; no library or runtime behavior is modified.
> 
> **Overview**
> Temporarily **skips two FT.HYBRID integration tests** that assert `search-on-timeout` behavior (`fail` raises an error; `return` populates `HybridReply` warnings). Both are annotated with `@Disabled("re-enable once MOD-17316 is fixed")` so CI stays green while Redis Search fixes the underlying server issue (CAE-3003 parity tests for hybrid queries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f15d21991591d104befbebd1b124cee337b3d0db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->