### PR TITLE
Declare partitions and readFrom volatile in PooledClusterConnectionProvider

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/PooledClusterConnectionProvider.java
+++ b/src/main/java/io/lettuce/core/cluster/PooledClusterConnectionProvider.java
@@ -98,11 +98,11 @@ class PooledClusterConnectionProvider<K, V>
 
     private final AsyncConnectionProvider<ConnectionKey, StatefulRedisConnection<K, V>, ConnectionFuture<StatefulRedisConnection<K, V>>> connectionProvider;
 
-    private Partitions partitions;
+    private volatile Partitions partitions;
 
     private boolean autoFlushCommands = true;
 
-    private ReadFrom readFrom;
+    private volatile ReadFrom readFrom;
 
     public PooledClusterConnectionProvider(RedisClusterClient redisClusterClient, RedisChannelWriter clusterWriter,
             RedisCodec<K, V> redisCodec, ClusterEventListener clusterEventListener) {


### PR DESCRIPTION
## Summary

- Mark `partitions` and `readFrom` as `volatile` in `PooledClusterConnectionProvider`
- Aligns with `ClusterDistributionChannelWriter`, `StatefulRedisClusterConnectionImpl`, and other cluster types that already use `volatile Partitions`
- Ensures unsynchronized readers observe the latest published topology/`ReadFrom`, matching the documented intent of `stateLock`-guarded writes

Fixes #3777

## Test plan

- [x] `mvn test -Dtest=PooledClusterConnectionProviderUnitTests` (unit scope, no Redis)
- [x] Existing tests cover `setPartitions` / `setReadFrom` read paths via connection selection