### PR TITLE
Relax timeouts on MOVING rebind without buffered commands

### DIFF
--- a/src/main/java/io/lettuce/core/protocol/MaintenanceAwareConnectionWatchdog.java
+++ b/src/main/java/io/lettuce/core/protocol/MaintenanceAwareConnectionWatchdog.java
@@ -154,15 +154,26 @@ public class MaintenanceAwareConnectionWatchdog extends ConnectionWatchdog imple
         channel.attr(REBIND_ATTRIBUTE).set(RebindState.STARTED);
         rebindAwareAddressSupplier.rebind(movingEvent.getTime(), movingEvent.getEndpoint());
 
+        // Relax the timeouts for the whole re-bind window, not only while commands are still in flight. While the
+        // re-bind is in progress the endpoint reports itself as disconnected (see DefaultEndpoint#isConnected), so
+        // every command issued after the MOVING notification is buffered until the connection to the new endpoint has
+        // been established. Those commands need the relaxed timeout just as much as the ones already on the wire.
+        notifyRebindStarted(movingEvent.getTime(), movingEvent.getEndpoint());
+
         ChannelPipeline pipeline = channel.pipeline();
         CommandHandler commandHandler = pipeline.get(CommandHandler.class);
         if (commandHandler.getStack().isEmpty()) {
             logger.debug("[{}] Closing channel as part of rebind", ChannelLogDescriptor.logDescriptor(channel));
             channel.close().awaitUninterruptibly();
             channel.attr(REBIND_ATTRIBUTE).set(RebindState.COMPLETED);
-        } else {
-            notifyRebindStarted(movingEvent.getTime(), movingEvent.getEndpoint());
+
+            // The channel is closed already, so channelReadComplete() is not going to fire for it again and cannot
+            // report the completion. Report it here, which lifts the relaxed timeouts after the grace period.
+            notifyRebindCompleted();
         }
+
+        // Otherwise CommandHandler#decode flips the state to COMPLETED once the stack has been drained and
+        // channelReadComplete() closes the channel and reports the completion of the re-bind.
     }
 
     private String getMigratingShards(PushMessage message) {

--- a/src/test/java/io/lettuce/core/protocol/MaintenanceAwareConnectionWatchdogUnitTests.java
+++ b/src/test/java/io/lettuce/core/protocol/MaintenanceAwareConnectionWatchdogUnitTests.java
@@ -247,7 +247,11 @@ class MaintenanceAwareConnectionWatchdogUnitTests {
         verify(rebindAwareAddressSupplier).rebind(eq(Duration.ofSeconds(15)), eq(new InetSocketAddress("127.0.0.1", 6380)));
         verify(channel).close();
         verify(rebindAttribute).set(RebindState.COMPLETED);
-        verify(component1, never()).onRebindStarted(any(), any()); // Not called when stack is empty
+        // Commands issued after the MOVING notification are buffered until the new connection is up, so the timeouts
+        // have to be relaxed for the re-bind window even when nothing was in flight when the notification arrived.
+        verify(component1).onRebindStarted(eq(Duration.ofSeconds(15)), eq(new InetSocketAddress("127.0.0.1", 6380)));
+        // The channel is closed here, so this is the only place that can report the completion of the re-bind.
+        verify(component1).onRebindCompleted();
     }
 
     @Test
@@ -275,6 +279,8 @@ class MaintenanceAwareConnectionWatchdogUnitTests {
         verify(rebindAttribute).set(RebindState.STARTED);
         verify(channel, never()).close();
         verify(component1).onRebindStarted(any(), any()); // Called when stack is not empty
+        // The stack still has to be drained, channelReadComplete() reports the completion later on.
+        verify(component1, never()).onRebindCompleted();
     }
 
     @Test
@@ -643,6 +649,8 @@ class MaintenanceAwareConnectionWatchdogUnitTests {
         verify(rebindAttribute).set(RebindState.STARTED);
         verify(channel, never()).close();
         verify(component1).onRebindStarted(any(), any()); // Called when stack is not empty
+        // The stack still has to be drained, channelReadComplete() reports the completion later on.
+        verify(component1, never()).onRebindCompleted();
     }
 
     /**


### PR DESCRIPTION
# Relax timeouts on MOVING rebind without buffered commands

## Summary
`MaintenanceAwareConnectionWatchdog` only notified `onRebindStarted` when a command was in flight at the moment the MOVING push arrived. On an idle connection the relaxed-timeout window was never opened, so commands issued during the ~rebind window timed out with the normal (unrelaxed) timeout. This surfaced as the recurring `RelaxedTimeoutConfigurationTest.timeoutUnrelaxedOnMovingTest` scenario failure. Rebind-started is now reported for every MOVING notification, regardless of the command stack.

## Description
- Commands issued after the MOVING notification are buffered until the new connection is up, so timeouts must be relaxed for the whole rebind window even when nothing was in flight when the push arrived.
- In the empty-stack path the channel is closed immediately and `channelReadComplete()` never fires again, so `onRebindCompleted` is reported inline there; the non-empty path keeps reporting completion from `channelReadComplete()` once the stack drains.

## Changes
- `onRebindStarted` now fires on every MOVING rebind, not only when the command stack is non-empty.
- The empty-stack path now also reports `onRebindCompleted`, so relaxed timeouts are lifted after the grace period instead of never being opened/closed.

## Testing
`MaintenanceAwareConnectionWatchdogUnitTests` updated: the empty-stack test previously asserted `onRebindStarted` was *not* called — that expectation encoded the bug and now asserts both started and completed notifications; the non-empty-stack tests additionally verify completion is deferred until the stack drains. The scenario test `RelaxedTimeoutConfigurationTest#timeoutUnrelaxedOnMovingTest` reproduces the bug end-to-end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches maintenance/MOVING rebind lifecycle and command timeout behavior during cluster endpoint moves; scope is narrow but affects timing-sensitive client paths.
> 
> **Overview**
> **MOVING** rebind handling in `MaintenanceAwareConnectionWatchdog` now always opens the relaxed-timeout window, including when the connection is idle and no commands were in flight when the push arrived.
> 
> `notifyRebindStarted` runs for every rebind (not only when the command stack is non-empty), so commands buffered while the endpoint is disconnected during rebind get the same relaxed timeouts as in-flight work. On the **empty-stack** path the channel closes immediately and `channelReadComplete()` never runs again, so **`onRebindCompleted`** is invoked there to end the relaxed window after the grace period; the non-empty path still completes via `channelReadComplete()` after the stack drains.
> 
> Unit tests were updated to match: the idle-connection case now expects both started and completed notifications, and non-empty-stack cases assert completion is not reported until later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8132ccc3e9a1d4d828c12222f74a062344ed40e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->