### PR TITLE
Mark partitions and readFrom volatile

### DIFF
--- a/src/main/java/io/lettuce/core/cluster/PooledClusterConnectionProvider.java
+++ b/src/main/java/io/lettuce/core/cluster/PooledClusterConnectionProvider.java
@@ -98,11 +98,11 @@ class PooledClusterConnectionProvider<K, V>
 
     private final AsyncConnectionProvider<ConnectionKey, StatefulRedisConnection<K, V>, ConnectionFuture<StatefulRedisConnection<K, V>>> connectionProvider;
 
-    private Partitions partitions;
+    private volatile Partitions partitions;
 
     private boolean autoFlushCommands = true;
 
-    private ReadFrom readFrom;
+    private volatile ReadFrom readFrom;
 
     public PooledClusterConnectionProvider(RedisClusterClient redisClusterClient, RedisChannelWriter clusterWriter,
             RedisCodec<K, V> redisCodec, ClusterEventListener clusterEventListener) {


### PR DESCRIPTION
Writers take stateLock. Readers do not. A lock only publishes to a later lock of the same lock, so the documented happens-before never reaches getPartitions / getReadFrom.

volatile on the two fields matches the javadoc. Writes still use the lock for the compound update.

Fixes #3777

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot-path cluster routing and read-replica selection; the change is small and standard for cross-thread visibility but incorrect reads could previously misroute commands.
> 
> **Overview**
> Fixes a **memory visibility** bug in `PooledClusterConnectionProvider` by declaring **`partitions`** and **`readFrom`** as **`volatile`**.
> 
> Updates to those fields still run under **`stateLock`** (including clearing reader caches when **`readFrom`** changes), but many connection paths read them **without** acquiring the lock. A lock only establishes happens-before between threads that use that same lock, so readers were not guaranteed to see fresh cluster topology or read preference after **`setPartitions`** / **`setReadFrom`**. **`volatile`** gives readers a proper publish/subscribe edge and aligns behavior with the existing javadoc about cross-thread visibility.
> 
> Addresses #3777.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39da985ae2e781f20d9725604d3c230f291354e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->