### PR TITLE
Update security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,11 +1,8 @@
 # Security Policy
 
-## Supported Versions
-
-Currently maintained 
-
-Information about supported Lettuce versions can be found on the [Lettuce version support page](https://github.com/lettuce-io/lettuce-core/wiki/Lettuce-Versions) in the [Lettuce wiki](https://github.com/lettuce-io/lettuce-core/wiki).
-
 ## Reporting a Vulnerability
 
-Please open an issue, without details. We will contact you then.
+If you believe you have found a security vulnerability, to ensure proper review and assessment, we kindly ask
+vulnerability reports be submitted through the
+[Redis Vulnerability Disclosure Program](https://redis.io/redis-responsible-vulnerability-disclosure/).
+Alternatively reach out via email to security@redis.com.


### PR DESCRIPTION
Replaces the existing `.github/SECURITY.md` so vulnerability reports are routed through the proper channel instead of being filed as public issues.

The updated policy mirrors the one used across other Redis client repositories (e.g. [redis/jedis](https://github.com/redis/jedis/blob/master/SECURITY.md)) and directs reporters to the [Redis Vulnerability Disclosure Program](https://redis.io/redis-responsible-vulnerability-disclosure/), with security@redis.com as an alternative contact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to security reporting; no runtime or dependency impact.
> 
> **Overview**
> **Updates `.github/SECURITY.md`** so security issues are no longer reported via public GitHub issues.
> 
> The **Supported Versions** section and the wiki link are removed. Reporters are directed to the **[Redis Vulnerability Disclosure Program](https://redis.io/redis-responsible-vulnerability-disclosure/)**, with **security@redis.com** as a fallback—aligned with other Redis client repos such as Jedis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd2975df66670723093a0b1392651fa68fd7040e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->