### PR TITLE
Support client-side caching (RESP3 tracking) for Redis Cluster

### DIFF
--- a/docs/user-guide/client-side-caching.md
+++ b/docs/user-guide/client-side-caching.md
@@ -24,10 +24,14 @@ String value = frontend.get(key);
 The `CacheFrontend` is associated with the Redis connection. Close the
 frontend through `CacheFrontend.close()` to release the connection after use.
 
-With RESP3, invalidation messages are delivered as push messages on the
-connection itself. With RESP2, use `TrackingArgs` redirection
-(`TrackingArgs.Builder.enabled().redirect(clientId)`) to deliver invalidations
-to a Pub/Sub connection.
+The example above requires RESP3: invalidation messages are delivered as push
+messages on the connection itself, and the frontend evicts local entries
+automatically. With RESP2, Redis delivers invalidations only to a redirected
+client (`TrackingArgs.Builder.enabled().redirect(clientId)`), so the
+frontend's built-in invalidation listener never receives them. In that case
+subscribe to the `__redis__:invalidate` Pub/Sub channel on the redirect target
+connection and evict entries from the client-side cache
+(`CacheAccessor.evict(...)`) in the Pub/Sub listener yourself.
 
 ## Redis Cluster connections
 
@@ -62,9 +66,12 @@ The following constraints apply to Redis Cluster:
 - **`OPTIN` is not supported** as the cache frontend does not issue
   `CLIENT CACHING yes` before reads. Opt-in `TrackingArgs` are rejected with an
   `IllegalArgumentException`.
-- **Topology changes are not tracked.** Nodes added to the cluster after
-  enabling the cache do not have tracking enabled. Applications that must
-  observe topology changes should re-enable tracking after a topology refresh.
+- **Topology and read-policy changes are not tracked.** Tracking is configured
+  for the topology and `ReadFrom` setting present when the cache is enabled.
+  Nodes added to the cluster afterwards do not have tracking enabled, and
+  changing the read policy through `setReadFrom(...)` does not track newly
+  selectable replicas. Applications that must observe such changes should
+  re-enable tracking afterwards.
 
 `FLUSHALL` and `FLUSHDB` emit a full invalidation, which clears the entire
 client-side cache.

--- a/docs/user-guide/client-side-caching.md
+++ b/docs/user-guide/client-side-caching.md
@@ -1,0 +1,70 @@
+# Client-Side Caching
+
+Lettuce supports server-assisted client-side caching as described in the
+[Redis client-side caching documentation](https://redis.io/docs/latest/develop/reference/client-side-caching/).
+The `ClientSideCaching` utility creates a `CacheFrontend` that represents a
+two-level cache: values are first looked up in a local, application-provided
+cache and only fetched from Redis on a cache miss. Redis notifies the client
+through `CLIENT TRACKING` invalidation messages when a cached key is modified,
+and the corresponding local entry is evicted.
+
+## Standalone connections
+
+```java
+Map<String, String> clientCache = new ConcurrentHashMap<>();
+
+StatefulRedisConnection<String, String> connection = redisClient.connect();
+
+CacheFrontend<String, String> frontend = ClientSideCaching.enable(CacheAccessor.forMap(clientCache), connection,
+        TrackingArgs.Builder.enabled());
+
+String value = frontend.get(key);
+```
+
+The `CacheFrontend` is associated with the Redis connection. Close the
+frontend through `CacheFrontend.close()` to release the connection after use.
+
+With RESP3, invalidation messages are delivered as push messages on the
+connection itself. With RESP2, use `TrackingArgs` redirection
+(`TrackingArgs.Builder.enabled().redirect(clientId)`) to deliver invalidations
+to a Pub/Sub connection.
+
+## Redis Cluster connections
+
+Since version 7.7, client-side caching is also supported for Redis Cluster
+connections:
+
+```java
+Map<String, String> clientCache = new ConcurrentHashMap<>();
+
+StatefulRedisClusterConnection<String, String> connection = clusterClient.connect();
+
+CacheFrontend<String, String> frontend = ClientSideCaching.enable(CacheAccessor.forMap(clientCache), connection,
+        TrackingArgs.Builder.enabled());
+
+String value = frontend.get(key);
+```
+
+`CLIENT TRACKING` is enabled on each cluster node connection because
+invalidation messages for a key are emitted by the node that serves the key's
+slot. Upstream (master) nodes are tracked through their write-intent
+connections. When a `ReadFrom` setting routes reads to replicas, the replicas
+that the read policy can select are tracked through their read-intent
+connections as well.
+
+The following constraints apply to Redis Cluster:
+
+- **RESP3 is required.** Enabling the cache fails with an
+  `IllegalStateException` if a node connection did not negotiate RESP3.
+- **`REDIRECT` is not supported** as invalidation messages can originate from
+  any node. Redirected `TrackingArgs` are rejected with an
+  `IllegalArgumentException`.
+- **`OPTIN` is not supported** as the cache frontend does not issue
+  `CLIENT CACHING yes` before reads. Opt-in `TrackingArgs` are rejected with an
+  `IllegalArgumentException`.
+- **Topology changes are not tracked.** Nodes added to the cluster after
+  enabling the cache do not have tracking enabled. Applications that must
+  observe topology changes should re-enable tracking after a topology refresh.
+
+`FLUSHALL` and `FLUSHDB` emit a full invalidation, which clears the entire
+client-side cache.

--- a/docs/user-guide/client-side-caching.md
+++ b/docs/user-guide/client-side-caching.md
@@ -31,7 +31,10 @@ client (`TrackingArgs.Builder.enabled().redirect(clientId)`), so the
 frontend's built-in invalidation listener never receives them. In that case
 subscribe to the `__redis__:invalidate` Pub/Sub channel on the redirect target
 connection and evict entries from the client-side cache
-(`CacheAccessor.evict(...)`) in the Pub/Sub listener yourself.
+(`CacheAccessor.evict(...)`) in the Pub/Sub listener yourself. Full
+invalidations such as `FLUSHALL`/`FLUSHDB` deliver a `null` message without
+keys — clear the entire client-side cache (`CacheAccessor.clear()`) when the
+invalidation message is `null`.
 
 ## Redis Cluster connections
 

--- a/docs/user-guide/client-side-caching.md
+++ b/docs/user-guide/client-side-caching.md
@@ -69,6 +69,10 @@ The following constraints apply to Redis Cluster:
 - **`OPTIN` is not supported** as the cache frontend does not issue
   `CLIENT CACHING yes` before reads. Opt-in `TrackingArgs` are rejected with an
   `IllegalArgumentException`.
+- **Prefix-limited `BCAST` is not supported** as the cache frontend caches all
+  keys regardless of prefix, so keys outside the configured prefixes would
+  never be invalidated. Prefixed `TrackingArgs` are rejected with an
+  `IllegalArgumentException`.
 - **Topology and read-policy changes are not tracked.** Tracking is configured
   for the topology and `ReadFrom` setting present when the cache is enabled.
   Nodes added to the cluster afterwards do not have tracking enabled, and

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
       - Kotlin API: user-guide/kotlin-api.md
       - Publish/Subscribe: user-guide/pubsub.md
       - Transactions/Multi: user-guide/transactions-multi.md
+      - Client-Side Caching: user-guide/client-side-caching.md
       - Redis Query Engine: user-guide/redis-search.md
       - Redis JSON: user-guide/redis-json.md
       - Redis Vector Sets: user-guide/vector-sets.md

--- a/src/main/java/io/lettuce/core/TrackingArgs.java
+++ b/src/main/java/io/lettuce/core/TrackingArgs.java
@@ -94,6 +94,16 @@ public class TrackingArgs implements CompositeArgument {
     }
 
     /**
+     * Return whether invalidation messages are redirected to another client connection through {@code REDIRECT}.
+     *
+     * @return {@code true} if {@link #redirect(long)} was configured.
+     * @since 7.7
+     */
+    public boolean isRedirect() {
+        return redirect != null;
+    }
+
+    /**
      * Enable tracking in broadcasting mode. In this mode invalidation messages are reported for all the prefixes specified,
      * regardless of the keys requested by the connection. Instead when the broadcasting mode is not enabled, Redis will track
      * which keys are fetched using read-only commands, and will report invalidation messages only for such keys.

--- a/src/main/java/io/lettuce/core/TrackingArgs.java
+++ b/src/main/java/io/lettuce/core/TrackingArgs.java
@@ -156,6 +156,16 @@ public class TrackingArgs implements CompositeArgument {
     }
 
     /**
+     * Return whether tracking requires a preceding {@code CLIENT CACHING yes} opt-in per read.
+     *
+     * @return {@code true} if {@link #optin()} was configured.
+     * @since 7.7
+     */
+    public boolean isOptin() {
+        return optin;
+    }
+
+    /**
      * When broadcasting is NOT active, normally track keys in read only commands, unless they are called immediately after a
      * CLIENT CACHING no command.
      *

--- a/src/main/java/io/lettuce/core/TrackingArgs.java
+++ b/src/main/java/io/lettuce/core/TrackingArgs.java
@@ -114,6 +114,16 @@ public class TrackingArgs implements CompositeArgument {
     }
 
     /**
+     * Return whether broadcasting invalidation messages are limited to key prefixes through {@code PREFIX}.
+     *
+     * @return {@code true} if {@link #prefixes(String...)} was configured with at least one prefix.
+     * @since 7.7
+     */
+    public boolean hasPrefixes() {
+        return prefixes != null && prefixes.length > 0;
+    }
+
+    /**
      * Create a copy of {@code this} {@link TrackingArgs} to guard against later modifications of a shared, mutable instance.
      *
      * @return a new {@link TrackingArgs} with the same configuration.

--- a/src/main/java/io/lettuce/core/TrackingArgs.java
+++ b/src/main/java/io/lettuce/core/TrackingArgs.java
@@ -94,6 +94,16 @@ public class TrackingArgs implements CompositeArgument {
     }
 
     /**
+     * Return whether key tracking is enabled.
+     *
+     * @return {@code true} if {@link #enabled(boolean)} was configured with {@code true}.
+     * @since 7.7
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
      * Return whether invalidation messages are redirected to another client connection through {@code REDIRECT}.
      *
      * @return {@code true} if {@link #redirect(long)} was configured.
@@ -101,6 +111,26 @@ public class TrackingArgs implements CompositeArgument {
      */
     public boolean isRedirect() {
         return redirect != null;
+    }
+
+    /**
+     * Create a copy of {@code this} {@link TrackingArgs} to guard against later modifications of a shared, mutable instance.
+     *
+     * @return a new {@link TrackingArgs} with the same configuration.
+     * @since 7.7
+     */
+    public TrackingArgs copy() {
+
+        TrackingArgs copy = new TrackingArgs();
+        copy.enabled = this.enabled;
+        copy.redirect = this.redirect;
+        copy.bcast = this.bcast;
+        copy.prefixes = this.prefixes == null ? null : this.prefixes.clone();
+        copy.prefixCharset = this.prefixCharset;
+        copy.optin = this.optin;
+        copy.optout = this.optout;
+        copy.noloop = this.noloop;
+        return copy;
     }
 
     /**

--- a/src/main/java/io/lettuce/core/support/caching/CacheAccessor.java
+++ b/src/main/java/io/lettuce/core/support/caching/CacheAccessor.java
@@ -59,4 +59,16 @@ public interface CacheAccessor<K, V> {
      */
     void evict(K key);
 
+    /**
+     * Evict all mappings from this cache. Invoked when Redis reports a full invalidation, for example after {@code FLUSHALL} or
+     * {@code FLUSHDB}.
+     * <p>
+     * The default implementation is a no-op; implementations should override this method to avoid serving stale entries after a
+     * flush.
+     *
+     * @since 7.7
+     */
+    default void clear() {
+    }
+
 }

--- a/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
+++ b/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
@@ -1,5 +1,6 @@
 package io.lettuce.core.support.caching;
 
+import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -12,6 +13,9 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 
 import io.lettuce.core.ReadFrom;
+import io.lettuce.core.RedisChannelHandler;
+import io.lettuce.core.RedisConnectionException;
+import io.lettuce.core.RedisConnectionStateListener;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.StatefulRedisConnectionImpl;
 import io.lettuce.core.TrackingArgs;
@@ -24,6 +28,8 @@ import io.lettuce.core.internal.LettuceAssert;
 import io.lettuce.core.models.role.RedisNodeDescription;
 import io.lettuce.core.protocol.ConnectionIntent;
 import io.lettuce.core.protocol.ProtocolVersion;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 /**
  * Utility to provide server-side assistance for client-side caches. This is a {@link CacheFrontend} that represents a two-level
@@ -50,6 +56,8 @@ import io.lettuce.core.protocol.ProtocolVersion;
  * @since 6.0
  */
 public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
+
+    private static final InternalLogger LOG = InternalLoggerFactory.getInstance(ClientSideCaching.class);
 
     private final CacheAccessor<K, V> cacheAccessor;
 
@@ -160,7 +168,14 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
         for (RedisNodeDescription node : readCandidates(connection)) {
             // reads from upstream nodes are served by the write-intent connections tracked above
             if (node.getRole().isReplica()) {
-                enableTracking(connection, node.getUri(), ConnectionIntent.READ, tracking);
+                try {
+                    enableTracking(connection, node.getUri(), ConnectionIntent.READ, tracking);
+                } catch (RedisConnectionException e) {
+                    // the read path tolerates unavailable replicas as long as another candidate connects,
+                    // so an unreachable replica must not fail cache setup
+                    LOG.warn("Cannot enable key tracking on replica {}, reads from this replica are not tracked", node.getUri(),
+                            e);
+                }
             }
         }
 
@@ -194,15 +209,23 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
         return node.is(RedisClusterNode.NodeFlag.UPSTREAM) && !node.hasNoSlots();
     }
 
+    private static boolean isReadCandidate(RedisClusterNode upstream, RedisClusterNode node) {
+
+        if (upstream.getNodeId().equals(node.getNodeId())) {
+            return true;
+        }
+
+        // consider only replicas that contain data from replication, mirroring the connection provider
+        return upstream.getNodeId().equals(node.getSlaveOf()) && node.getReplOffset() != 0;
+    }
+
     private static ReadFrom.Nodes slotGroup(StatefulRedisClusterConnection<?, ?> connection, RedisClusterNode upstream) {
 
+        // preserve the partition order, mirroring PooledClusterConnectionProvider#getReadCandidates
         List<RedisNodeDescription> nodes = new ArrayList<>();
-        nodes.add(upstream);
 
         for (RedisClusterNode node : connection.getPartitions()) {
-            // consider only replicas that contain data from replication, mirroring the connection provider
-            if (node.is(RedisClusterNode.NodeFlag.REPLICA) && upstream.getNodeId().equals(node.getSlaveOf())
-                    && node.getReplOffset() != 0) {
+            if (isReadCandidate(upstream, node)) {
                 nodes.add(node);
             }
         }
@@ -226,13 +249,23 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
             ConnectionIntent intent, TrackingArgs tracking) {
 
         StatefulRedisConnection<K, V> nodeConnection = connection.getConnection(uri.getHost(), uri.getPort(), intent);
+        StatefulRedisConnectionImpl<K, V> nodeConnectionImpl = (StatefulRedisConnectionImpl<K, V>) nodeConnection;
 
-        ProtocolVersion protocolVersion = ((StatefulRedisConnectionImpl<K, V>) nodeConnection).getConnectionState()
-                .getNegotiatedProtocolVersion();
+        ProtocolVersion protocolVersion = nodeConnectionImpl.getConnectionState().getNegotiatedProtocolVersion();
         LettuceAssert.assertState(protocolVersion == ProtocolVersion.RESP3,
                 "Client-side caching for Redis Cluster requires RESP3");
 
         nodeConnection.sync().clientTracking(tracking);
+
+        // CLIENT TRACKING is connection state that the reconnect handshake does not restore, re-apply it
+        nodeConnectionImpl.addListener(new RedisConnectionStateListener() {
+
+            @Override
+            public void onRedisConnected(RedisChannelHandler<?, ?> connectionHandler, SocketAddress socketAddress) {
+                nodeConnection.async().clientTracking(tracking);
+            }
+
+        });
     }
 
     /**

--- a/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
+++ b/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
@@ -125,8 +125,10 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
      * {@code CLIENT CACHING yes} before reads; this method throws {@link IllegalArgumentException} for redirected or opt-in
      * tracking parameters and {@link IllegalStateException} if a node connection did not negotiate RESP3.
      * <p>
-     * Nodes added to the cluster after this call do not have tracking enabled. Applications that must observe topology changes
-     * should re-enable tracking after a topology refresh.
+     * Tracking is configured for the topology and {@link ReadFrom} setting present at the time of this call. Nodes added to the
+     * cluster afterwards do not have tracking enabled, and changing the read policy through
+     * {@link StatefulRedisClusterConnection#setReadFrom} does not track newly selectable replicas. Applications that must
+     * observe such changes should re-enable tracking afterwards.
      * <p>
      * Note that the {@link CacheFrontend} is associated with a Redis connection. Make sure to {@link CacheFrontend#close()
      * close} the frontend object to release the Redis connection after use.
@@ -150,7 +152,7 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
         for (RedisClusterNode node : connection.getPartitions()) {
             // use host/port connections: slot-routed commands are served by connections keyed
             // by intent, host and port, not by the nodeId-keyed connections
-            if (node.is(RedisClusterNode.NodeFlag.UPSTREAM)) {
+            if (isServingUpstream(node)) {
                 enableTracking(connection, node.getUri(), ConnectionIntent.WRITE, tracking);
             }
         }
@@ -179,12 +181,17 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
         Set<RedisNodeDescription> candidates = new LinkedHashSet<>();
 
         for (RedisClusterNode upstream : connection.getPartitions()) {
-            if (upstream.is(RedisClusterNode.NodeFlag.UPSTREAM)) {
+            if (isServingUpstream(upstream)) {
                 candidates.addAll(readFrom.select(slotGroup(connection, upstream)));
             }
         }
 
         return candidates;
+    }
+
+    private static boolean isServingUpstream(RedisClusterNode node) {
+        // upstream nodes without slots cannot serve slot-routed reads or writes
+        return node.is(RedisClusterNode.NodeFlag.UPSTREAM) && !node.hasNoSlots();
     }
 
     private static ReadFrom.Nodes slotGroup(StatefulRedisClusterConnection<?, ?> connection, RedisClusterNode upstream) {
@@ -193,7 +200,9 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
         nodes.add(upstream);
 
         for (RedisClusterNode node : connection.getPartitions()) {
-            if (node.is(RedisClusterNode.NodeFlag.REPLICA) && upstream.getNodeId().equals(node.getSlaveOf())) {
+            // consider only replicas that contain data from replication, mirroring the connection provider
+            if (node.is(RedisClusterNode.NodeFlag.REPLICA) && upstream.getNodeId().equals(node.getSlaveOf())
+                    && node.getReplOffset() != 0) {
                 nodes.add(node);
             }
         }

--- a/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
+++ b/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
@@ -5,9 +5,13 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 
+import io.lettuce.core.RedisURI;
 import io.lettuce.core.StatefulRedisConnectionImpl;
 import io.lettuce.core.TrackingArgs;
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.cluster.StatefulRedisClusterConnectionImpl;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
 import io.lettuce.core.codec.RedisCodec;
 
 /**
@@ -31,6 +35,7 @@ import io.lettuce.core.codec.RedisCodec;
  * @param <K> Key type.
  * @param <V> Value type.
  * @author Mark Paluch
+ * @author Julien Ruaux
  * @since 6.0
  */
 public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
@@ -88,6 +93,74 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
         StatefulRedisConnectionImpl<K, V> connectionImpl = (StatefulRedisConnectionImpl) connection;
         RedisCodec<K, V> codec = connectionImpl.getCodec();
         RedisCache<K, V> redisCache = new DefaultRedisCache<>(connection, codec);
+
+        return create(cacheAccessor, redisCache);
+    }
+
+    /**
+     * Enable server-assisted Client side caching for the given {@link CacheAccessor} and
+     * {@link StatefulRedisClusterConnection}.
+     * <p>
+     * {@code CLIENT TRACKING} is enabled on each upstream (master) node connection: invalidation messages for a key are emitted
+     * by the node that serves the key's slot, so tracking must be active there. Note that a keyless {@code CLIENT TRACKING}
+     * command issued through the cluster command API would be routed to the default connection only, whose push messages are
+     * not associated with cluster node connections.
+     * <p>
+     * Client-side caching for Redis Cluster requires RESP3 ({@code TrackingArgs} redirection is not supported as invalidation
+     * messages can originate from any node).
+     * <p>
+     * Nodes added to the cluster after this call do not have tracking enabled. Applications that must observe topology changes
+     * should re-enable tracking after a topology refresh.
+     * <p>
+     * Note that the {@link CacheFrontend} is associated with a Redis connection. Make sure to {@link CacheFrontend#close()
+     * close} the frontend object to release the Redis connection after use.
+     *
+     * @param cacheAccessor the accessor used to interact with the client-side cache.
+     * @param connection the Redis Cluster connection to use. The connection will be associated with {@link CacheFrontend} and
+     *        must be closed through {@link CacheFrontend#close()}.
+     * @param tracking the tracking parameters.
+     * @param <K> Key type.
+     * @param <V> Value type.
+     * @return the {@link CacheFrontend} for value retrieval.
+     * @since 7.7
+     */
+    public static <K, V> CacheFrontend<K, V> enable(CacheAccessor<K, V> cacheAccessor,
+            StatefulRedisClusterConnection<K, V> connection, TrackingArgs tracking) {
+
+        for (RedisClusterNode node : connection.getPartitions()) {
+            if (node.is(RedisClusterNode.NodeFlag.UPSTREAM)) {
+                // use the host/port connection: slot-routed commands are served by connections keyed
+                // by host and port, not by the nodeId-keyed connections
+                RedisURI uri = node.getUri();
+                connection.getConnection(uri.getHost(), uri.getPort()).sync().clientTracking(tracking);
+            }
+        }
+
+        return create(cacheAccessor, connection);
+    }
+
+    /**
+     * Create a server-assisted Client side caching for the given {@link CacheAccessor} and
+     * {@link StatefulRedisClusterConnection}. This method expects that client key tracking is already configured on the cluster
+     * node connections.
+     * <p>
+     * Note that the {@link CacheFrontend} is associated with a Redis connection. Make sure to {@link CacheFrontend#close()
+     * close} the frontend object to release the Redis connection after use.
+     *
+     * @param cacheAccessor the accessor used to interact with the client-side cache.
+     * @param connection the Redis Cluster connection to use. The connection will be associated with {@link CacheFrontend} and
+     *        must be closed through {@link CacheFrontend#close()}.
+     * @param <K> Key type.
+     * @param <V> Value type.
+     * @return the {@link CacheFrontend} for value retrieval.
+     * @since 7.7
+     */
+    public static <K, V> CacheFrontend<K, V> create(CacheAccessor<K, V> cacheAccessor,
+            StatefulRedisClusterConnection<K, V> connection) {
+
+        StatefulRedisClusterConnectionImpl<K, V> connectionImpl = (StatefulRedisClusterConnectionImpl) connection;
+        RedisCodec<K, V> codec = connectionImpl.getCodec();
+        RedisCache<K, V> redisCache = new ClusterRedisCache<>(connection, codec);
 
         return create(cacheAccessor, redisCache);
     }

--- a/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
+++ b/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
@@ -1,10 +1,14 @@
 package io.lettuce.core.support.caching;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 
+import io.lettuce.core.ReadFrom;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.StatefulRedisConnectionImpl;
 import io.lettuce.core.TrackingArgs;
@@ -14,6 +18,7 @@ import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.internal.LettuceAssert;
+import io.lettuce.core.models.role.RedisNodeDescription;
 import io.lettuce.core.protocol.ConnectionIntent;
 import io.lettuce.core.protocol.ProtocolVersion;
 
@@ -106,10 +111,11 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
      * <p>
      * {@code CLIENT TRACKING} is enabled on each cluster node connection: invalidation messages for a key are emitted by the
      * node that serves the key's slot (or, for replica reads, by the replica the value was read from), so tracking must be
-     * active there. Upstream (master) nodes are tracked through their write-intent connections and replicas through their
-     * read-intent connections so that reads routed by {@link io.lettuce.core.ReadFrom} settings are registered for tracking as
-     * well. Note that a keyless {@code CLIENT TRACKING} command issued through the cluster command API would be routed to the
-     * default connection only, whose push messages are not associated with cluster node connections.
+     * active there. Upstream (master) nodes are tracked through their write-intent connections. Replicas are tracked through
+     * their read-intent connections only when the connection's {@link ReadFrom} setting can select them for reads, so no
+     * replica connections are opened when reads are routed to upstream nodes only (the default). Note that a keyless
+     * {@code CLIENT TRACKING} command issued through the cluster command API would be routed to the default connection only,
+     * whose push messages are not associated with cluster node connections.
      * <p>
      * Client-side caching for Redis Cluster requires RESP3. {@code TrackingArgs} redirection is not supported as invalidation
      * messages can originate from any node; this method throws {@link IllegalArgumentException} for redirected tracking
@@ -140,19 +146,49 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
             // use host/port connections: slot-routed commands are served by connections keyed
             // by intent, host and port, not by the nodeId-keyed connections
             if (node.is(RedisClusterNode.NodeFlag.UPSTREAM)) {
-                enableTracking(connection, node, ConnectionIntent.WRITE, tracking);
-            } else if (node.is(RedisClusterNode.NodeFlag.REPLICA)) {
-                enableTracking(connection, node, ConnectionIntent.READ, tracking);
+                enableTracking(connection, node.getUri(), ConnectionIntent.WRITE, tracking);
+            }
+        }
+
+        for (RedisNodeDescription node : readCandidates(connection)) {
+            // reads from upstream nodes are served by the write-intent connections tracked above
+            if (node.getRole().isReplica()) {
+                enableTracking(connection, node.getUri(), ConnectionIntent.READ, tracking);
             }
         }
 
         return create(cacheAccessor, connection);
     }
 
-    private static <K, V> void enableTracking(StatefulRedisClusterConnection<K, V> connection, RedisClusterNode node,
+    private static List<RedisNodeDescription> readCandidates(StatefulRedisClusterConnection<?, ?> connection) {
+
+        ReadFrom readFrom = connection.getReadFrom();
+
+        if (readFrom == null) {
+            // without a ReadFrom setting, all reads are routed to upstream nodes
+            return Collections.emptyList();
+        }
+
+        List<RedisNodeDescription> nodes = new ArrayList<>(connection.getPartitions().getPartitions());
+
+        return readFrom.select(new ReadFrom.Nodes() {
+
+            @Override
+            public List<RedisNodeDescription> getNodes() {
+                return nodes;
+            }
+
+            @Override
+            public Iterator<RedisNodeDescription> iterator() {
+                return nodes.iterator();
+            }
+
+        });
+    }
+
+    private static <K, V> void enableTracking(StatefulRedisClusterConnection<K, V> connection, RedisURI uri,
             ConnectionIntent intent, TrackingArgs tracking) {
 
-        RedisURI uri = node.getUri();
         StatefulRedisConnection<K, V> nodeConnection = connection.getConnection(uri.getHost(), uri.getPort(), intent);
 
         ProtocolVersion protocolVersion = ((StatefulRedisConnectionImpl<K, V>) nodeConnection).getConnectionState()

--- a/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
+++ b/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
@@ -148,20 +148,27 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
      * @param <K> Key type.
      * @param <V> Value type.
      * @return the {@link CacheFrontend} for value retrieval.
+     * @throws IllegalArgumentException if {@code tracking} is {@code null}, disabled, redirected or opt-in.
+     * @throws IllegalStateException if a node connection did not negotiate RESP3.
      * @since 7.7
      */
     public static <K, V> CacheFrontend<K, V> enable(CacheAccessor<K, V> cacheAccessor,
             StatefulRedisClusterConnection<K, V> connection, TrackingArgs tracking) {
 
+        LettuceAssert.notNull(tracking, "TrackingArgs must not be null");
+        LettuceAssert.isTrue(tracking.isEnabled(), "TrackingArgs must be enabled for Redis Cluster client-side caching");
         LettuceAssert.isTrue(!tracking.isRedirect(),
                 "TrackingArgs REDIRECT is not supported for Redis Cluster client-side caching");
         LettuceAssert.isTrue(!tracking.isOptin(), "TrackingArgs OPTIN is not supported for Redis Cluster client-side caching");
+
+        // snapshot the mutable args so reconnect replay does not observe later modifications
+        TrackingArgs trackingSnapshot = tracking.copy();
 
         for (RedisClusterNode node : connection.getPartitions()) {
             // use host/port connections: slot-routed commands are served by connections keyed
             // by intent, host and port, not by the nodeId-keyed connections
             if (isServingUpstream(node)) {
-                enableTracking(connection, node.getUri(), ConnectionIntent.WRITE, tracking);
+                enableTracking(connection, node.getUri(), ConnectionIntent.WRITE, trackingSnapshot);
             }
         }
 
@@ -169,7 +176,7 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
             // reads from upstream nodes are served by the write-intent connections tracked above
             if (node.getRole().isReplica()) {
                 try {
-                    enableTracking(connection, node.getUri(), ConnectionIntent.READ, tracking);
+                    enableTracking(connection, node.getUri(), ConnectionIntent.READ, trackingSnapshot);
                 } catch (RedisConnectionException e) {
                     // the read path tolerates unavailable replicas as long as another candidate connects,
                     // so an unreachable replica must not fail cache setup

--- a/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
+++ b/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
@@ -1,9 +1,12 @@
 package io.lettuce.core.support.caching;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
@@ -118,8 +121,9 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
      * whose push messages are not associated with cluster node connections.
      * <p>
      * Client-side caching for Redis Cluster requires RESP3. {@code TrackingArgs} redirection is not supported as invalidation
-     * messages can originate from any node; this method throws {@link IllegalArgumentException} for redirected tracking
-     * parameters and {@link IllegalStateException} if a node connection did not negotiate RESP3.
+     * messages can originate from any node, and {@code OPTIN} tracking is not supported as the cache frontend does not issue
+     * {@code CLIENT CACHING yes} before reads; this method throws {@link IllegalArgumentException} for redirected or opt-in
+     * tracking parameters and {@link IllegalStateException} if a node connection did not negotiate RESP3.
      * <p>
      * Nodes added to the cluster after this call do not have tracking enabled. Applications that must observe topology changes
      * should re-enable tracking after a topology refresh.
@@ -141,6 +145,7 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
 
         LettuceAssert.isTrue(!tracking.isRedirect(),
                 "TrackingArgs REDIRECT is not supported for Redis Cluster client-side caching");
+        LettuceAssert.isTrue(!tracking.isOptin(), "TrackingArgs OPTIN is not supported for Redis Cluster client-side caching");
 
         for (RedisClusterNode node : connection.getPartitions()) {
             // use host/port connections: slot-routed commands are served by connections keyed
@@ -160,7 +165,7 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
         return create(cacheAccessor, connection);
     }
 
-    private static List<RedisNodeDescription> readCandidates(StatefulRedisClusterConnection<?, ?> connection) {
+    private static Collection<RedisNodeDescription> readCandidates(StatefulRedisClusterConnection<?, ?> connection) {
 
         ReadFrom readFrom = connection.getReadFrom();
 
@@ -169,9 +174,31 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
             return Collections.emptyList();
         }
 
-        List<RedisNodeDescription> nodes = new ArrayList<>(connection.getPartitions().getPartitions());
+        // mirror the per-slot selection of the cluster connection provider: ReadFrom sees an
+        // upstream node and its replicas, not the whole cluster
+        Set<RedisNodeDescription> candidates = new LinkedHashSet<>();
 
-        return readFrom.select(new ReadFrom.Nodes() {
+        for (RedisClusterNode upstream : connection.getPartitions()) {
+            if (upstream.is(RedisClusterNode.NodeFlag.UPSTREAM)) {
+                candidates.addAll(readFrom.select(slotGroup(connection, upstream)));
+            }
+        }
+
+        return candidates;
+    }
+
+    private static ReadFrom.Nodes slotGroup(StatefulRedisClusterConnection<?, ?> connection, RedisClusterNode upstream) {
+
+        List<RedisNodeDescription> nodes = new ArrayList<>();
+        nodes.add(upstream);
+
+        for (RedisClusterNode node : connection.getPartitions()) {
+            if (node.is(RedisClusterNode.NodeFlag.REPLICA) && upstream.getNodeId().equals(node.getSlaveOf())) {
+                nodes.add(node);
+            }
+        }
+
+        return new ReadFrom.Nodes() {
 
             @Override
             public List<RedisNodeDescription> getNodes() {
@@ -183,7 +210,7 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
                 return nodes.iterator();
             }
 
-        });
+        };
     }
 
     private static <K, V> void enableTracking(StatefulRedisClusterConnection<K, V> connection, RedisURI uri,

--- a/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
+++ b/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
@@ -164,11 +164,31 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
         // snapshot the mutable args so reconnect replay does not observe later modifications
         TrackingArgs trackingSnapshot = tracking.copy();
 
+        // clear cached entries when a tracked node connection reconnects: Redis dropped the tracking
+        // state with the old connection, so existing entries would no longer receive invalidations
+        Runnable clearAction = cacheAccessor::clear;
+
+        List<Runnable> rollbackActions = new ArrayList<>();
+
+        try {
+            enableClusterTracking(connection, trackingSnapshot, clearAction, rollbackActions);
+        } catch (RuntimeException e) {
+            // do not leave earlier nodes half-configured with tracking and reconnect listeners
+            rollback(rollbackActions);
+            throw e;
+        }
+
+        return create(cacheAccessor, connection);
+    }
+
+    private static <K, V> void enableClusterTracking(StatefulRedisClusterConnection<K, V> connection, TrackingArgs tracking,
+            Runnable clearAction, List<Runnable> rollbackActions) {
+
         for (RedisClusterNode node : connection.getPartitions()) {
             // use host/port connections: slot-routed commands are served by connections keyed
             // by intent, host and port, not by the nodeId-keyed connections
             if (isServingUpstream(node)) {
-                enableTracking(connection, node.getUri(), ConnectionIntent.WRITE, trackingSnapshot);
+                rollbackActions.add(enableTracking(connection, node.getUri(), ConnectionIntent.WRITE, tracking, clearAction));
             }
         }
 
@@ -176,7 +196,8 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
             // reads from upstream nodes are served by the write-intent connections tracked above
             if (node.getRole().isReplica()) {
                 try {
-                    enableTracking(connection, node.getUri(), ConnectionIntent.READ, trackingSnapshot);
+                    rollbackActions
+                            .add(enableTracking(connection, node.getUri(), ConnectionIntent.READ, tracking, clearAction));
                 } catch (RedisConnectionException e) {
                     // the read path tolerates unavailable replicas as long as another candidate connects,
                     // so an unreachable replica must not fail cache setup
@@ -185,8 +206,17 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
                 }
             }
         }
+    }
 
-        return create(cacheAccessor, connection);
+    private static void rollback(List<Runnable> rollbackActions) {
+
+        for (Runnable rollbackAction : rollbackActions) {
+            try {
+                rollbackAction.run();
+            } catch (RuntimeException e) {
+                LOG.warn("Cannot roll back key tracking", e);
+            }
+        }
     }
 
     private static Collection<RedisNodeDescription> readCandidates(StatefulRedisClusterConnection<?, ?> connection) {
@@ -252,8 +282,8 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
         };
     }
 
-    private static <K, V> void enableTracking(StatefulRedisClusterConnection<K, V> connection, RedisURI uri,
-            ConnectionIntent intent, TrackingArgs tracking) {
+    private static <K, V> Runnable enableTracking(StatefulRedisClusterConnection<K, V> connection, RedisURI uri,
+            ConnectionIntent intent, TrackingArgs tracking, Runnable clearAction) {
 
         StatefulRedisConnection<K, V> nodeConnection = connection.getConnection(uri.getHost(), uri.getPort(), intent);
         StatefulRedisConnectionImpl<K, V> nodeConnectionImpl = (StatefulRedisConnectionImpl<K, V>) nodeConnection;
@@ -265,14 +295,29 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
         nodeConnection.sync().clientTracking(tracking);
 
         // CLIENT TRACKING is connection state that the reconnect handshake does not restore, re-apply it
-        nodeConnectionImpl.addListener(new RedisConnectionStateListener() {
+        RedisConnectionStateListener trackingRestorer = new RedisConnectionStateListener() {
 
             @Override
             public void onRedisConnected(RedisChannelHandler<?, ?> connectionHandler, SocketAddress socketAddress) {
-                nodeConnection.async().clientTracking(tracking);
+
+                // Redis dropped the tracking state with the old connection: entries cached so far no
+                // longer receive invalidations and must be evicted
+                clearAction.run();
+
+                nodeConnection.async().clientTracking(tracking).exceptionally(e -> {
+                    LOG.warn("Cannot re-enable key tracking on {} after reconnect, reads from this node are not tracked", uri,
+                            e);
+                    return null;
+                });
             }
 
-        });
+        };
+        nodeConnectionImpl.addListener(trackingRestorer);
+
+        return () -> {
+            nodeConnectionImpl.removeListener(trackingRestorer);
+            nodeConnection.async().clientTracking(TrackingArgs.Builder.enabled(false));
+        };
     }
 
     /**

--- a/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
+++ b/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
@@ -148,7 +148,7 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
      * @param <K> Key type.
      * @param <V> Value type.
      * @return the {@link CacheFrontend} for value retrieval.
-     * @throws IllegalArgumentException if {@code tracking} is {@code null}, disabled, redirected or opt-in.
+     * @throws IllegalArgumentException if {@code tracking} is {@code null}, disabled, redirected, opt-in or prefix-limited.
      * @throws IllegalStateException if a node connection did not negotiate RESP3.
      * @since 7.7
      */
@@ -160,6 +160,9 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
         LettuceAssert.isTrue(!tracking.isRedirect(),
                 "TrackingArgs REDIRECT is not supported for Redis Cluster client-side caching");
         LettuceAssert.isTrue(!tracking.isOptin(), "TrackingArgs OPTIN is not supported for Redis Cluster client-side caching");
+        LettuceAssert.isTrue(!tracking.hasPrefixes(),
+                "TrackingArgs PREFIX is not supported for Redis Cluster client-side caching as the cache frontend caches "
+                        + "all keys regardless of prefix");
 
         // snapshot the mutable args so reconnect replay does not observe later modifications
         TrackingArgs trackingSnapshot = tracking.copy();
@@ -304,10 +307,15 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
                 // longer receive invalidations and must be evicted
                 clearAction.run();
 
-                nodeConnection.async().clientTracking(tracking).exceptionally(e -> {
-                    LOG.warn("Cannot re-enable key tracking on {} after reconnect, reads from this node are not tracked", uri,
-                            e);
-                    return null;
+                nodeConnection.async().clientTracking(tracking).whenComplete((result, e) -> {
+                    if (e != null) {
+                        LOG.warn("Cannot re-enable key tracking on {} after reconnect, reads from this node are not tracked",
+                                uri, e);
+                    } else {
+                        // commands buffered during the outage replay before this listener runs, so reads may
+                        // have populated the cache untracked; evict them now that tracking is restored
+                        clearAction.run();
+                    }
                 });
             }
 

--- a/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
+++ b/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
@@ -13,6 +13,9 @@ import io.lettuce.core.cluster.StatefulRedisClusterConnectionImpl;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
 import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.internal.LettuceAssert;
+import io.lettuce.core.protocol.ConnectionIntent;
+import io.lettuce.core.protocol.ProtocolVersion;
 
 /**
  * Utility to provide server-side assistance for client-side caches. This is a {@link CacheFrontend} that represents a two-level
@@ -101,13 +104,16 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
      * Enable server-assisted Client side caching for the given {@link CacheAccessor} and
      * {@link StatefulRedisClusterConnection}.
      * <p>
-     * {@code CLIENT TRACKING} is enabled on each upstream (master) node connection: invalidation messages for a key are emitted
-     * by the node that serves the key's slot, so tracking must be active there. Note that a keyless {@code CLIENT TRACKING}
-     * command issued through the cluster command API would be routed to the default connection only, whose push messages are
-     * not associated with cluster node connections.
+     * {@code CLIENT TRACKING} is enabled on each cluster node connection: invalidation messages for a key are emitted by the
+     * node that serves the key's slot (or, for replica reads, by the replica the value was read from), so tracking must be
+     * active there. Upstream (master) nodes are tracked through their write-intent connections and replicas through their
+     * read-intent connections so that reads routed by {@link io.lettuce.core.ReadFrom} settings are registered for tracking as
+     * well. Note that a keyless {@code CLIENT TRACKING} command issued through the cluster command API would be routed to the
+     * default connection only, whose push messages are not associated with cluster node connections.
      * <p>
-     * Client-side caching for Redis Cluster requires RESP3 ({@code TrackingArgs} redirection is not supported as invalidation
-     * messages can originate from any node).
+     * Client-side caching for Redis Cluster requires RESP3. {@code TrackingArgs} redirection is not supported as invalidation
+     * messages can originate from any node; this method throws {@link IllegalArgumentException} for redirected tracking
+     * parameters and {@link IllegalStateException} if a node connection did not negotiate RESP3.
      * <p>
      * Nodes added to the cluster after this call do not have tracking enabled. Applications that must observe topology changes
      * should re-enable tracking after a topology refresh.
@@ -127,16 +133,34 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
     public static <K, V> CacheFrontend<K, V> enable(CacheAccessor<K, V> cacheAccessor,
             StatefulRedisClusterConnection<K, V> connection, TrackingArgs tracking) {
 
+        LettuceAssert.isTrue(!tracking.isRedirect(),
+                "TrackingArgs REDIRECT is not supported for Redis Cluster client-side caching");
+
         for (RedisClusterNode node : connection.getPartitions()) {
+            // use host/port connections: slot-routed commands are served by connections keyed
+            // by intent, host and port, not by the nodeId-keyed connections
             if (node.is(RedisClusterNode.NodeFlag.UPSTREAM)) {
-                // use the host/port connection: slot-routed commands are served by connections keyed
-                // by host and port, not by the nodeId-keyed connections
-                RedisURI uri = node.getUri();
-                connection.getConnection(uri.getHost(), uri.getPort()).sync().clientTracking(tracking);
+                enableTracking(connection, node, ConnectionIntent.WRITE, tracking);
+            } else if (node.is(RedisClusterNode.NodeFlag.REPLICA)) {
+                enableTracking(connection, node, ConnectionIntent.READ, tracking);
             }
         }
 
         return create(cacheAccessor, connection);
+    }
+
+    private static <K, V> void enableTracking(StatefulRedisClusterConnection<K, V> connection, RedisClusterNode node,
+            ConnectionIntent intent, TrackingArgs tracking) {
+
+        RedisURI uri = node.getUri();
+        StatefulRedisConnection<K, V> nodeConnection = connection.getConnection(uri.getHost(), uri.getPort(), intent);
+
+        ProtocolVersion protocolVersion = ((StatefulRedisConnectionImpl<K, V>) nodeConnection).getConnectionState()
+                .getNegotiatedProtocolVersion();
+        LettuceAssert.assertState(protocolVersion == ProtocolVersion.RESP3,
+                "Client-side caching for Redis Cluster requires RESP3");
+
+        nodeConnection.sync().clientTracking(tracking);
     }
 
     /**
@@ -170,6 +194,7 @@ public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
         ClientSideCaching<K, V> caching = new ClientSideCaching<>(cacheAccessor, redisCache);
 
         redisCache.addInvalidationListener(caching::notifyInvalidate);
+        redisCache.addClearListener(cacheAccessor::clear);
         caching.addInvalidationListener(cacheAccessor::evict);
 
         return caching;

--- a/src/main/java/io/lettuce/core/support/caching/ClusterRedisCache.java
+++ b/src/main/java/io/lettuce/core/support/caching/ClusterRedisCache.java
@@ -1,0 +1,56 @@
+package io.lettuce.core.support.caching;
+
+import java.util.List;
+
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.codec.RedisCodec;
+
+/**
+ * {@link RedisCache} implementation for Redis Cluster using {@code GET} and {@code SET} operations to map cache values to
+ * top-level keys. Invalidation messages are consumed from all cluster node connections through the cluster push listener.
+ *
+ * @param <K> Key type.
+ * @param <V> Value type.
+ * @author Julien Ruaux
+ * @since 7.7
+ */
+class ClusterRedisCache<K, V> implements RedisCache<K, V> {
+
+    private final StatefulRedisClusterConnection<K, V> connection;
+
+    private final RedisCodec<K, V> codec;
+
+    public ClusterRedisCache(StatefulRedisClusterConnection<K, V> connection, RedisCodec<K, V> codec) {
+        this.connection = connection;
+        this.codec = codec;
+    }
+
+    @Override
+    public V get(K key) {
+        return connection.sync().get(key);
+    }
+
+    @Override
+    public void put(K key, V value) {
+        connection.sync().set(key, value);
+    }
+
+    @Override
+    public void addInvalidationListener(java.util.function.Consumer<? super K> listener) {
+
+        connection.addListener((node, message) -> {
+            if (message.getType().equals("invalidate")) {
+
+                List<Object> content = message.getContent(codec::decodeKey);
+                List<K> keys = (List<K>) content.get(1);
+                keys.forEach(listener);
+            }
+        });
+    }
+
+    @Override
+    public void close() {
+        connection.close();
+    }
+
+}

--- a/src/main/java/io/lettuce/core/support/caching/ClusterRedisCache.java
+++ b/src/main/java/io/lettuce/core/support/caching/ClusterRedisCache.java
@@ -1,6 +1,7 @@
 package io.lettuce.core.support.caching;
 
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.codec.RedisCodec;
@@ -19,6 +20,8 @@ class ClusterRedisCache<K, V> implements RedisCache<K, V> {
     private final StatefulRedisClusterConnection<K, V> connection;
 
     private final RedisCodec<K, V> codec;
+
+    private final List<Runnable> clearListeners = new CopyOnWriteArrayList<>();
 
     public ClusterRedisCache(StatefulRedisClusterConnection<K, V> connection, RedisCodec<K, V> codec) {
         this.connection = connection;
@@ -43,9 +46,20 @@ class ClusterRedisCache<K, V> implements RedisCache<K, V> {
 
                 List<Object> content = message.getContent(codec::decodeKey);
                 List<K> keys = (List<K>) content.get(1);
-                keys.forEach(listener);
+
+                if (keys == null) {
+                    // null payload indicates a full invalidation, e.g. after FLUSHALL/FLUSHDB
+                    clearListeners.forEach(Runnable::run);
+                } else {
+                    keys.forEach(listener);
+                }
             }
         });
+    }
+
+    @Override
+    public void addClearListener(Runnable listener) {
+        clearListeners.add(listener);
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/support/caching/ClusterRedisCache.java
+++ b/src/main/java/io/lettuce/core/support/caching/ClusterRedisCache.java
@@ -1,7 +1,9 @@
 package io.lettuce.core.support.caching;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
 
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.codec.RedisCodec;
@@ -39,19 +41,20 @@ class ClusterRedisCache<K, V> implements RedisCache<K, V> {
     }
 
     @Override
-    public void addInvalidationListener(java.util.function.Consumer<? super K> listener) {
+    public void addInvalidationListener(Consumer<? super K> listener) {
 
         connection.addListener((node, message) -> {
             if (message.getType().equals("invalidate")) {
 
-                List<Object> content = message.getContent(codec::decodeKey);
-                List<K> keys = (List<K>) content.get(1);
+                // decode only the key payload, the frame type element is not a key
+                List<Object> content = message.getContent();
+                List<Object> keys = (List<Object>) content.get(1);
 
                 if (keys == null) {
                     // null payload indicates a full invalidation, e.g. after FLUSHALL/FLUSHDB
                     clearListeners.forEach(Runnable::run);
                 } else {
-                    keys.forEach(listener);
+                    keys.forEach(key -> listener.accept(codec.decodeKey((ByteBuffer) key)));
                 }
             }
         });

--- a/src/main/java/io/lettuce/core/support/caching/ClusterRedisCache.java
+++ b/src/main/java/io/lettuce/core/support/caching/ClusterRedisCache.java
@@ -54,7 +54,14 @@ class ClusterRedisCache<K, V> implements RedisCache<K, V> {
                     // null payload indicates a full invalidation, e.g. after FLUSHALL/FLUSHDB
                     clearListeners.forEach(Runnable::run);
                 } else {
-                    keys.forEach(key -> listener.accept(codec.decodeKey((ByteBuffer) key)));
+                    for (Object key : keys) {
+                        if (key == null) {
+                            clearListeners.forEach(Runnable::run);
+                        } else {
+                            // decode from a duplicate so shared buffers are not consumed for other listeners
+                            listener.accept(codec.decodeKey(((ByteBuffer) key).duplicate()));
+                        }
+                    }
                 }
             }
         });

--- a/src/main/java/io/lettuce/core/support/caching/DefaultRedisCache.java
+++ b/src/main/java/io/lettuce/core/support/caching/DefaultRedisCache.java
@@ -1,6 +1,9 @@
 package io.lettuce.core.support.caching;
 
+import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
 
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.codec.RedisCodec;
@@ -16,6 +19,8 @@ class DefaultRedisCache<K, V> implements RedisCache<K, V> {
     private final StatefulRedisConnection<K, V> connection;
 
     private final RedisCodec<K, V> codec;
+
+    private final List<Runnable> clearListeners = new CopyOnWriteArrayList<>();
 
     public DefaultRedisCache(StatefulRedisConnection<K, V> connection, RedisCodec<K, V> codec) {
         this.connection = connection;
@@ -33,16 +38,35 @@ class DefaultRedisCache<K, V> implements RedisCache<K, V> {
     }
 
     @Override
-    public void addInvalidationListener(java.util.function.Consumer<? super K> listener) {
+    public void addInvalidationListener(Consumer<? super K> listener) {
 
         connection.addListener(message -> {
             if (message.getType().equals("invalidate")) {
 
-                List<Object> content = message.getContent(codec::decodeKey);
-                List<K> keys = (List<K>) content.get(1);
-                keys.forEach(listener);
+                // decode only the key payload, the frame type element is not a key
+                List<Object> content = message.getContent();
+                List<Object> keys = (List<Object>) content.get(1);
+
+                if (keys == null) {
+                    // null payload indicates a full invalidation, e.g. after FLUSHALL/FLUSHDB
+                    clearListeners.forEach(Runnable::run);
+                } else {
+                    for (Object key : keys) {
+                        if (key == null) {
+                            clearListeners.forEach(Runnable::run);
+                        } else {
+                            // decode from a duplicate so shared buffers are not consumed for other listeners
+                            listener.accept(codec.decodeKey(((ByteBuffer) key).duplicate()));
+                        }
+                    }
+                }
             }
         });
+    }
+
+    @Override
+    public void addClearListener(Runnable listener) {
+        clearListeners.add(listener);
     }
 
     @Override

--- a/src/main/java/io/lettuce/core/support/caching/MapCacheAccessor.java
+++ b/src/main/java/io/lettuce/core/support/caching/MapCacheAccessor.java
@@ -33,4 +33,9 @@ class MapCacheAccessor<K, V> implements CacheAccessor<K, V> {
         map.remove(key);
     }
 
+    @Override
+    public void clear() {
+        map.clear();
+    }
+
 }

--- a/src/main/java/io/lettuce/core/support/caching/RedisCache.java
+++ b/src/main/java/io/lettuce/core/support/caching/RedisCache.java
@@ -35,6 +35,16 @@ public interface RedisCache<K, V> {
     void addInvalidationListener(java.util.function.Consumer<? super K> listener);
 
     /**
+     * Register a {@code listener} that is notified if Redis reports a full invalidation of the cache, for example after
+     * {@code FLUSHALL} or {@code FLUSHDB}. The default implementation does not notify the listener.
+     *
+     * @param listener the listener to notify.
+     * @since 7.7
+     */
+    default void addClearListener(Runnable listener) {
+    }
+
+    /**
      * Closes this Redis cache and releases any connections associated with it. If the cache is already closed then invoking
      * this method has no effect.
      */

--- a/src/test/java/io/lettuce/core/support/caching/ClientsideCachingIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/support/caching/ClientsideCachingIntegrationTests.java
@@ -165,6 +165,32 @@ public class ClientsideCachingIntegrationTests extends TestSupport {
     }
 
     @Test
+    void serverAssistedCachingShouldClearOnFlush() {
+
+        Map<String, String> clientCache = new ConcurrentHashMap<>();
+
+        StatefulRedisConnection<String, String> otherParty = redisClient.connect();
+        RedisCommands<String, String> commands = otherParty.sync();
+
+        commands.set(key, value);
+
+        StatefulRedisConnection<String, String> connection = redisClient.connect();
+        CacheFrontend<String, String> frontend = ClientSideCaching.enable(CacheAccessor.forMap(clientCache), connection,
+                TrackingArgs.Builder.enabled());
+
+        assertThat(frontend.get(key)).isEqualTo(value);
+        assertThat(clientCache).hasSize(1);
+
+        commands.flushall();
+
+        Wait.untilTrue(clientCache::isEmpty).waitOrTimeout();
+        assertThat(frontend.get(key)).isNull();
+
+        otherParty.close();
+        frontend.close();
+    }
+
+    @Test
     void serverAssistedCachingShouldExpireValueFromRedis() throws InterruptedException {
 
         Map<String, String> clientCache = new ConcurrentHashMap<>();

--- a/src/test/java/io/lettuce/core/support/caching/ClusterClientsideCachingIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/support/caching/ClusterClientsideCachingIntegrationTests.java
@@ -104,6 +104,32 @@ public class ClusterClientsideCachingIntegrationTests {
         frontend.close();
     }
 
+    @Test
+    void serverAssistedCachingShouldClearOnFlush() {
+
+        Map<String, String> clientCache = new ConcurrentHashMap<>();
+
+        StatefulRedisClusterConnection<String, String> otherParty = clusterClient.connect();
+        StatefulRedisClusterConnection<String, String> connection = clusterClient.connect();
+
+        CacheFrontend<String, String> frontend = ClientSideCaching.enable(CacheAccessor.forMap(clientCache), connection,
+                TrackingArgs.Builder.enabled());
+
+        String key = "key";
+        otherParty.sync().set(key, "value");
+
+        assertThat(frontend.get(key)).isEqualTo("value");
+        assertThat(clientCache).hasSize(1);
+
+        otherParty.sync().flushall();
+
+        Wait.untilTrue(clientCache::isEmpty).waitOrTimeout();
+        assertThat(frontend.get(key)).isNull();
+
+        otherParty.close();
+        frontend.close();
+    }
+
     private static String keyOwnedBy(StatefulRedisClusterConnection<String, String> connection, RedisClusterNode node) {
 
         return IntStream.range(0, SlotHash.SLOT_COUNT).mapToObj(i -> "key-" + i)

--- a/src/test/java/io/lettuce/core/support/caching/ClusterClientsideCachingIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/support/caching/ClusterClientsideCachingIntegrationTests.java
@@ -1,0 +1,114 @@
+package io.lettuce.core.support.caching;
+
+import static io.lettuce.TestTags.INTEGRATION_TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.IntStream;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.lettuce.core.TrackingArgs;
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.SlotHash;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
+import io.lettuce.test.LettuceExtension;
+import io.lettuce.test.Wait;
+import io.lettuce.test.condition.EnabledOnCommand;
+
+/**
+ * Integration tests for server-side assisted cache invalidation using Redis Cluster.
+ *
+ * @author Julien Ruaux
+ */
+@Tag(INTEGRATION_TEST)
+@ExtendWith(LettuceExtension.class)
+@EnabledOnCommand("ACL")
+public class ClusterClientsideCachingIntegrationTests {
+
+    private final RedisClusterClient clusterClient;
+
+    @Inject
+    public ClusterClientsideCachingIntegrationTests(RedisClusterClient clusterClient) {
+        this.clusterClient = clusterClient;
+    }
+
+    @BeforeEach
+    void setUp() {
+
+        try (StatefulRedisClusterConnection<String, String> connection = clusterClient.connect()) {
+            connection.sync().flushall();
+        }
+    }
+
+    @Test
+    void serverAssistedCachingShouldUseClientCache() {
+
+        Map<String, String> clientCache = new ConcurrentHashMap<>();
+
+        StatefulRedisClusterConnection<String, String> otherParty = clusterClient.connect();
+        StatefulRedisClusterConnection<String, String> connection = clusterClient.connect();
+
+        CacheFrontend<String, String> frontend = ClientSideCaching.enable(CacheAccessor.forMap(clientCache), connection,
+                TrackingArgs.Builder.enabled());
+
+        String key = "key";
+        otherParty.sync().set(key, "value");
+
+        assertThat(frontend.get(key)).isEqualTo("value");
+        assertThat(clientCache).hasSize(1);
+
+        otherParty.close();
+        frontend.close();
+    }
+
+    @Test
+    void serverAssistedCachingShouldInvalidateAcrossAllNodes() {
+
+        Map<String, String> clientCache = new ConcurrentHashMap<>();
+
+        StatefulRedisClusterConnection<String, String> otherParty = clusterClient.connect();
+        StatefulRedisClusterConnection<String, String> connection = clusterClient.connect();
+
+        CacheFrontend<String, String> frontend = ClientSideCaching.enable(CacheAccessor.forMap(clientCache), connection,
+                TrackingArgs.Builder.enabled());
+
+        // Invalidation messages are emitted by the node serving a key's slot, so exercise a key on
+        // each upstream node.
+        for (RedisClusterNode node : connection.getPartitions()) {
+
+            if (!node.is(RedisClusterNode.NodeFlag.UPSTREAM)) {
+                continue;
+            }
+
+            String key = keyOwnedBy(connection, node);
+
+            otherParty.sync().set(key, "value");
+            assertThat(frontend.get(key)).isEqualTo("value");
+            assertThat(clientCache).containsKey(key);
+
+            otherParty.sync().set(key, "changed");
+
+            Wait.untilTrue(() -> !clientCache.containsKey(key)).waitOrTimeout();
+            assertThat(frontend.get(key)).isEqualTo("changed");
+        }
+
+        otherParty.close();
+        frontend.close();
+    }
+
+    private static String keyOwnedBy(StatefulRedisClusterConnection<String, String> connection, RedisClusterNode node) {
+
+        return IntStream.range(0, SlotHash.SLOT_COUNT).mapToObj(i -> "key-" + i)
+                .filter(key -> node.hasSlot(SlotHash.getSlot(key))).findFirst()
+                .orElseThrow(() -> new IllegalStateException("No key found for node " + node.getNodeId()));
+    }
+
+}


### PR DESCRIPTION
This PR addresses #1380 (Support client-side caching in Redis Cluster mode): it adds server-assisted client-side caching support for Redis Cluster connections. `ClientSideCaching` gains cluster-aware `enable(...)` and `create(...)` factory methods that turn on `CLIENT TRACKING` on each upstream node connection (invalidations originate from the node serving a key's slot), backed by a new `ClusterRedisCache` implementation and a `ClusterClientsideCachingIntegrationTests` integration test suite. Requires RESP3; redirection mode is not supported for cluster.

Closes #1380

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request. (#1380)
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cache invalidation and cluster connection tracking, where bugs can serve stale data. Additive feature with integration tests, but reconnect/topology edge cases are subtle.
> 
> **Overview**
> Adds **server-assisted client-side caching for Redis Cluster** via new `ClientSideCaching.enable/create` overloads that turn on `CLIENT TRACKING` on each relevant node connection (upstream write-intent, plus replica read-intent when `ReadFrom` can select them).
> 
> Introduces `ClusterRedisCache` to consume invalidate push messages across cluster nodes. Also adds full-cache clear support for `FLUSHALL`/`FLUSHDB` (`CacheAccessor.clear()`, `RedisCache.addClearListener`) and reconnect handling that re-applies tracking and clears stale entries. Cluster mode requires RESP3 and rejects `REDIRECT`, `OPTIN`, and prefix-limited `BCAST`.
> 
> Includes user-guide docs and cluster/standalone integration tests covering per-node invalidation and flush clears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3828fa464dec2824f2dbf82ce53973c6f7eb970. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->