### PR TITLE
Fix NoClassDefFoundError when jdk.net.ExtendedSocketOptions is unavailable

### DIFF
--- a/src/main/java/io/lettuce/core/resource/ExtendedKeepAliveSupport.java
+++ b/src/main/java/io/lettuce/core/resource/ExtendedKeepAliveSupport.java
@@ -13,7 +13,6 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.socket.nio.NioChannelOption;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import jdk.net.ExtendedSocketOptions;
 
 /**
  * Utility class to determine if extended TCP keep-alive options are supported on the current platform and to apply them.
@@ -26,6 +25,10 @@ import jdk.net.ExtendedSocketOptions;
  * </ul>
  * <p>
  * macOS (kqueue) does not support per-socket extended keep-alive options.
+ * <p>
+ * When {@code jdk.net.ExtendedSocketOptions} is not present (for example a jlink runtime image without the {@code jdk.net}
+ * module), NIO extended keep-alive is treated as unavailable and callers fall back to plain {@code SO_KEEPALIVE} instead of
+ * failing class initialization.
  *
  * @author Aleksandar Todorov
  * @since 7.5
@@ -41,8 +44,16 @@ public class ExtendedKeepAliveSupport {
         // 1. epoll is available (Linux), OR
         // 2. io_uring is available (Linux), OR
         // 3. NIO extended options are available AND kqueue is NOT available (not macOS)
-        EXTENDED_KEEPALIVE_SUPPORTED = EpollProvider.isAvailable() || IOUringProvider.isAvailable()
-                || (ExtendedNioSocketOptions.isAvailable() && !KqueueProvider.isAvailable());
+        //
+        // Probe must never throw: restricted/custom runtimes may lack jdk.net (see #3862).
+        boolean supported = false;
+        try {
+            supported = EpollProvider.isAvailable() || IOUringProvider.isAvailable()
+                    || (ExtendedNioSocketOptions.isAvailable() && !KqueueProvider.isAvailable());
+        } catch (Throwable e) {
+            logger.debug("Extended keep-alive support detection failed; falling back to plain SO_KEEPALIVE", e);
+        }
+        EXTENDED_KEEPALIVE_SUPPORTED = supported;
     }
 
     /**
@@ -92,7 +103,7 @@ public class ExtendedKeepAliveSupport {
     }
 
     /**
-     * Utility to support Java 11 {@link ExtendedSocketOptions extended keepalive options}.
+     * Utility to support Java 11 {@code jdk.net.ExtendedSocketOptions} extended keepalive options.
      */
     @SuppressWarnings("unchecked")
     static class ExtendedNioSocketOptions {
@@ -105,22 +116,39 @@ public class ExtendedKeepAliveSupport {
 
         static {
 
+            SocketOption<Integer>[] resolved = resolveOptions(ExtendedNioSocketOptions.class.getClassLoader());
+            TCP_KEEPCOUNT = resolved[0];
+            TCP_KEEPIDLE = resolved[1];
+            TCP_KEEPINTERVAL = resolved[2];
+        }
+
+        /**
+         * Resolve TCP keep-alive {@link SocketOption} constants from {@code jdk.net.ExtendedSocketOptions}.
+         * <p>
+         * Uses reflective lookup (no hard dependency on the {@code jdk.net} module) so restricted runtimes without that module
+         * degrade gracefully.
+         *
+         * @param classLoader class loader used to load {@code jdk.net.ExtendedSocketOptions}
+         * @return array of {@code [TCP_KEEPCOUNT, TCP_KEEPIDLE, TCP_KEEPINTERVAL]}, elements may be {@code null}
+         */
+        static SocketOption<Integer>[] resolveOptions(ClassLoader classLoader) {
+
             SocketOption<Integer> keepCount = null;
             SocketOption<Integer> keepIdle = null;
             SocketOption<Integer> keepInterval = null;
             try {
 
-                keepCount = (SocketOption<Integer>) ExtendedSocketOptions.class.getDeclaredField("TCP_KEEPCOUNT").get(null);
-                keepIdle = (SocketOption<Integer>) ExtendedSocketOptions.class.getDeclaredField("TCP_KEEPIDLE").get(null);
-                keepInterval = (SocketOption<Integer>) ExtendedSocketOptions.class.getDeclaredField("TCP_KEEPINTERVAL")
-                        .get(null);
-            } catch (ReflectiveOperationException e) {
+                Class<?> extendedSocketOptions = Class.forName("jdk.net.ExtendedSocketOptions", true, classLoader);
+                keepCount = (SocketOption<Integer>) extendedSocketOptions.getDeclaredField("TCP_KEEPCOUNT").get(null);
+                keepIdle = (SocketOption<Integer>) extendedSocketOptions.getDeclaredField("TCP_KEEPIDLE").get(null);
+                keepInterval = (SocketOption<Integer>) extendedSocketOptions.getDeclaredField("TCP_KEEPINTERVAL").get(null);
+            } catch (ReflectiveOperationException | NoClassDefFoundError | UnsupportedOperationException e) {
+                // ReflectiveOperationException covers ClassNotFoundException / NoSuchFieldException / etc.
+                // NoClassDefFoundError covers restricted runtimes that lack the jdk.net module (#3862).
                 logger.trace("Cannot extract ExtendedSocketOptions for KeepAlive", e);
             }
 
-            TCP_KEEPCOUNT = keepCount;
-            TCP_KEEPIDLE = keepIdle;
-            TCP_KEEPINTERVAL = keepInterval;
+            return new SocketOption[] { keepCount, keepIdle, keepInterval };
         }
 
         static boolean isAvailable() {

--- a/src/test/java/io/lettuce/core/resource/ExtendedKeepAliveSupportUnitTests.java
+++ b/src/test/java/io/lettuce/core/resource/ExtendedKeepAliveSupportUnitTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ */
+package io.lettuce.core.resource;
+
+import static io.lettuce.TestTags.UNIT_TEST;
+import static org.assertj.core.api.Assertions.*;
+
+import java.net.SocketOption;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.lettuce.core.SocketOptions;
+
+/**
+ * Unit tests for {@link ExtendedKeepAliveSupport}.
+ */
+@Tag(UNIT_TEST)
+class ExtendedKeepAliveSupportUnitTests {
+
+    @Test
+    void isSupportedDoesNotThrow() {
+        assertThatCode(ExtendedKeepAliveSupport::isSupported).doesNotThrowAnyException();
+    }
+
+    @Test
+    void socketOptionsDefaultInitDoesNotRequireExtendedSocketOptions() {
+        // Regression for #3862: ClientOptions / SocketOptions static defaults probe extended keep-alive
+        // support. Missing jdk.net.ExtendedSocketOptions must not crash application startup.
+        assertThatCode(() -> SocketOptions.builder().build()).doesNotThrowAnyException();
+
+        SocketOptions options = SocketOptions.create();
+        assertThat(options.isKeepAlive()).isTrue();
+        assertThat(options.getKeepAlive()).isNotNull();
+    }
+
+    @Test
+    void resolveOptionsReturnsNullsWhenExtendedSocketOptionsClassIsUnavailable() {
+
+        ClassLoader hidingLoader = new ClassLoader(ExtendedKeepAliveSupport.class.getClassLoader()) {
+
+            @Override
+            protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+                if (name.startsWith("jdk.net.")) {
+                    throw new ClassNotFoundException(name);
+                }
+                return super.loadClass(name, resolve);
+            }
+
+        };
+
+        SocketOption<Integer>[] options = ExtendedKeepAliveSupport.ExtendedNioSocketOptions.resolveOptions(hidingLoader);
+
+        assertThat(options).hasSize(3);
+        assertThat(options[0]).isNull();
+        assertThat(options[1]).isNull();
+        assertThat(options[2]).isNull();
+    }
+
+    @Test
+    void resolveOptionsDoesNotThrowWithCallersClassLoader() {
+
+        assertThatCode(() -> ExtendedKeepAliveSupport.ExtendedNioSocketOptions
+                .resolveOptions(ExtendedKeepAliveSupport.class.getClassLoader())).doesNotThrowAnyException();
+
+        SocketOption<Integer>[] options = ExtendedKeepAliveSupport.ExtendedNioSocketOptions
+                .resolveOptions(ExtendedKeepAliveSupport.class.getClassLoader());
+        assertThat(options).hasSize(3);
+    }
+
+}


### PR DESCRIPTION
## Summary

Fixes #3862.

When Lettuce runs on a restricted/custom runtime (e.g. a jlink image without the `jdk.net` module), class initialization of `ExtendedKeepAliveSupport` crashed with:

```text
java.lang.NoClassDefFoundError: jdk/net/ExtendedSocketOptions
```

That happens because `SocketOptions` defaults probe extended keep-alive support via a static field initializer, and the NIO path held a hard reference to `jdk.net.ExtendedSocketOptions` while only catching `ReflectiveOperationException`.

This change:

- Removes the hard dependency on `jdk.net.ExtendedSocketOptions` and resolves the type via `Class.forName` (same pattern as `EpollProvider` / native transport guards).
- Catches `ReflectiveOperationException`, `NoClassDefFoundError`, and `UnsupportedOperationException` so missing `jdk.net` degrades to “extended keep-alive unavailable”.
- Guards the outer support probe so detection failures never fail class init.
- Leaves plain `SO_KEEPALIVE` defaults intact when extended options are unavailable (pre-7.5.0 graceful behavior for restricted runtimes).

## Checklist

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request. (bug report #3862; maintainer confirmed the approach)
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

## Testing

```bash
export JAVA_HOME=.../jdk-21.0.12+8/Contents/Home
mvn test -Dtest=ExtendedKeepAliveSupportUnitTests,SocketOptionsUnitTests,KeepAliveOptionsUnitTests
```

Results: **15 tests, 0 failures** (Temurin 21).

Unit coverage includes a ClassLoader that hides `jdk.net.*` and asserts `resolveOptions` returns nulls without throwing, plus smoke tests that `SocketOptions` default construction still succeeds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow defensive change to optional JDK module probing; normal JDKs keep extended keep-alive when available, with unit tests for the missing-module path.
> 
> **Overview**
> Fixes startup crashes on restricted JVMs (e.g. jlink without the `jdk.net` module) where `ExtendedKeepAliveSupport` static initialization previously failed with `NoClassDefFoundError` because `SocketOptions` defaults call `ExtendedKeepAliveSupport.isSupported()` during class load.
> 
> **`ExtendedKeepAliveSupport`** no longer imports `jdk.net.ExtendedSocketOptions`. NIO TCP keep-alive constants are loaded via `Class.forName` in a new `resolveOptions(ClassLoader)` helper, and missing or broken `jdk.net` is handled by catching `ReflectiveOperationException`, `NoClassDefFoundError`, and `UnsupportedOperationException`, leaving options as null so extended keep-alive is treated as unavailable. The top-level support probe is wrapped in try/catch so detection errors never break class initialization; behavior falls back to plain `SO_KEEPALIVE`.
> 
> Adds **`ExtendedKeepAliveSupportUnitTests`** with regression coverage: `isSupported` and default `SocketOptions` construction do not throw, and a ClassLoader that hides `jdk.net.*` yields null resolved options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e51034c936523db59047af9e7a02a922378886c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->