### PR TITLE
Deprecate legacy client-side caching support

### DIFF
--- a/docs/new-features.md
+++ b/docs/new-features.md
@@ -1,6 +1,10 @@
 # New & Noteworthy
 
 
+## What's new in Lettuce 7.8
+
+- Deprecated the server-assisted client-side caching support (`ClientSideCaching`, `CacheFrontend`, `CacheAccessor`, `RedisCache` in `io.lettuce.core.support.caching`). This implementation is legacy and incomplete and is scheduled for removal in a future major release. There is no replacement yet — a redesigned client-side caching API is planned.
+
 ## What's new in Lettuce 7.7
 
 - [Probabilistic data structures (RedisBloom)](user-guide/probabilistic.md) support through `RedisBloomFilterCommands`, `RedisCuckooFilterCommands`, `RedisTopKCommands`, `RedisCMSCommands` and `RedisTDigestCommands`, with the respective async, reactive and Kotlin APIs — covering Bloom Filter (`BF.*`), Cuckoo Filter (`CF.*`), Top-K, Count-Min Sketch and T-Digest

--- a/src/main/java/io/lettuce/core/support/caching/CacheAccessor.java
+++ b/src/main/java/io/lettuce/core/support/caching/CacheAccessor.java
@@ -10,7 +10,7 @@ import java.util.Map;
  * @param <V> Value type.
  * @author Mark Paluch
  * @since 6.0
- * @deprecated since 7.8. Part of the legacy and incomplete client-side caching implementation; no replacement type is available
+ * @deprecated since 7.8, part of the legacy and incomplete client-side caching implementation; no replacement type is available
  *             yet, a redesigned client-side caching API is planned. Scheduled for removal in a future major release.
  */
 @Deprecated

--- a/src/main/java/io/lettuce/core/support/caching/CacheAccessor.java
+++ b/src/main/java/io/lettuce/core/support/caching/CacheAccessor.java
@@ -10,7 +10,10 @@ import java.util.Map;
  * @param <V> Value type.
  * @author Mark Paluch
  * @since 6.0
+ * @deprecated since 7.8. Part of the legacy and incomplete client-side caching implementation; no replacement type is available
+ *             yet, a redesigned client-side caching API is planned. Scheduled for removal in a future major release.
  */
+@Deprecated
 public interface CacheAccessor<K, V> {
 
     /**

--- a/src/main/java/io/lettuce/core/support/caching/CacheFrontend.java
+++ b/src/main/java/io/lettuce/core/support/caching/CacheFrontend.java
@@ -12,7 +12,10 @@ import io.lettuce.core.RedisException;
  * @param <V> Value type.
  * @author Mark Paluch
  * @since 6.0
+ * @deprecated since 7.8. Part of the legacy and incomplete client-side caching implementation; no replacement type is available
+ *             yet, a redesigned client-side caching API is planned. Scheduled for removal in a future major release.
  */
+@Deprecated
 public interface CacheFrontend<K, V> extends Closeable {
 
     /**

--- a/src/main/java/io/lettuce/core/support/caching/CacheFrontend.java
+++ b/src/main/java/io/lettuce/core/support/caching/CacheFrontend.java
@@ -12,7 +12,7 @@ import io.lettuce.core.RedisException;
  * @param <V> Value type.
  * @author Mark Paluch
  * @since 6.0
- * @deprecated since 7.8. Part of the legacy and incomplete client-side caching implementation; no replacement type is available
+ * @deprecated since 7.8, part of the legacy and incomplete client-side caching implementation; no replacement type is available
  *             yet, a redesigned client-side caching API is planned. Scheduled for removal in a future major release.
  */
 @Deprecated

--- a/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
+++ b/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
@@ -32,7 +32,10 @@ import io.lettuce.core.codec.RedisCodec;
  * @param <V> Value type.
  * @author Mark Paluch
  * @since 6.0
+ * @deprecated since 7.8. This client-side caching implementation is legacy and incomplete; no replacement type is available
+ *             yet, a redesigned client-side caching API is planned. Scheduled for removal in a future major release.
  */
+@Deprecated
 public class ClientSideCaching<K, V> implements CacheFrontend<K, V> {
 
     private final CacheAccessor<K, V> cacheAccessor;

--- a/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
+++ b/src/main/java/io/lettuce/core/support/caching/ClientSideCaching.java
@@ -32,7 +32,7 @@ import io.lettuce.core.codec.RedisCodec;
  * @param <V> Value type.
  * @author Mark Paluch
  * @since 6.0
- * @deprecated since 7.8. This client-side caching implementation is legacy and incomplete; no replacement type is available
+ * @deprecated since 7.8, this client-side caching implementation is legacy and incomplete; no replacement type is available
  *             yet, a redesigned client-side caching API is planned. Scheduled for removal in a future major release.
  */
 @Deprecated

--- a/src/main/java/io/lettuce/core/support/caching/DefaultRedisCache.java
+++ b/src/main/java/io/lettuce/core/support/caching/DefaultRedisCache.java
@@ -10,7 +10,9 @@ import io.lettuce.core.codec.RedisCodec;
  *
  * @param <K> Key type.
  * @param <V> Value type.
+ * @deprecated since 7.8, along with {@link RedisCache}; scheduled for removal in a future major release.
  */
+@Deprecated
 class DefaultRedisCache<K, V> implements RedisCache<K, V> {
 
     private final StatefulRedisConnection<K, V> connection;

--- a/src/main/java/io/lettuce/core/support/caching/MapCacheAccessor.java
+++ b/src/main/java/io/lettuce/core/support/caching/MapCacheAccessor.java
@@ -9,7 +9,9 @@ import java.util.Map;
  * @param <V> Value type.
  * @author Mark Paluch
  * @since 6.0
+ * @deprecated since 7.8, along with {@link CacheAccessor}; scheduled for removal in a future major release.
  */
+@Deprecated
 class MapCacheAccessor<K, V> implements CacheAccessor<K, V> {
 
     private final Map<K, V> map;

--- a/src/main/java/io/lettuce/core/support/caching/RedisCache.java
+++ b/src/main/java/io/lettuce/core/support/caching/RedisCache.java
@@ -7,7 +7,10 @@ package io.lettuce.core.support.caching;
  * @param <V> Value type.
  * @author Mark Paluch
  * @since 6.0
+ * @deprecated since 7.8. Part of the legacy and incomplete client-side caching implementation; no replacement type is available
+ *             yet, a redesigned client-side caching API is planned. Scheduled for removal in a future major release.
  */
+@Deprecated
 public interface RedisCache<K, V> {
 
     /**

--- a/src/main/java/io/lettuce/core/support/caching/RedisCache.java
+++ b/src/main/java/io/lettuce/core/support/caching/RedisCache.java
@@ -7,7 +7,7 @@ package io.lettuce.core.support.caching;
  * @param <V> Value type.
  * @author Mark Paluch
  * @since 6.0
- * @deprecated since 7.8. Part of the legacy and incomplete client-side caching implementation; no replacement type is available
+ * @deprecated since 7.8, part of the legacy and incomplete client-side caching implementation; no replacement type is available
  *             yet, a redesigned client-side caching API is planned. Scheduled for removal in a future major release.
  */
 @Deprecated

--- a/src/test/java/io/lettuce/core/support/caching/ClientsideCachingIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/support/caching/ClientsideCachingIntegrationTests.java
@@ -38,6 +38,7 @@ import io.lettuce.test.condition.EnabledOnCommand;
 @Tag(INTEGRATION_TEST)
 @ExtendWith(LettuceExtension.class)
 @EnabledOnCommand("ACL")
+@SuppressWarnings("deprecation")
 public class ClientsideCachingIntegrationTests extends TestSupport {
 
     private final RedisClient redisClient;


### PR DESCRIPTION
## Summary
Marks the `io.lettuce.core.support.caching` client-side caching support as deprecated. The existing implementation is legacy and incomplete, and a redesigned client-side caching API is planned to replace it. This is a documentation/annotation-only change — no behavior is altered.

## Key Decisions & Assumptions
- No replacement type is linked yet because the redesigned API is still planned; the `@deprecated` text says so explicitly rather than pointing at a stand-in.
- Deprecation version derived from the current build (`7.8.0-SNAPSHOT` → `@since`/`@deprecated 7.8`).
- The package-private implementations (`MapCacheAccessor`, `DefaultRedisCache`) are deprecated alongside their interfaces so implementing a deprecated type emits no warnings.

## Behavioral / Conceptual Changes
- `CacheFrontend`, `CacheAccessor`, `RedisCache`, and `ClientSideCaching` now carry `@Deprecated` and are scheduled for removal in a future major release. Callers will see deprecation warnings; runtime behavior is unchanged.

## Testing
`ClientsideCachingIntegrationTests` gains `@SuppressWarnings("deprecation")` since it exercises the now-deprecated API on purpose. No test logic changed.

## Notes
- The `CLIENT TRACKING` command support and its roadmap entry are intentionally left untouched — only the higher-level caching support utility is deprecated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation and docs only; no behavior, protocol, or tracking-command changes. Callers will see deprecation warnings until a future major removal.
> 
> **Overview**
> Marks the server-assisted client-side caching types (`ClientSideCaching`, `CacheFrontend`, `CacheAccessor`, `RedisCache`, plus package-private implementations) as `@Deprecated` since 7.8. They are described as legacy and incomplete, with no replacement yet and removal planned for a future major release.
> 
> Runtime behavior is unchanged. `CLIENT TRACKING` itself is not deprecated. Release notes and the existing integration tests are updated accordingly (`@SuppressWarnings("deprecation")`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ac311b92549731181884a563417de705093f8b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->