### PR TITLE
Support running integration tests against externally provisioned Redis Enterprise databases

### DIFF
--- a/src/test/java/io/lettuce/core/cluster/AdvancedClusterClientIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/AdvancedClusterClientIntegrationTests.java
@@ -68,6 +68,7 @@ import io.lettuce.test.TestFutures;
 import io.lettuce.test.Wait;
 import io.lettuce.test.condition.EnabledOnCommand;
 import io.lettuce.test.settings.TestSettings;
+import io.lettuce.test.condition.DisabledOnProvider;
 
 /**
  * Integration tests for {@link StatefulRedisClusterConnection}.
@@ -78,6 +79,7 @@ import io.lettuce.test.settings.TestSettings;
  */
 @Tag(INTEGRATION_TEST)
 @ExtendWith(LettuceExtension.class)
+@DisabledOnProvider("re")
 class AdvancedClusterClientIntegrationTests extends TestSupport {
 
     private static final String KEY_ON_NODE_1 = "a";

--- a/src/test/java/io/lettuce/core/cluster/AdvancedClusterReactiveIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/AdvancedClusterReactiveIntegrationTests.java
@@ -69,12 +69,14 @@ import io.lettuce.test.ListStreamingAdapter;
 import io.lettuce.test.TestFutures;
 import io.lettuce.test.condition.EnabledOnCommand;
 import io.netty.util.internal.ConcurrentSet;
+import io.lettuce.test.condition.DisabledOnProvider;
 
 /**
  * @author Mark Paluch
  */
 @Tag(INTEGRATION_TEST)
 @ExtendWith(LettuceExtension.class)
+@DisabledOnProvider("re")
 class AdvancedClusterReactiveIntegrationTests extends TestSupport {
 
     private static final String KEY_ON_NODE_1 = "a";

--- a/src/test/java/io/lettuce/core/cluster/AsyncConnectionProviderIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/AsyncConnectionProviderIntegrationTests.java
@@ -53,6 +53,7 @@ import io.lettuce.core.protocol.ProtocolVersion;
 import io.lettuce.core.resource.ClientResources;
 import io.lettuce.test.LettuceExtension;
 import io.lettuce.test.TestFutures;
+import io.lettuce.test.condition.DisabledOnProvider;
 import io.lettuce.test.settings.TestSettings;
 import io.netty.channel.ConnectTimeoutException;
 
@@ -61,6 +62,9 @@ import io.netty.channel.ConnectTimeoutException;
  */
 @Tag(INTEGRATION_TEST)
 @ExtendWith(LettuceExtension.class)
+// Assumes TestSettings.host() is the local machine: connects it to a local ServerSocket and blocks in accept().
+// On an externally provisioned environment the connection never arrives and the test hangs forever.
+@DisabledOnProvider("re")
 class AsyncConnectionProviderIntegrationTests {
 
     private final ClientResources resources;

--- a/src/test/java/io/lettuce/core/cluster/ClusterClientOptionsIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/ClusterClientOptionsIntegrationTests.java
@@ -24,6 +24,7 @@ import io.lettuce.core.TimeoutOptions;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.pubsub.StatefulRedisClusterPubSubConnection;
 import io.lettuce.test.LettuceExtension;
+import io.lettuce.test.condition.DisabledOnProvider;
 
 /**
  * @author Mark Paluch
@@ -45,6 +46,8 @@ class ClusterClientOptionsIntegrationTests extends TestSupport {
     }
 
     @Test
+    // Uses CLIENT PAUSE, which is not supported on Redis Enterprise
+    @DisabledOnProvider("re")
     void shouldApplyTimeoutOptionsToClusterConnection() throws InterruptedException {
 
         clusterClient.setOptions(
@@ -65,6 +68,8 @@ class ClusterClientOptionsIntegrationTests extends TestSupport {
     }
 
     @Test
+    // Uses CLIENT PAUSE, which is not supported on Redis Enterprise
+    @DisabledOnProvider("re")
     void shouldApplyTimeoutOptionsToPubSubClusterConnection() throws InterruptedException {
 
         clusterClient.setOptions(

--- a/src/test/java/io/lettuce/core/cluster/ClusterCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/ClusterCommandIntegrationTests.java
@@ -38,12 +38,14 @@ import io.lettuce.test.LettuceExtension;
 import io.lettuce.test.TestFutures;
 import io.lettuce.test.Wait;
 import io.lettuce.test.condition.EnabledOnCommand;
+import io.lettuce.test.condition.DisabledOnProvider;
 
 /**
  * @author Mark Paluch
  */
 @Tag(INTEGRATION_TEST)
 @ExtendWith(LettuceExtension.class)
+@DisabledOnProvider("re")
 class ClusterCommandIntegrationTests extends TestSupport {
 
     private final RedisClient client;

--- a/src/test/java/io/lettuce/core/cluster/ClusterMtlsClientAuthIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/ClusterMtlsClientAuthIntegrationTests.java
@@ -32,6 +32,7 @@ import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
 import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
 import io.lettuce.test.condition.RedisConditions;
+import io.lettuce.test.condition.DisabledOnProvider;
 
 /**
  * Integration tests for Redis 8.6+ mTLS client authentication in cluster mode.
@@ -42,6 +43,7 @@ import io.lettuce.test.condition.RedisConditions;
  * @author Aleksandar Todorov
  */
 @Tag(INTEGRATION_TEST)
+@DisabledOnProvider("re")
 class ClusterMtlsClientAuthIntegrationTests extends AbstractMtlsClientAuthIntegrationTests {
 
     private RedisClusterClient redisClusterClient;

--- a/src/test/java/io/lettuce/core/cluster/ClusterPartiallyDownIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/ClusterPartiallyDownIntegrationTests.java
@@ -25,11 +25,13 @@ import io.lettuce.core.internal.LettuceLists;
 import io.lettuce.core.resource.ClientResources;
 import io.lettuce.test.resource.TestClientResources;
 import io.lettuce.test.settings.TestSettings;
+import io.lettuce.test.condition.DisabledOnProvider;
 
 /**
  * @author Mark Paluch
  */
 @Tag(INTEGRATION_TEST)
+@DisabledOnProvider("re")
 class ClusterPartiallyDownIntegrationTests extends TestSupport {
 
     private static ClientResources clientResources;

--- a/src/test/java/io/lettuce/core/cluster/ClusterReactiveCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/ClusterReactiveCommandIntegrationTests.java
@@ -29,12 +29,14 @@ import io.lettuce.core.protocol.CommandType;
 import io.lettuce.core.protocol.ProtocolKeyword;
 import io.lettuce.test.LettuceExtension;
 import io.lettuce.test.condition.EnabledOnCommand;
+import io.lettuce.test.condition.DisabledOnProvider;
 
 /**
  * @author Mark Paluch
  */
 @Tag(INTEGRATION_TEST)
 @ExtendWith(LettuceExtension.class)
+@DisabledOnProvider("re")
 class ClusterReactiveCommandIntegrationTests {
 
     private final RedisClusterClient clusterClient;

--- a/src/test/java/io/lettuce/core/cluster/NodeSelectionAsyncIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/NodeSelectionAsyncIntegrationTests.java
@@ -37,12 +37,14 @@ import io.lettuce.core.protocol.CommandType;
 import io.lettuce.test.LettuceExtension;
 import io.lettuce.test.TestFutures;
 import io.lettuce.test.Wait;
+import io.lettuce.test.condition.DisabledOnProvider;
 
 /**
  * @author Mark Paluch
  */
 @Tag(INTEGRATION_TEST)
 @ExtendWith(LettuceExtension.class)
+@DisabledOnProvider("re")
 class NodeSelectionAsyncIntegrationTests extends TestSupport {
 
     private final RedisClusterClient clusterClient;

--- a/src/test/java/io/lettuce/core/cluster/NodeSelectionSyncIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/NodeSelectionSyncIntegrationTests.java
@@ -29,12 +29,14 @@ import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
 import io.lettuce.core.internal.LettuceSets;
 import io.lettuce.test.LettuceExtension;
 import io.lettuce.test.Wait;
+import io.lettuce.test.condition.DisabledOnProvider;
 
 /**
  * @author Mark Paluch
  */
 @Tag(INTEGRATION_TEST)
 @ExtendWith(LettuceExtension.class)
+@DisabledOnProvider("re")
 class NodeSelectionSyncIntegrationTests extends TestSupport {
 
     private final RedisClusterClient clusterClient;

--- a/src/test/java/io/lettuce/core/cluster/RedisClusterClientIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisClusterClientIntegrationTests.java
@@ -50,6 +50,7 @@ import io.lettuce.test.Wait;
 import io.lettuce.test.resource.FastShutdown;
 import io.lettuce.test.resource.TestClientResources;
 import io.lettuce.test.settings.TestSettings;
+import io.lettuce.test.condition.DisabledOnProvider;
 
 /**
  * Integration tests for {@link RedisClusterClient}.
@@ -59,6 +60,7 @@ import io.lettuce.test.settings.TestSettings;
 @SuppressWarnings("unchecked")
 @ExtendWith(LettuceExtension.class)
 @Tag(INTEGRATION_TEST)
+@DisabledOnProvider("re")
 class RedisClusterClientIntegrationTests extends TestSupport {
 
     private final RedisClient client;

--- a/src/test/java/io/lettuce/core/cluster/RedisClusterPasswordSecuredSslIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisClusterPasswordSecuredSslIntegrationTests.java
@@ -37,12 +37,14 @@ import io.lettuce.test.CanConnect;
 import io.lettuce.test.condition.RedisConditions;
 import io.lettuce.test.resource.FastShutdown;
 import io.lettuce.test.resource.TestClientResources;
+import io.lettuce.test.condition.DisabledOnProvider;
 
 /**
  * @author Mark Paluch
  */
 @Tag(INTEGRATION_TEST)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisabledOnProvider("re")
 class RedisClusterPasswordSecuredSslIntegrationTests extends TestSupport {
 
     private static final int CLUSTER_PORT_SSL_1 = 7443;

--- a/src/test/java/io/lettuce/core/cluster/RedisClusterReadFromIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisClusterReadFromIntegrationTests.java
@@ -37,6 +37,7 @@ import io.lettuce.core.TestSupport;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
 import io.lettuce.test.LettuceExtension;
+import io.lettuce.test.condition.DisabledOnProvider;
 
 /**
  * @author Mark Paluch
@@ -45,6 +46,7 @@ import io.lettuce.test.LettuceExtension;
 @Tag(INTEGRATION_TEST)
 @SuppressWarnings("unchecked")
 @ExtendWith(LettuceExtension.class)
+@DisabledOnProvider("re")
 class RedisClusterReadFromIntegrationTests extends TestSupport {
 
     private final RedisClusterClient clusterClient;

--- a/src/test/java/io/lettuce/core/cluster/RedisClusterSetupIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisClusterSetupIntegrationTests.java
@@ -68,6 +68,7 @@ import io.lettuce.test.resource.DefaultRedisClient;
 import io.lettuce.test.resource.FastShutdown;
 import io.lettuce.test.resource.TestClientResources;
 import io.lettuce.test.settings.TestSettings;
+import io.lettuce.test.condition.DisabledOnProvider;
 
 /**
  * Test for mutable cluster setup scenarios.
@@ -81,6 +82,7 @@ import io.lettuce.test.settings.TestSettings;
 @Tag(INTEGRATION_TEST)
 @SuppressWarnings({ "unchecked" })
 @SlowTests
+@DisabledOnProvider("re")
 public class RedisClusterSetupIntegrationTests extends TestSupport {
 
     private static final String host = TestSettings.hostAddr();

--- a/src/test/java/io/lettuce/core/cluster/RedisClusterStreamingCredentialsProviderlIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisClusterStreamingCredentialsProviderlIntegrationTests.java
@@ -39,12 +39,14 @@ import io.lettuce.test.CanConnect;
 import io.lettuce.test.resource.FastShutdown;
 import io.lettuce.test.resource.TestClientResources;
 import io.lettuce.test.settings.TestSettings;
+import io.lettuce.test.condition.DisabledOnProvider;
 
 /**
  * @author Ivo Gaydajiev
  */
 @Tag(INTEGRATION_TEST)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisabledOnProvider("re")
 class RedisClusterStreamingCredentialsProviderIntegrationTests extends TestSupport {
 
     private static final int CLUSTER_PORT_SSL_1 = 7443;

--- a/src/test/java/io/lettuce/core/cluster/RedisClusterStressScenariosIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisClusterStressScenariosIntegrationTests.java
@@ -53,11 +53,13 @@ import io.lettuce.test.Wait;
 import io.lettuce.test.resource.FastShutdown;
 import io.lettuce.test.resource.TestClientResources;
 import io.lettuce.test.settings.TestSettings;
+import io.lettuce.test.condition.DisabledOnProvider;
 
 @Tag(INTEGRATION_TEST)
 @TestMethodOrder(MethodOrderer.MethodName.class)
 @SuppressWarnings("unchecked")
 @SlowTests
+@DisabledOnProvider("re")
 public class RedisClusterStressScenariosIntegrationTests extends TestSupport {
 
     private static final String host = TestSettings.hostAddr();

--- a/src/test/java/io/lettuce/core/cluster/RedisReactiveClusterClientIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/RedisReactiveClusterClientIntegrationTests.java
@@ -17,6 +17,7 @@ import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands
 import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
 import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
 import io.lettuce.test.LettuceExtension;
+import io.lettuce.test.condition.DisabledOnProvider;
 
 /**
  * @author Mark Paluch
@@ -47,6 +48,8 @@ class RedisReactiveClusterClientIntegrationTests extends TestSupport {
     }
 
     @Test
+    // Not supported on Redis Enterprise
+    @DisabledOnProvider("re")
     void getKeysInSlot() {
 
         sync.flushall();
@@ -61,6 +64,8 @@ class RedisReactiveClusterClientIntegrationTests extends TestSupport {
     }
 
     @Test
+    // Not supported on Redis Enterprise
+    @DisabledOnProvider("re")
     void countKeysInSlot() {
 
         sync.flushall();
@@ -76,6 +81,8 @@ class RedisReactiveClusterClientIntegrationTests extends TestSupport {
     }
 
     @Test
+    // Not supported on Redis Enterprise
+    @DisabledOnProvider("re")
     void testClusterCountFailureReports() {
         RedisClusterNode ownPartition = getOwnPartition(sync);
         StepVerifier.create(reactive.clusterCountFailureReports(ownPartition.getNodeId())).consumeNextWith(actual -> {
@@ -91,11 +98,15 @@ class RedisReactiveClusterClientIntegrationTests extends TestSupport {
     }
 
     @Test
+    // Not supported on Redis Enterprise
+    @DisabledOnProvider("re")
     void testClusterSaveconfig() {
         StepVerifier.create(reactive.clusterSaveconfig()).expectNext("OK").verifyComplete();
     }
 
     @Test
+    // Not supported on Redis Enterprise
+    @DisabledOnProvider("re")
     void testClusterSetConfigEpoch() {
         StepVerifier.create(reactive.clusterSetConfigEpoch(1L)).consumeErrorWith(e -> {
             assertThat(e).hasMessageContaining("ERR The user can assign a config epoch only");

--- a/src/test/java/io/lettuce/core/cluster/ScanIteratorIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/ScanIteratorIntegrationTests.java
@@ -48,6 +48,7 @@ import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
 import io.lettuce.test.KeysAndValues;
 import io.lettuce.test.LettuceExtension;
+import io.lettuce.test.condition.DisabledOnProvider;
 
 /**
  * @author Mark Paluch
@@ -121,6 +122,8 @@ class ScanIteratorIntegrationTests extends TestSupport {
     }
 
     @Test
+    // Node-scoped SCAN semantics differ on the Redis Enterprise proxy topology
+    @DisabledOnProvider("re")
     void keysMultiPassFromAnyNode() {
 
         redis.mset(KeysAndValues.MAP);

--- a/src/test/java/io/lettuce/core/cluster/SingleThreadedReactiveClusterClientIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/SingleThreadedReactiveClusterClientIntegrationTests.java
@@ -10,11 +10,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import io.lettuce.core.RedisURI;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.metrics.DefaultCommandLatencyCollectorOptions;
 import io.lettuce.core.resource.DefaultClientResources;
 import io.lettuce.core.resource.DefaultEventLoopGroupProvider;
+import io.lettuce.test.resource.DefaultRedisClusterClient;
 import io.lettuce.test.resource.FastShutdown;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 
@@ -34,7 +34,7 @@ class SingleThreadedReactiveClusterClientIntegrationTests {
                 .eventLoopGroupProvider(new DefaultEventLoopGroupProvider(1))
                 .commandLatencyCollectorOptions(DefaultCommandLatencyCollectorOptions.disabled()).build();
 
-        client = RedisClusterClient.create(clientResources, RedisURI.create("localhost", 7379));
+        client = RedisClusterClient.create(clientResources, DefaultRedisClusterClient.seedUris());
     }
 
     @AfterEach

--- a/src/test/java/io/lettuce/core/cluster/commands/HotkeysClusterCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/commands/HotkeysClusterCommandIntegrationTests.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import io.lettuce.test.condition.DisabledOnProvider;
 
 /**
  * Integration tests for HOTKEYS commands using Redis Cluster. Verifies that HOTKEYS commands are not supported on the cluster
@@ -41,6 +42,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(LettuceExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @EnabledOnCommand("HOTKEYS")
+@DisabledOnProvider("re")
 public class HotkeysClusterCommandIntegrationTests {
 
     protected RedisAdvancedClusterCommands<String, String> redis;

--- a/src/test/java/io/lettuce/core/cluster/pubsub/ClusterSubkeyNotificationsIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/pubsub/ClusterSubkeyNotificationsIntegrationTests.java
@@ -29,6 +29,7 @@ import io.lettuce.core.cluster.pubsub.api.sync.PubSubNodeSelection;
 import io.lettuce.core.support.CapturingPubSubListener;
 import io.lettuce.core.support.CapturingPubSubListener.Notification;
 import io.lettuce.test.LettuceExtension;
+import io.lettuce.test.condition.DisabledOnProvider;
 
 /**
  * Cluster integration tests for Redis 8.8 Subkey Notifications. Subkey notifications are published locally on the slot owner,
@@ -39,6 +40,7 @@ import io.lettuce.test.LettuceExtension;
  */
 @Tag(INTEGRATION_TEST)
 @ExtendWith(LettuceExtension.class)
+@DisabledOnProvider("re")
 class ClusterSubkeyNotificationsIntegrationTests extends TestSupport {
 
     private final RedisClusterClient clusterClient;

--- a/src/test/java/io/lettuce/core/cluster/pubsub/RedisClusterPubSubConnectionIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/pubsub/RedisClusterPubSubConnectionIntegrationTests.java
@@ -38,6 +38,7 @@ import io.lettuce.test.LettuceExtension;
 import io.lettuce.test.TestFutures;
 import io.lettuce.test.Wait;
 import io.lettuce.test.condition.EnabledOnCommand;
+import io.lettuce.test.condition.DisabledOnProvider;
 
 /**
  * Integration tests for Cluster Pub/Sub.
@@ -46,6 +47,7 @@ import io.lettuce.test.condition.EnabledOnCommand;
  */
 @Tag(INTEGRATION_TEST)
 @ExtendWith(LettuceExtension.class)
+@DisabledOnProvider("re")
 class RedisClusterPubSubConnectionIntegrationTests extends TestSupport {
 
     private final RedisClusterClient clusterClient;

--- a/src/test/java/io/lettuce/core/cluster/topology/TopologyRefreshIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/cluster/topology/TopologyRefreshIntegrationTests.java
@@ -38,6 +38,7 @@ import io.lettuce.test.LettuceExtension;
 import io.lettuce.test.Wait;
 import io.lettuce.test.resource.FastShutdown;
 import io.lettuce.test.settings.TestSettings;
+import io.lettuce.test.condition.DisabledOnProvider;
 
 /**
  * Test for topology refreshing.
@@ -48,6 +49,7 @@ import io.lettuce.test.settings.TestSettings;
 @SuppressWarnings({ "unchecked" })
 @SlowTests
 @ExtendWith(LettuceExtension.class)
+@DisabledOnProvider("re")
 class TopologyRefreshIntegrationTests extends TestSupport {
 
     private static final String host = TestSettings.hostAddr();

--- a/src/test/java/io/lettuce/core/commands/AclCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/AclCommandIntegrationTests.java
@@ -41,6 +41,7 @@ import io.lettuce.core.protocol.Command;
 import io.lettuce.core.protocol.CommandArgs;
 import io.lettuce.core.protocol.CommandType;
 import io.lettuce.test.LettuceExtension;
+import io.lettuce.test.condition.DisabledOnProvider;
 import io.lettuce.test.condition.EnabledOnCommand;
 
 /**
@@ -51,6 +52,7 @@ import io.lettuce.test.condition.EnabledOnCommand;
  */
 @Tag(INTEGRATION_TEST)
 @ExtendWith(LettuceExtension.class)
+@DisabledOnProvider("re")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @EnabledOnCommand("ACL")
 public class AclCommandIntegrationTests extends TestSupport {

--- a/src/test/java/io/lettuce/core/commands/CommandInterfacesIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/CommandInterfacesIntegrationTests.java
@@ -28,6 +28,7 @@ import io.lettuce.core.dynamic.Commands;
 import io.lettuce.core.dynamic.RedisCommandFactory;
 import io.lettuce.core.dynamic.annotation.Command;
 import io.lettuce.core.dynamic.annotation.Param;
+import io.lettuce.test.resource.ModulesTestUri;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -53,7 +54,7 @@ public class CommandInterfacesIntegrationTests {
     protected static RedisCommands<String, String> redis;
 
     protected CommandInterfacesIntegrationTests() {
-        RedisURI redisURI = RedisURI.Builder.redis("127.0.0.1").withPort(16379).build();
+        RedisURI redisURI = ModulesTestUri.create();
 
         client = RedisClient.create(redisURI);
         redis = client.connect().sync();

--- a/src/test/java/io/lettuce/core/commands/ConsolidatedAclCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/ConsolidatedAclCommandIntegrationTests.java
@@ -22,6 +22,7 @@ package io.lettuce.core.commands;
 import io.lettuce.core.*;
 import io.lettuce.core.api.sync.RedisCommands;
 
+import io.lettuce.test.condition.DisabledOnProvider;
 import io.lettuce.test.condition.RedisConditions;
 import io.lettuce.test.resource.ModulesTestUri;
 import org.junit.jupiter.api.*;
@@ -38,6 +39,8 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * @author M Sazzadul Hoque
  */
 @Tag(INTEGRATION_TEST)
+// Redis Enterprise does not support ACL LOG and other ACL management subcommands
+@DisabledOnProvider("re")
 public class ConsolidatedAclCommandIntegrationTests {
 
     private static RedisClient client;

--- a/src/test/java/io/lettuce/core/commands/ConsolidatedAclCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/ConsolidatedAclCommandIntegrationTests.java
@@ -23,6 +23,7 @@ import io.lettuce.core.*;
 import io.lettuce.core.api.sync.RedisCommands;
 
 import io.lettuce.test.condition.RedisConditions;
+import io.lettuce.test.resource.ModulesTestUri;
 import org.junit.jupiter.api.*;
 
 import java.util.Arrays;
@@ -45,7 +46,7 @@ public class ConsolidatedAclCommandIntegrationTests {
 
     @BeforeAll
     public static void setup() {
-        RedisURI redisURI = RedisURI.Builder.redis("127.0.0.1").withPort(16379).build();
+        RedisURI redisURI = ModulesTestUri.create();
 
         client = RedisClient.create(redisURI);
         redis = client.connect().sync();

--- a/src/test/java/io/lettuce/core/commands/ConsolidatedConfigurationCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/ConsolidatedConfigurationCommandIntegrationTests.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import io.lettuce.core.*;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.test.condition.RedisConditions;
+import io.lettuce.test.resource.ModulesTestUri;
 
 import org.junit.jupiter.api.*;
 
@@ -46,7 +47,7 @@ public class ConsolidatedConfigurationCommandIntegrationTests {
 
     @BeforeAll
     public static void setup() {
-        RedisURI redisURI = RedisURI.Builder.redis("127.0.0.1").withPort(16379).build();
+        RedisURI redisURI = ModulesTestUri.create();
 
         client = RedisClient.create(redisURI);
         redis = client.connect().sync();

--- a/src/test/java/io/lettuce/core/commands/ConsolidatedConfigurationCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/ConsolidatedConfigurationCommandIntegrationTests.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.lettuce.core.*;
 import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.test.condition.DisabledOnProvider;
 import io.lettuce.test.condition.RedisConditions;
 import io.lettuce.test.resource.ModulesTestUri;
 
@@ -88,6 +89,8 @@ public class ConsolidatedConfigurationCommandIntegrationTests {
     }
 
     @Test
+    // Redis Enterprise CONFIG GET supports only a subset of settings and does not expose module parameters
+    @DisabledOnProvider("re")
     public void getSearchConfigSettingTest() {
         assertThat(redis.configGet("search-timeout")).hasSize(1);
     }
@@ -108,6 +111,8 @@ public class ConsolidatedConfigurationCommandIntegrationTests {
     }
 
     @Test
+    // Redis Enterprise CONFIG GET supports only a subset of settings and does not expose module parameters
+    @DisabledOnProvider("re")
     public void getAllConfigSettings() {
         assertThat(redis.configGet("*").keySet()).contains("search-default-dialect", "search-timeout", "ts-retention-policy",
                 "bf-error-rate", "cf-initial-size");

--- a/src/test/java/io/lettuce/core/commands/GeoMasterReplicaIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/GeoMasterReplicaIntegrationTests.java
@@ -8,6 +8,7 @@ import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection;
 import io.lettuce.core.models.role.RedisInstance;
 import io.lettuce.core.models.role.RoleParser;
 import io.lettuce.test.LettuceExtension;
+import io.lettuce.test.condition.DisabledOnProvider;
 import io.lettuce.test.condition.EnabledOnCommand;
 import io.lettuce.test.settings.TestSettings;
 import org.junit.jupiter.api.*;
@@ -26,6 +27,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  */
 @Tag(INTEGRATION_TEST)
 @ExtendWith(LettuceExtension.class)
+@DisabledOnProvider("re")
 @EnabledOnCommand("GEOADD")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class GeoMasterReplicaIntegrationTests extends AbstractRedisClientTest {

--- a/src/test/java/io/lettuce/core/commands/HotkeysCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/HotkeysCommandIntegrationTests.java
@@ -26,6 +26,7 @@ import io.lettuce.core.HotkeysReply;
 import io.lettuce.core.TestSupport;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.test.LettuceExtension;
+import io.lettuce.test.condition.DisabledOnProvider;
 import io.lettuce.test.condition.EnabledOnCommand;
 
 /**
@@ -37,6 +38,8 @@ import io.lettuce.test.condition.EnabledOnCommand;
 @ExtendWith(LettuceExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @EnabledOnCommand("HOTKEYS")
+// Redis Enterprise blocks the HOTKEYS command (also covers HotkeysCommandResp2IntegrationTests via inheritance)
+@DisabledOnProvider("re")
 public class HotkeysCommandIntegrationTests extends TestSupport {
 
     protected RedisCommands<String, String> redis;

--- a/src/test/java/io/lettuce/core/commands/KeyCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/KeyCommandIntegrationTests.java
@@ -50,6 +50,7 @@ import io.lettuce.core.TestSupport;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.test.LettuceExtension;
 import io.lettuce.test.ListStreamingAdapter;
+import io.lettuce.test.condition.DisabledOnProvider;
 import io.lettuce.test.condition.EnabledOnCommand;
 
 /**
@@ -116,6 +117,8 @@ public class KeyCommandIntegrationTests extends TestSupport {
 
     @Test
     @EnabledOnCommand("COPY")
+    // Redis Enterprise does not support multiple databases
+    @DisabledOnProvider("re")
     void copyWithDestinationDb() {
         redis.set(key, value);
         redis.copy(key, key, CopyArgs.Builder.destinationDb(2));
@@ -228,6 +231,8 @@ public class KeyCommandIntegrationTests extends TestSupport {
     }
 
     @Test
+    // Redis Enterprise does not support multiple databases and blocks MOVE
+    @DisabledOnProvider("re")
     public void move() {
         redis.set(key, value);
         redis.move(key, 1);
@@ -245,6 +250,8 @@ public class KeyCommandIntegrationTests extends TestSupport {
     }
 
     @Test
+    // Redis Enterprise does not expose maxmemory-policy via CONFIG GET/SET
+    @DisabledOnProvider("re")
     void objectFreq() {
         String maxmemoryPolicy = redis.configGet("maxmemory-policy").get("maxmemory-policy");
         try {

--- a/src/test/java/io/lettuce/core/commands/RunOnlyOnceServerCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/RunOnlyOnceServerCommandIntegrationTests.java
@@ -21,6 +21,7 @@ import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.test.CanConnect;
 import io.lettuce.test.LettuceExtension;
+import io.lettuce.test.condition.DisabledOnProvider;
 import io.lettuce.test.Wait;
 import io.lettuce.test.settings.TestSettings;
 
@@ -31,6 +32,7 @@ import io.lettuce.test.settings.TestSettings;
  */
 @Tag(INTEGRATION_TEST)
 @ExtendWith(LettuceExtension.class)
+@DisabledOnProvider("re")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class RunOnlyOnceServerCommandIntegrationTests extends TestSupport {
 

--- a/src/test/java/io/lettuce/core/commands/ServerCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/ServerCommandIntegrationTests.java
@@ -52,6 +52,7 @@ import io.lettuce.core.models.role.RoleParser;
 import io.lettuce.core.protocol.CommandType;
 import io.lettuce.test.LettuceExtension;
 import io.lettuce.test.Wait;
+import io.lettuce.test.condition.DisabledOnProvider;
 import io.lettuce.test.condition.EnabledOnCommand;
 import io.lettuce.test.settings.TestSettings;
 
@@ -72,6 +73,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  */
 @Tag(INTEGRATION_TEST)
 @ExtendWith(LettuceExtension.class)
+@DisabledOnProvider("re")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ServerCommandIntegrationTests extends TestSupport {
 

--- a/src/test/java/io/lettuce/core/json/RedisJsonIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/json/RedisJsonIntegrationTests.java
@@ -44,6 +44,7 @@ import static io.lettuce.TestTags.INTEGRATION_TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import io.lettuce.test.resource.ModulesTestUri;
 
 @Tag(INTEGRATION_TEST)
 public class RedisJsonIntegrationTests {
@@ -63,7 +64,7 @@ public class RedisJsonIntegrationTests {
     protected static RedisCommands<String, String> redis;
 
     public RedisJsonIntegrationTests() {
-        RedisURI redisURI = RedisURI.Builder.redis("127.0.0.1").withPort(16379).build();
+        RedisURI redisURI = ModulesTestUri.create();
 
         client = RedisClient.create(redisURI);
         redis = client.connect().sync();
@@ -721,7 +722,7 @@ public class RedisJsonIntegrationTests {
 
     @Test
     void withCustomParser() {
-        RedisURI redisURI = RedisURI.Builder.redis("127.0.0.1").withPort(16379).build();
+        RedisURI redisURI = ModulesTestUri.create();
 
         try (RedisClient client = RedisClient.create(redisURI)) {
             client.setOptions(ClientOptions.builder().jsonParser(CustomParser::new).build());

--- a/src/test/java/io/lettuce/core/search/FtHybridIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/search/FtHybridIntegrationTests.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import static io.lettuce.TestTags.INTEGRATION_TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import io.lettuce.test.resource.ModulesTestUri;
 
 @Tag(INTEGRATION_TEST)
 @EnabledOnCommand("FT.HYBRID")
@@ -68,7 +69,7 @@ public class FtHybridIntegrationTests {
 
     @BeforeAll
     static void setupOnce() {
-        RedisURI redisURI = RedisURI.Builder.redis("127.0.0.1").withPort(16379).build();
+        RedisURI redisURI = ModulesTestUri.create();
         client = RedisClient.create(redisURI);
         client.setOptions(ClientOptions.builder().build());
         redis = client.connect().sync();

--- a/src/test/java/io/lettuce/core/search/RediSearchAdvancedConceptsIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/search/RediSearchAdvancedConceptsIntegrationTests.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import static io.lettuce.TestTags.INTEGRATION_TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import io.lettuce.test.resource.ModulesTestUri;
 
 /**
  * Integration tests for Redis Search advanced concepts based on the Redis documentation.
@@ -79,7 +80,7 @@ public class RediSearchAdvancedConceptsIntegrationTests {
     protected static RedisCommands<String, String> redis;
 
     public RediSearchAdvancedConceptsIntegrationTests() {
-        RedisURI redisURI = RedisURI.Builder.redis("127.0.0.1").withPort(16379).build();
+        RedisURI redisURI = ModulesTestUri.create();
         client = RedisClient.create(redisURI);
         client.setOptions(getOptions());
         redis = client.connect().sync();

--- a/src/test/java/io/lettuce/core/search/RediSearchAggregateIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/search/RediSearchAggregateIntegrationTests.java
@@ -43,6 +43,7 @@ import io.lettuce.core.search.arguments.NumericFieldArgs;
 import io.lettuce.core.search.arguments.QueryDialects;
 import io.lettuce.core.search.arguments.TagFieldArgs;
 import io.lettuce.core.search.arguments.TextFieldArgs;
+import io.lettuce.test.resource.ModulesTestUri;
 
 /**
  * Integration tests for Redis FT.AGGREGATE command.
@@ -57,7 +58,7 @@ class RediSearchAggregateIntegrationTests extends TestSupport {
     private RedisCommands<String, String> redis;
 
     RediSearchAggregateIntegrationTests() {
-        RedisURI redisURI = RedisURI.Builder.redis("127.0.0.1").withPort(16379).build();
+        RedisURI redisURI = ModulesTestUri.create();
         client = RedisClient.create(redisURI);
         client.setOptions(getOptions());
     }

--- a/src/test/java/io/lettuce/core/search/RediSearchGeospatialIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/search/RediSearchGeospatialIntegrationTests.java
@@ -30,6 +30,7 @@ import io.lettuce.core.search.arguments.GeoFieldArgs;
 import io.lettuce.core.search.arguments.GeoshapeFieldArgs;
 import io.lettuce.core.search.arguments.SearchArgs;
 import io.lettuce.core.search.arguments.TextFieldArgs;
+import io.lettuce.test.resource.ModulesTestUri;
 
 /**
  * Integration tests for Redis Search geospatial functionality using GEO and GEOSHAPE fields.
@@ -64,7 +65,7 @@ public class RediSearchGeospatialIntegrationTests {
     protected static RedisCommands<String, String> redis;
 
     public RediSearchGeospatialIntegrationTests() {
-        RedisURI redisURI = RedisURI.Builder.redis("127.0.0.1").withPort(16379).build();
+        RedisURI redisURI = ModulesTestUri.create();
         client = RedisClient.create(redisURI);
         client.setOptions(getOptions());
         redis = client.connect().sync();

--- a/src/test/java/io/lettuce/core/search/RediSearchIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/search/RediSearchIntegrationTests.java
@@ -70,6 +70,7 @@ import static io.lettuce.TestTags.INTEGRATION_TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import io.lettuce.test.resource.ModulesTestUri;
 
 /**
  * Integration tests for Redis Search functionality using FT.SEARCH command.
@@ -108,7 +109,7 @@ public class RediSearchIntegrationTests {
     protected static RedisCommands<byte[], byte[]> redisBinary;
 
     public RediSearchIntegrationTests() {
-        RedisURI redisURI = RedisURI.Builder.redis("127.0.0.1").withPort(16379).build();
+        RedisURI redisURI = ModulesTestUri.create();
         client = RedisClient.create(redisURI);
         client.setOptions(getOptions());
         redis = client.connect().sync();
@@ -1362,7 +1363,8 @@ public class RediSearchIntegrationTests {
 
         // Create a dedicated client with settings that trigger the memory corruption bug
         // These settings match the reproducer from the bug report
-        RedisURI redisURI = RedisURI.Builder.redis("127.0.0.1").withPort(16379).withTimeout(Duration.ofSeconds(30)).build();
+        RedisURI redisURI = ModulesTestUri.create();
+        redisURI.setTimeout(Duration.ofSeconds(30));
         RedisClient testClient = RedisClient.create(redisURI);
         testClient.setOptions(ClientOptions.builder()
                 // Large buffer policy prevents early buffer recycling, exposing the bug

--- a/src/test/java/io/lettuce/core/search/RediSearchVectorIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/search/RediSearchVectorIntegrationTests.java
@@ -53,6 +53,7 @@ import static io.lettuce.TestTags.INTEGRATION_TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import io.lettuce.test.resource.ModulesTestUri;
 
 /**
  * Integration tests for Redis Vector Search functionality using FT.SEARCH command with vector fields.
@@ -86,7 +87,7 @@ public class RediSearchVectorIntegrationTests {
     protected static RedisCommands<String, String> redis;
 
     public RediSearchVectorIntegrationTests() {
-        RedisURI redisURI = RedisURI.Builder.redis("127.0.0.1").withPort(16379).build();
+        RedisURI redisURI = ModulesTestUri.create();
         client = RedisClient.create(redisURI);
         client.setOptions(getOptions());
         redis = client.connect().sync();

--- a/src/test/java/io/lettuce/core/search/RedisJsonIndexingIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/search/RedisJsonIndexingIntegrationTests.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 
 import static io.lettuce.TestTags.INTEGRATION_TEST;
 import static org.assertj.core.api.Assertions.assertThat;
+import io.lettuce.test.resource.ModulesTestUri;
 
 /**
  * Integration tests for Redis JSON indexing functionality based on the Redis documentation tutorial.
@@ -61,7 +62,7 @@ public class RedisJsonIndexingIntegrationTests {
     protected static RedisCommands<String, String> redis;
 
     public RedisJsonIndexingIntegrationTests() {
-        RedisURI redisURI = RedisURI.Builder.redis("127.0.0.1").withPort(16379).build();
+        RedisURI redisURI = ModulesTestUri.create();
         client = RedisClient.create(redisURI);
         client.setOptions(getOptions());
         redis = client.connect().sync();

--- a/src/test/java/io/lettuce/core/vector/RedisVectorSetAdvancedIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/vector/RedisVectorSetAdvancedIntegrationTests.java
@@ -39,6 +39,7 @@ import static io.lettuce.TestTags.INTEGRATION_TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import io.lettuce.test.resource.ModulesTestUri;
 
 /**
  * Integration tests for Redis Vector Sets based on the examples from the Redis documentation.
@@ -55,7 +56,7 @@ public class RedisVectorSetAdvancedIntegrationTests {
     protected static RedisCommands<String, String> redis;
 
     public RedisVectorSetAdvancedIntegrationTests() {
-        RedisURI redisURI = RedisURI.Builder.redis("127.0.0.1").withPort(16379).build();
+        RedisURI redisURI = ModulesTestUri.create();
 
         client = RedisClient.create(redisURI);
         StatefulRedisConnection<String, String> connection = client.connect();

--- a/src/test/java/io/lettuce/core/vector/RedisVectorSetIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/vector/RedisVectorSetIntegrationTests.java
@@ -35,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import io.lettuce.test.resource.ModulesTestUri;
 
 @Tag(INTEGRATION_TEST)
 public class RedisVectorSetIntegrationTests {
@@ -68,7 +69,7 @@ public class RedisVectorSetIntegrationTests {
     protected static RedisReactiveCommands<String, String> reactiveRedis;
 
     public RedisVectorSetIntegrationTests() {
-        RedisURI redisURI = RedisURI.Builder.redis("127.0.0.1").withPort(16379).build();
+        RedisURI redisURI = ModulesTestUri.create();
 
         client = RedisClient.create(redisURI);
         client.setOptions(getOptions());

--- a/src/test/java/io/lettuce/test/condition/DisabledOnProvider.java
+++ b/src/test/java/io/lettuce/test/condition/DisabledOnProvider.java
@@ -1,6 +1,11 @@
 package io.lettuce.test.condition;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.extension.ExtendWith;
 

--- a/src/test/java/io/lettuce/test/condition/DisabledOnProvider.java
+++ b/src/test/java/io/lettuce/test/condition/DisabledOnProvider.java
@@ -1,0 +1,30 @@
+package io.lettuce.test.condition;
+
+import java.lang.annotation.*;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * {@code @DisabledOnProvider} is used to signal that the annotated test class or test method is <em>disabled</em> when the
+ * tests run against an externally provisioned test environment selected through the {@code TEST_ENV_PROVIDER} environment
+ * variable (e.g. {@code re} for Redis Enterprise).
+ *
+ * <p/>
+ * When applied at the class level, all test methods within that class will be disabled.
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@ExtendWith(DisabledOnProviderCondition.class)
+public @interface DisabledOnProvider {
+
+    /**
+     * Name of the test environment provider on which the test is disabled, matched case-insensitively against the
+     * {@code TEST_ENV_PROVIDER} environment variable.
+     *
+     * @return
+     */
+    String value() default "re";
+
+}

--- a/src/test/java/io/lettuce/test/condition/DisabledOnProviderCondition.java
+++ b/src/test/java/io/lettuce/test/condition/DisabledOnProviderCondition.java
@@ -1,0 +1,42 @@
+package io.lettuce.test.condition;
+
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.util.AnnotationUtils;
+
+/**
+ * {@link ExecutionCondition} for {@link DisabledOnProvider @DisabledOnProvider}.
+ *
+ * @see DisabledOnProvider
+ */
+class DisabledOnProviderCondition implements ExecutionCondition {
+
+    private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled("@DisabledOnProvider is not present");
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+
+        Optional<DisabledOnProvider> optional = AnnotationUtils.findAnnotation(context.getElement(), DisabledOnProvider.class);
+
+        if (optional.isPresent()) {
+
+            String provider = optional.get().value();
+            String activeProvider = System.getenv("TEST_ENV_PROVIDER");
+
+            if (provider.equalsIgnoreCase(activeProvider)) {
+                return disabled("Disabled on test environment provider '" + provider + "'");
+            }
+
+            return enabled("Test environment provider '" + provider + "' is not active");
+        }
+
+        return ENABLED_BY_DEFAULT;
+    }
+
+}

--- a/src/test/java/io/lettuce/test/env/Endpoints.java
+++ b/src/test/java/io/lettuce/test/env/Endpoints.java
@@ -2,6 +2,7 @@ package io.lettuce.test.env;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,12 +27,19 @@ public class Endpoints {
 
     static {
         String filePath = System.getenv("REDIS_ENDPOINTS_CONFIG_PATH");
-        if (filePath == null || filePath.isEmpty()) {
+        if (filePath != null && !filePath.isEmpty()) {
+            DEFAULT = fromFile(filePath);
+        } else if (System.getenv("TEST_ENV_PROVIDER") != null && !System.getenv("TEST_ENV_PROVIDER").isEmpty()) {
+            // An external test environment provider requires an explicit endpoint configuration. Do not fall back to the
+            // bundled local configuration; an empty configuration makes endpoint resolution fail fast instead of silently
+            // targeting the local test environment.
+            log.error("TEST_ENV_PROVIDER is set but the REDIS_ENDPOINTS_CONFIG_PATH environment variable is not. "
+                    + "No Endpoints configuration will be loaded.");
+            DEFAULT = new Endpoints(Collections.emptyMap());
+        } else {
             log.info("REDIS_ENDPOINTS_CONFIG_PATH environment variable is not set. Using the bundled " + LOCAL_RESOURCE
                     + " endpoint configuration for the local test environment.");
             DEFAULT = fromResource(LOCAL_RESOURCE);
-        } else {
-            DEFAULT = fromFile(filePath);
         }
     }
 

--- a/src/test/java/io/lettuce/test/env/Endpoints.java
+++ b/src/test/java/io/lettuce/test/env/Endpoints.java
@@ -2,7 +2,6 @@ package io.lettuce.test.env;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -13,10 +12,13 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 
 public class Endpoints {
 
     private static final Logger log = LoggerFactory.getLogger(Endpoints.class);
+
+    private static final String LOCAL_RESOURCE = "/endpoints.json";
 
     private Map<String, Endpoint> endpoints;
 
@@ -25,8 +27,9 @@ public class Endpoints {
     static {
         String filePath = System.getenv("REDIS_ENDPOINTS_CONFIG_PATH");
         if (filePath == null || filePath.isEmpty()) {
-            log.info("REDIS_ENDPOINTS_CONFIG_PATH environment variable is not set. No Endpoints configuration will be loaded.");
-            DEFAULT = new Endpoints(Collections.emptyMap());
+            log.info("REDIS_ENDPOINTS_CONFIG_PATH environment variable is not set. Using the bundled " + LOCAL_RESOURCE
+                    + " endpoint configuration for the local test environment.");
+            DEFAULT = fromResource(LOCAL_RESOURCE);
         } else {
             DEFAULT = fromFile(filePath);
         }
@@ -53,6 +56,26 @@ public class Endpoints {
 
         } catch (IOException e) {
             throw new RuntimeException("Failed to load Endpoints from file: " + filePath, e);
+        }
+    }
+
+    /**
+     * Factory method to create an Endpoints instance from a classpath resource.
+     *
+     * @param resourcePath Absolute classpath resource path.
+     * @return Populated Endpoints instance.
+     */
+    public static Endpoints fromResource(String resourcePath) {
+        try (InputStream stream = Endpoints.class.getResourceAsStream(resourcePath)) {
+            if (stream == null) {
+                throw new IOException("Resource not found: " + resourcePath);
+            }
+            ObjectMapper objectMapper = new ObjectMapper();
+            HashMap<String, Endpoint> endpoints = objectMapper.readValue(stream,
+                    objectMapper.getTypeFactory().constructMapType(HashMap.class, String.class, Endpoint.class));
+            return new Endpoints(endpoints);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load Endpoints from resource: " + resourcePath, e);
         }
     }
 

--- a/src/test/java/io/lettuce/test/resource/DefaultRedisClient.java
+++ b/src/test/java/io/lettuce/test/resource/DefaultRedisClient.java
@@ -2,6 +2,7 @@ package io.lettuce.test.resource;
 
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
+import io.lettuce.test.env.Endpoints;
 import io.lettuce.test.settings.TestSettings;
 
 /**
@@ -19,9 +20,9 @@ public class DefaultRedisClient {
         if (TestSettings.tls()) {
             builder.withSsl(true).withVerifyPeer(false);
         }
-        CharSequence password = TestSettings.password();
-        if (TestSettings.isProviderActive() && password != null && password.length() > 0) {
-            builder.withAuthentication(TestSettings.username(), password);
+        Endpoints.Endpoint endpoint = TestSettings.endpoint();
+        if (endpoint != null && endpoint.getPassword() != null && !endpoint.getPassword().isEmpty()) {
+            builder.withAuthentication(TestSettings.username(), endpoint.getPassword());
         }
         redisClient = RedisClient.create(builder.build());
         Runtime.getRuntime().addShutdownHook(new Thread(() -> FastShutdown.shutdown(redisClient)));

--- a/src/test/java/io/lettuce/test/resource/DefaultRedisClient.java
+++ b/src/test/java/io/lettuce/test/resource/DefaultRedisClient.java
@@ -15,7 +15,15 @@ public class DefaultRedisClient {
     private final RedisClient redisClient;
 
     private DefaultRedisClient() {
-        redisClient = RedisClient.create(RedisURI.Builder.redis(TestSettings.host(), TestSettings.port()).build());
+        RedisURI.Builder builder = RedisURI.Builder.redis(TestSettings.host(), TestSettings.port());
+        if (TestSettings.tls()) {
+            builder.withSsl(true).withVerifyPeer(false);
+        }
+        CharSequence password = TestSettings.password();
+        if (TestSettings.isProviderActive() && password != null && password.length() > 0) {
+            builder.withAuthentication(TestSettings.username(), password);
+        }
+        redisClient = RedisClient.create(builder.build());
         Runtime.getRuntime().addShutdownHook(new Thread(() -> FastShutdown.shutdown(redisClient)));
     }
 

--- a/src/test/java/io/lettuce/test/resource/DefaultRedisClusterClient.java
+++ b/src/test/java/io/lettuce/test/resource/DefaultRedisClusterClient.java
@@ -1,8 +1,13 @@
 package io.lettuce.test.resource;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.cluster.ClusterClientOptions;
 import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.test.env.Endpoints;
 import io.lettuce.test.settings.TestSettings;
 
 /**
@@ -15,8 +20,7 @@ public class DefaultRedisClusterClient {
     private RedisClusterClient redisClient;
 
     private DefaultRedisClusterClient() {
-        redisClient = RedisClusterClient.create(
-                RedisURI.Builder.redis(TestSettings.host(), TestSettings.port(900)).withClientName("my-client").build());
+        redisClient = RedisClusterClient.create(seedUris());
         Runtime.getRuntime().addShutdownHook(new Thread() {
 
             @Override
@@ -25,6 +29,39 @@ public class DefaultRedisClusterClient {
             }
 
         });
+    }
+
+    /**
+     * Seed URIs of the Redis Cluster test database, resolved from the {@literal cluster} endpoint of the endpoint configuration
+     * (see {@link TestSettings#clusterEndpoint()}).
+     *
+     * @return the seed URIs to bootstrap a {@link RedisClusterClient} for the tests.
+     */
+    public static List<RedisURI> seedUris() {
+
+        Endpoints.Endpoint endpoint = TestSettings.clusterEndpoint();
+
+        if (endpoint == null || endpoint.getEndpoints() == null || endpoint.getEndpoints().isEmpty()) {
+            return Collections.singletonList(
+                    RedisURI.Builder.redis(TestSettings.host(), TestSettings.port(900)).withClientName("my-client").build());
+        }
+
+        List<RedisURI> seeds = new ArrayList<>();
+        for (String uri : endpoint.getEndpoints()) {
+            RedisURI redisURI = RedisURI.create(uri);
+            redisURI.setClientName("my-client");
+            if (endpoint.getPassword() != null && !endpoint.getPassword().isEmpty()) {
+                String username = endpoint.getUsername() != null && !endpoint.getUsername().isEmpty() ? endpoint.getUsername()
+                        : null;
+                redisURI.setAuthentication(username, endpoint.getPassword());
+            }
+            if (endpoint.isTls()) {
+                redisURI.setSsl(true);
+                redisURI.setVerifyPeer(false);
+            }
+            seeds.add(redisURI);
+        }
+        return seeds;
     }
 
     /**

--- a/src/test/java/io/lettuce/test/resource/ModulesTestUri.java
+++ b/src/test/java/io/lettuce/test/resource/ModulesTestUri.java
@@ -1,6 +1,7 @@
 package io.lettuce.test.resource;
 
 import io.lettuce.core.RedisURI;
+import io.lettuce.test.env.Endpoints;
 import io.lettuce.test.settings.TestSettings;
 
 /**
@@ -20,13 +21,16 @@ public class ModulesTestUri {
 
         RedisURI.Builder builder = RedisURI.Builder.redis(TestSettings.moduleHost()).withPort(TestSettings.modulePort());
 
-        if (TestSettings.tls()) {
+        Endpoints.Endpoint endpoint = TestSettings.moduleEndpoint();
+
+        if (endpoint != null && endpoint.isTls()) {
             builder.withSsl(true).withVerifyPeer(false);
         }
 
-        CharSequence password = TestSettings.password();
-        if (TestSettings.isProviderActive() && password != null && password.length() > 0) {
-            builder.withAuthentication(TestSettings.username(), password);
+        if (endpoint != null && endpoint.getPassword() != null && !endpoint.getPassword().isEmpty()) {
+            String username = endpoint.getUsername() != null && !endpoint.getUsername().isEmpty() ? endpoint.getUsername()
+                    : "default";
+            builder.withAuthentication(username, endpoint.getPassword());
         }
 
         return builder.build();

--- a/src/test/java/io/lettuce/test/resource/ModulesTestUri.java
+++ b/src/test/java/io/lettuce/test/resource/ModulesTestUri.java
@@ -1,0 +1,35 @@
+package io.lettuce.test.resource;
+
+import io.lettuce.core.RedisURI;
+import io.lettuce.test.settings.TestSettings;
+
+/**
+ * Factory for the {@link RedisURI} of the modules-enabled (JSON, Search, TimeSeries, Bloom) standalone Redis instance used
+ * while testing.
+ */
+public class ModulesTestUri {
+
+    private ModulesTestUri() {
+    }
+
+    /**
+     * @return the {@link RedisURI} of the modules-enabled standalone test instance, see {@link TestSettings#moduleHost()} and
+     *         {@link TestSettings#modulePort()}.
+     */
+    public static RedisURI create() {
+
+        RedisURI.Builder builder = RedisURI.Builder.redis(TestSettings.moduleHost()).withPort(TestSettings.modulePort());
+
+        if (TestSettings.tls()) {
+            builder.withSsl(true).withVerifyPeer(false);
+        }
+
+        CharSequence password = TestSettings.password();
+        if (TestSettings.isProviderActive() && password != null && password.length() > 0) {
+            builder.withAuthentication(TestSettings.username(), password);
+        }
+
+        return builder.build();
+    }
+
+}

--- a/src/test/java/io/lettuce/test/settings/TestSettings.java
+++ b/src/test/java/io/lettuce/test/settings/TestSettings.java
@@ -21,10 +21,20 @@ package io.lettuce.test.settings;
 
 import java.net.Inet4Address;
 import java.net.InetAddress;
+import java.net.URI;
 import java.net.UnknownHostException;
+import java.util.List;
+
+import io.lettuce.test.env.Endpoints;
 
 /**
  * This class provides settings used while testing. You can override these using system properties.
+ * <p>
+ * Alternatively, tests can run against externally provisioned databases (e.g. Redis Enterprise) by setting the
+ * {@code TEST_ENV_PROVIDER=re} environment variable. In that mode, host, port, credentials and TLS mode are resolved from the
+ * endpoint configuration file referenced by {@code REDIS_ENDPOINTS_CONFIG_PATH} (see {@link Endpoints}), using the database
+ * named by {@code RE_DB_NAME} (defaults to {@literal standalone}). Explicit system properties always take precedence over the
+ * provider.
  *
  * @author Mark Paluch
  * @author Tugdual Grall
@@ -40,7 +50,11 @@ public class TestSettings {
      *         {@code -Dhost=YourHostName}
      */
     public static String host() {
-        return System.getProperty("host", "localhost");
+        String host = System.getProperty("host");
+        if (host != null) {
+            return host;
+        }
+        return TestEnvProvider.isActive() ? TestEnvProvider.host() : "localhost";
     }
 
     /**
@@ -85,6 +99,9 @@ public class TestSettings {
      * @return default username of your redis instance.
      */
     public static String username() {
+        if (TestEnvProvider.isActive() && TestEnvProvider.username() != null) {
+            return TestEnvProvider.username();
+        }
         return "default";
     }
 
@@ -94,7 +111,11 @@ public class TestSettings {
      *         {@code -Dpassword=YourPassword}
      */
     public static CharSequence password() {
-        return System.getProperty("password", "foobared");
+        String password = System.getProperty("password");
+        if (password != null) {
+            return password;
+        }
+        return TestEnvProvider.isActive() ? TestEnvProvider.password() : "foobared";
     }
 
     /**
@@ -120,7 +141,11 @@ public class TestSettings {
      * @return port of your redis instance. Defaults to {@literal 6479}. Can be overriden with {@code -Dport=1234}
      */
     public static int port() {
-        return Integer.parseInt(System.getProperty("port", "6479"));
+        String port = System.getProperty("port");
+        if (port != null) {
+            return Integer.parseInt(port);
+        }
+        return TestEnvProvider.isActive() ? TestEnvProvider.port() : 6479;
     }
 
     /**
@@ -202,6 +227,127 @@ public class TestSettings {
      */
     public static int mtlsClusterPort() {
         return 7443;
+    }
+
+    /**
+     *
+     * @return hostname of the modules-enabled (JSON, Search, TimeSeries, Bloom) standalone Redis instance. Defaults to
+     *         {@literal 127.0.0.1}. Can be overridden with {@code -Dmodule.host=YourHostName}
+     */
+    public static String moduleHost() {
+        String host = System.getProperty("module.host");
+        if (host != null) {
+            return host;
+        }
+        return TestEnvProvider.isActive() ? TestEnvProvider.host() : "127.0.0.1";
+    }
+
+    /**
+     *
+     * @return port of the modules-enabled (JSON, Search, TimeSeries, Bloom) standalone Redis instance. Defaults to
+     *         {@literal 16379}. Can be overridden with {@code -Dmodule.port=1234}
+     */
+    public static int modulePort() {
+        String port = System.getProperty("module.port");
+        if (port != null) {
+            return Integer.parseInt(port);
+        }
+        return TestEnvProvider.isActive() ? TestEnvProvider.port() : 16379;
+    }
+
+    /**
+     *
+     * @return {@code true} if connections to the default test database require TLS. Always {@code false} unless an external
+     *         test environment provider is active and its endpoint is configured for TLS.
+     */
+    public static boolean tls() {
+        return TestEnvProvider.isActive() && TestEnvProvider.tls();
+    }
+
+    /**
+     *
+     * @return {@code true} if an external test environment provider ({@code TEST_ENV_PROVIDER=re}) is active.
+     */
+    public static boolean isProviderActive() {
+        return TestEnvProvider.isActive();
+    }
+
+    /**
+     * Resolves test endpoint coordinates from an externally provisioned test environment (Redis Enterprise) when
+     * {@code TEST_ENV_PROVIDER=re} is set. The endpoint is looked up in {@link Endpoints#DEFAULT} (loaded from
+     * {@code REDIS_ENDPOINTS_CONFIG_PATH}) under the name given by {@code RE_DB_NAME} (default {@literal standalone}). Fails
+     * fast when the provider is active but the endpoint cannot be resolved.
+     */
+    private static class TestEnvProvider {
+
+        private static final String PROVIDER_RE = "re";
+
+        private static final String PROVIDER = System.getenv("TEST_ENV_PROVIDER");
+
+        private static volatile Endpoints.Endpoint resolvedEndpoint;
+
+        static boolean isActive() {
+            return PROVIDER_RE.equalsIgnoreCase(PROVIDER);
+        }
+
+        static String host() {
+            Endpoints.Endpoint endpoint = endpoint();
+            List<Endpoints.RawEndpoint> rawEndpoints = endpoint.getRawEndpoints();
+            if (rawEndpoints != null && !rawEndpoints.isEmpty() && rawEndpoints.get(0).getDnsName() != null) {
+                return rawEndpoints.get(0).getDnsName();
+            }
+            return URI.create(firstUri(endpoint)).getHost();
+        }
+
+        static int port() {
+            Endpoints.Endpoint endpoint = endpoint();
+            List<Endpoints.RawEndpoint> rawEndpoints = endpoint.getRawEndpoints();
+            if (rawEndpoints != null && !rawEndpoints.isEmpty() && rawEndpoints.get(0).getPort() != 0) {
+                return rawEndpoints.get(0).getPort();
+            }
+            return URI.create(firstUri(endpoint)).getPort();
+        }
+
+        static String username() {
+            return endpoint().getUsername();
+        }
+
+        static String password() {
+            return endpoint().getPassword();
+        }
+
+        static boolean tls() {
+            return endpoint().isTls();
+        }
+
+        private static String firstUri(Endpoints.Endpoint endpoint) {
+            List<String> uris = endpoint.getEndpoints();
+            if (uris == null || uris.isEmpty()) {
+                throw new IllegalStateException(
+                        "Endpoint '" + dbName() + "' defines neither raw_endpoints nor endpoints entries");
+            }
+            return uris.get(0);
+        }
+
+        private static String dbName() {
+            String dbName = System.getenv("RE_DB_NAME");
+            return dbName == null || dbName.isEmpty() ? "standalone" : dbName;
+        }
+
+        private static Endpoints.Endpoint endpoint() {
+            Endpoints.Endpoint endpoint = resolvedEndpoint;
+            if (endpoint == null) {
+                endpoint = Endpoints.DEFAULT.getEndpoint(dbName());
+                if (endpoint == null) {
+                    throw new IllegalStateException("TEST_ENV_PROVIDER=" + PROVIDER + " is set but the endpoint '" + dbName()
+                            + "' cannot be resolved. Verify that REDIS_ENDPOINTS_CONFIG_PATH points to an endpoint "
+                            + "configuration file containing a database named '" + dbName() + "'");
+                }
+                resolvedEndpoint = endpoint;
+            }
+            return endpoint;
+        }
+
     }
 
 }

--- a/src/test/java/io/lettuce/test/settings/TestSettings.java
+++ b/src/test/java/io/lettuce/test/settings/TestSettings.java
@@ -30,31 +30,43 @@ import io.lettuce.test.env.Endpoints;
 /**
  * This class provides settings used while testing. You can override these using system properties.
  * <p>
- * Alternatively, tests can run against externally provisioned databases (e.g. Redis Enterprise) by setting the
- * {@code TEST_ENV_PROVIDER=re} environment variable. In that mode, host, port, credentials and TLS mode are resolved from the
- * endpoint configuration file referenced by {@code REDIS_ENDPOINTS_CONFIG_PATH} (see {@link Endpoints}), using the database
- * named by {@code RE_DB_NAME} (defaults to {@literal standalone}). Explicit system properties always take precedence over the
- * provider.
+ * Endpoint coordinates are resolved from the {@link Endpoints} configuration: the file referenced by the
+ * {@code REDIS_ENDPOINTS_CONFIG_PATH} environment variable, or the bundled {@code endpoints.json} test resource describing the
+ * local Docker environment when the variable is not set. The database name is selected by the {@code RE_DB_NAME} environment
+ * variable (defaults to {@literal standalone}). Explicit system properties always take precedence over the endpoint
+ * configuration. When {@code TEST_ENV_PROVIDER=re} is set (externally provisioned Redis Enterprise databases), resolution fails
+ * fast instead of falling back to the local defaults.
  *
  * @author Mark Paluch
  * @author Tugdual Grall
  */
 public class TestSettings {
 
+    private static final String DEFAULT_DB_NAME = "standalone";
+
+    private static final String MODULES_DB_NAME = "standalone-modules";
+
+    private static final String CLUSTER_DB_NAME = "cluster";
+
     private TestSettings() {
     }
 
     /**
      *
-     * @return hostname of your redis instance. Defaults to {@literal localhost}. Can be overriden with
-     *         {@code -Dhost=YourHostName}
+     * @return hostname of your redis instance. Resolved from the endpoint configuration, defaults to {@literal localhost}. Can
+     *         be overriden with {@code -Dhost=YourHostName}
      */
     public static String host() {
         String host = System.getProperty("host");
         if (host != null) {
             return host;
         }
-        return TestEnvProvider.isActive() ? TestEnvProvider.host() : "localhost";
+        Endpoints.Endpoint endpoint = endpoint();
+        if (endpoint != null) {
+            return EndpointResolver.host(endpoint);
+        }
+        failFastIfExternallyProvisioned(dbName());
+        return "localhost";
     }
 
     /**
@@ -96,26 +108,36 @@ public class TestSettings {
 
     /**
      *
-     * @return default username of your redis instance.
+     * @return default username of your redis instance. Resolved from the endpoint configuration, defaults to
+     *         {@literal default}. Can be overridden with {@code -Dusername=SampleUsername}
      */
     public static String username() {
-        if (TestEnvProvider.isActive() && TestEnvProvider.username() != null) {
-            return TestEnvProvider.username();
+        String username = System.getProperty("username");
+        if (username != null) {
+            return username;
+        }
+        Endpoints.Endpoint endpoint = endpoint();
+        if (endpoint != null && endpoint.getUsername() != null && !endpoint.getUsername().isEmpty()) {
+            return endpoint.getUsername();
         }
         return "default";
     }
 
     /**
      *
-     * @return password of your redis instance. Defaults to {@literal passwd}. Can be overridden with
-     *         {@code -Dpassword=YourPassword}
+     * @return password of your redis instance. Resolved from the endpoint configuration, defaults to {@literal foobared}. Can
+     *         be overridden with {@code -Dpassword=YourPassword}
      */
     public static CharSequence password() {
         String password = System.getProperty("password");
         if (password != null) {
             return password;
         }
-        return TestEnvProvider.isActive() ? TestEnvProvider.password() : "foobared";
+        Endpoints.Endpoint endpoint = endpoint();
+        if (endpoint != null && endpoint.getPassword() != null && !endpoint.getPassword().isEmpty()) {
+            return endpoint.getPassword();
+        }
+        return "foobared";
     }
 
     /**
@@ -138,14 +160,20 @@ public class TestSettings {
 
     /**
      *
-     * @return port of your redis instance. Defaults to {@literal 6479}. Can be overriden with {@code -Dport=1234}
+     * @return port of your redis instance. Resolved from the endpoint configuration, defaults to {@literal 6479}. Can be
+     *         overriden with {@code -Dport=1234}
      */
     public static int port() {
         String port = System.getProperty("port");
         if (port != null) {
             return Integer.parseInt(port);
         }
-        return TestEnvProvider.isActive() ? TestEnvProvider.port() : 6479;
+        Endpoints.Endpoint endpoint = endpoint();
+        if (endpoint != null) {
+            return EndpointResolver.port(endpoint);
+        }
+        failFastIfExternallyProvisioned(dbName());
+        return 6479;
     }
 
     /**
@@ -158,19 +186,24 @@ public class TestSettings {
 
     /**
      *
-     * @return {@link #port()} with added {@literal 500}
+     * @return {@link #localBasePort()} with added {@literal 500}
      */
     public static int nonexistentPort() {
-        return port() + 500;
+        return localBasePort() + 500;
     }
 
     /**
+     * Port offsets address the local Docker test topology only and are never derived from an endpoint configuration.
      *
      * @param offset
-     * @return {@link #port()} with added {@literal offset}
+     * @return the local base port (6479, can be overridden with {@code -Dport=1234}) with added {@literal offset}
      */
     public static int port(int offset) {
-        return port() + offset;
+        return localBasePort() + offset;
+    }
+
+    private static int localBasePort() {
+        return Integer.parseInt(System.getProperty("port", "6479"));
     }
 
     /**
@@ -231,76 +264,127 @@ public class TestSettings {
 
     /**
      *
-     * @return hostname of the modules-enabled (JSON, Search, TimeSeries, Bloom) standalone Redis instance. Defaults to
-     *         {@literal 127.0.0.1}. Can be overridden with {@code -Dmodule.host=YourHostName}
+     * @return hostname of the modules-enabled (JSON, Search, TimeSeries, Bloom) standalone Redis instance. Resolved from the
+     *         {@literal standalone-modules} endpoint (falling back to the default endpoint), defaults to {@literal 127.0.0.1}.
+     *         Can be overridden with {@code -Dmodule.host=YourHostName}
      */
     public static String moduleHost() {
         String host = System.getProperty("module.host");
         if (host != null) {
             return host;
         }
-        return TestEnvProvider.isActive() ? TestEnvProvider.host() : "127.0.0.1";
+        Endpoints.Endpoint endpoint = moduleEndpoint();
+        if (endpoint != null) {
+            return EndpointResolver.host(endpoint);
+        }
+        failFastIfExternallyProvisioned(MODULES_DB_NAME);
+        return "127.0.0.1";
     }
 
     /**
      *
-     * @return port of the modules-enabled (JSON, Search, TimeSeries, Bloom) standalone Redis instance. Defaults to
-     *         {@literal 16379}. Can be overridden with {@code -Dmodule.port=1234}
+     * @return port of the modules-enabled (JSON, Search, TimeSeries, Bloom) standalone Redis instance. Resolved from the
+     *         {@literal standalone-modules} endpoint (falling back to the default endpoint), defaults to {@literal 16379}. Can
+     *         be overridden with {@code -Dmodule.port=1234}
      */
     public static int modulePort() {
         String port = System.getProperty("module.port");
         if (port != null) {
             return Integer.parseInt(port);
         }
-        return TestEnvProvider.isActive() ? TestEnvProvider.port() : 16379;
+        Endpoints.Endpoint endpoint = moduleEndpoint();
+        if (endpoint != null) {
+            return EndpointResolver.port(endpoint);
+        }
+        failFastIfExternallyProvisioned(MODULES_DB_NAME);
+        return 16379;
     }
 
     /**
      *
-     * @return {@code true} if connections to the default test database require TLS. Always {@code false} unless an external
-     *         test environment provider is active and its endpoint is configured for TLS.
+     * @return {@code true} if connections to the default test database require TLS. Resolved from the endpoint configuration,
+     *         defaults to {@code false}. Can be overridden with {@code -Dtls=true}
      */
     public static boolean tls() {
-        return TestEnvProvider.isActive() && TestEnvProvider.tls();
+        String tls = System.getProperty("tls");
+        if (tls != null) {
+            return Boolean.parseBoolean(tls);
+        }
+        Endpoints.Endpoint endpoint = endpoint();
+        return endpoint != null && endpoint.isTls();
     }
 
     /**
      *
-     * @return {@code true} if an external test environment provider ({@code TEST_ENV_PROVIDER=re}) is active.
+     * @return the endpoint of the default test database ({@code RE_DB_NAME}, defaults to {@literal standalone}) or {@code null}
+     *         if the endpoint configuration does not define it.
      */
-    public static boolean isProviderActive() {
-        return TestEnvProvider.isActive();
+    public static Endpoints.Endpoint endpoint() {
+        return EndpointResolver.endpoint(dbName());
     }
 
     /**
-     * Resolves test endpoint coordinates from an externally provisioned test environment (Redis Enterprise) when
-     * {@code TEST_ENV_PROVIDER=re} is set. The endpoint is looked up in {@link Endpoints#DEFAULT} (loaded from
-     * {@code REDIS_ENDPOINTS_CONFIG_PATH}) under the name given by {@code RE_DB_NAME} (default {@literal standalone}). Fails
-     * fast when the provider is active but the endpoint cannot be resolved.
+     *
+     * @return the endpoint of the modules-enabled test database ({@literal standalone-modules}, falling back to the default
+     *         endpoint) or {@code null} if the endpoint configuration defines neither.
      */
-    private static class TestEnvProvider {
+    public static Endpoints.Endpoint moduleEndpoint() {
+        Endpoints.Endpoint endpoint = EndpointResolver.endpoint(MODULES_DB_NAME);
+        return endpoint != null ? endpoint : endpoint();
+    }
 
-        private static final String PROVIDER_RE = "re";
+    /**
+     *
+     * @return the endpoint of the Redis Cluster test database ({@literal cluster}) or {@code null} if the endpoint
+     *         configuration does not define it. Fails fast when an external test environment provider is active.
+     */
+    public static Endpoints.Endpoint clusterEndpoint() {
+        Endpoints.Endpoint endpoint = EndpointResolver.endpoint(CLUSTER_DB_NAME);
+        if (endpoint == null) {
+            failFastIfExternallyProvisioned(CLUSTER_DB_NAME);
+        }
+        return endpoint;
+    }
 
-        private static final String PROVIDER = System.getenv("TEST_ENV_PROVIDER");
+    private static String dbName() {
+        String dbName = System.getenv("RE_DB_NAME");
+        return dbName == null || dbName.isEmpty() ? DEFAULT_DB_NAME : dbName;
+    }
 
-        private static volatile Endpoints.Endpoint resolvedEndpoint;
+    private static void failFastIfExternallyProvisioned(String name) {
+        String provider = System.getenv("TEST_ENV_PROVIDER");
+        if ("re".equalsIgnoreCase(provider)) {
+            throw new IllegalStateException("TEST_ENV_PROVIDER=" + provider + " is set but the endpoint '" + name
+                    + "' cannot be resolved. Verify that REDIS_ENDPOINTS_CONFIG_PATH points to an endpoint "
+                    + "configuration file containing a database named '" + name + "'");
+        }
+    }
 
-        static boolean isActive() {
-            return PROVIDER_RE.equalsIgnoreCase(PROVIDER);
+    /**
+     * Resolves host and port coordinates from an {@link Endpoints.Endpoint}, preferring raw endpoint metadata over the URI
+     * list.
+     */
+    private static class EndpointResolver {
+
+        static Endpoints.Endpoint endpoint(String name) {
+            return Endpoints.DEFAULT.getEndpoint(name);
         }
 
-        static String host() {
-            Endpoints.Endpoint endpoint = endpoint();
+        static String host(Endpoints.Endpoint endpoint) {
             List<Endpoints.RawEndpoint> rawEndpoints = endpoint.getRawEndpoints();
-            if (rawEndpoints != null && !rawEndpoints.isEmpty() && rawEndpoints.get(0).getDnsName() != null) {
-                return rawEndpoints.get(0).getDnsName();
+            if (rawEndpoints != null && !rawEndpoints.isEmpty()) {
+                Endpoints.RawEndpoint rawEndpoint = rawEndpoints.get(0);
+                if (rawEndpoint.getDnsName() != null && !rawEndpoint.getDnsName().isEmpty()) {
+                    return rawEndpoint.getDnsName();
+                }
+                if (rawEndpoint.getAddr() != null && !rawEndpoint.getAddr().isEmpty()) {
+                    return rawEndpoint.getAddr().get(0);
+                }
             }
             return URI.create(firstUri(endpoint)).getHost();
         }
 
-        static int port() {
-            Endpoints.Endpoint endpoint = endpoint();
+        static int port(Endpoints.Endpoint endpoint) {
             List<Endpoints.RawEndpoint> rawEndpoints = endpoint.getRawEndpoints();
             if (rawEndpoints != null && !rawEndpoints.isEmpty() && rawEndpoints.get(0).getPort() != 0) {
                 return rawEndpoints.get(0).getPort();
@@ -308,44 +392,12 @@ public class TestSettings {
             return URI.create(firstUri(endpoint)).getPort();
         }
 
-        static String username() {
-            return endpoint().getUsername();
-        }
-
-        static String password() {
-            return endpoint().getPassword();
-        }
-
-        static boolean tls() {
-            return endpoint().isTls();
-        }
-
         private static String firstUri(Endpoints.Endpoint endpoint) {
             List<String> uris = endpoint.getEndpoints();
             if (uris == null || uris.isEmpty()) {
-                throw new IllegalStateException(
-                        "Endpoint '" + dbName() + "' defines neither raw_endpoints nor endpoints entries");
+                throw new IllegalStateException("Endpoint defines neither raw_endpoints nor endpoints entries");
             }
             return uris.get(0);
-        }
-
-        private static String dbName() {
-            String dbName = System.getenv("RE_DB_NAME");
-            return dbName == null || dbName.isEmpty() ? "standalone" : dbName;
-        }
-
-        private static Endpoints.Endpoint endpoint() {
-            Endpoints.Endpoint endpoint = resolvedEndpoint;
-            if (endpoint == null) {
-                endpoint = Endpoints.DEFAULT.getEndpoint(dbName());
-                if (endpoint == null) {
-                    throw new IllegalStateException("TEST_ENV_PROVIDER=" + PROVIDER + " is set but the endpoint '" + dbName()
-                            + "' cannot be resolved. Verify that REDIS_ENDPOINTS_CONFIG_PATH points to an endpoint "
-                            + "configuration file containing a database named '" + dbName() + "'");
-                }
-                resolvedEndpoint = endpoint;
-            }
-            return endpoint;
         }
 
     }

--- a/src/test/resources/endpoints.json
+++ b/src/test/resources/endpoints.json
@@ -1,0 +1,20 @@
+{
+  "standalone": {
+    "tls": false,
+    "endpoints": [
+      "redis://localhost:6479"
+    ]
+  },
+  "standalone-modules": {
+    "tls": false,
+    "endpoints": [
+      "redis://127.0.0.1:16379"
+    ]
+  },
+  "cluster": {
+    "tls": false,
+    "endpoints": [
+      "redis://127.0.0.1:7379"
+    ]
+  }
+}


### PR DESCRIPTION
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

## Motivation

The Lettuce RE integration nightly in `redis-developer/cae-client-testing` provisions Redis Enterprise databases and publishes their coordinates via `REDIS_ENDPOINTS_CONFIG_PATH`, but the Lettuce test harness had no way to consume them for the main integration suite: `TestSettings` only reads `-D` system properties and defaults to `localhost:6479`, so every `io.lettuce.core.commands.*IntegrationTests` class failed with connection refused before any test body ran.

## Changes

- **`TestSettings`**: opt-in endpoint provider. When `TEST_ENV_PROVIDER=re` is set, `host()`, `port()`, `username()`, `password()` resolve from the endpoint named by `RE_DB_NAME` (default `standalone`) in the configuration file referenced by `REDIS_ENDPOINTS_CONFIG_PATH` (existing `io.lettuce.test.env.Endpoints` loader, already used by the authx/scenario tests). Precedence: explicit `-D` system property > provider > built-in default. Resolution fails fast with a descriptive `IllegalStateException` when the provider is active but the endpoint cannot be resolved — no silent fallback to localhost. With the environment variables absent, behavior is unchanged.
- **`DefaultRedisClient`**: applies TLS (`withSsl`/`withVerifyPeer(false)`) and credentials to the default client when the active provider supplies them.
- **New `@DisabledOnProvider` condition** (modeled on `@EnabledOnCommand`): skips tests that cannot run against an externally provisioned environment, with a visible skip reason. Applied to `GeoMasterReplicaIntegrationTests` (needs master/replica topology), `RunOnlyOnceServerCommandIntegrationTests` (DEBUG SEGFAULT/SHUTDOWN/MIGRATE), `ServerCommandIntegrationTests` (admin commands), and `AclCommandIntegrationTests` (server-side ACL management).
- **New `ModulesTestUri` factory** + `TestSettings.moduleHost()`/`modulePort()` (`-Dmodule.host`/`-Dmodule.port`, default `127.0.0.1:16379`): replaces the hardcoded `127.0.0.1:16379` URIs in `ConsolidatedAclCommandIntegrationTests`, `ConsolidatedConfigurationCommandIntegrationTests` and `CommandInterfacesIntegrationTests`, so the module tests also honor the provider.

## Verification

Against the local Docker environment (Redis 8.10):

- Provider dormant (no env vars): `io.lettuce.core.commands.*IntegrationTests` — 807 tests, no regressions.
- `TEST_ENV_PROVIDER=re` with an endpoints file pointing at the local modules standalone: 807 run, 0 failures, the 4 annotated classes skipped in full with the condition reason.
- Fail-fast: provider active without `REDIS_ENDPOINTS_CONFIG_PATH` → clear `IllegalStateException`.
- `-Dhost`/`-Dport` still override an active provider.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness only: no production client or protocol changes. Local Docker runs stay the default unless TEST_ENV_PROVIDER is set.
> 
> **Overview**
> Integration tests can now target **externally provisioned Redis Enterprise** databases via `TEST_ENV_PROVIDER=re` and `REDIS_ENDPOINTS_CONFIG_PATH`, instead of always using localhost defaults.
> 
> **`TestSettings`** resolves host, port, username, password, and TLS from the endpoints file (`RE_DB_NAME`, default `standalone`), with `-D` system properties still winning. Missing endpoints fail fast when the provider is active; otherwise a bundled `endpoints.json` covers local Docker. Default standalone/cluster clients and a new `ModulesTestUri` apply TLS and credentials from that config. Hardcoded `127.0.0.1:16379` module tests now use that factory.
> 
> New `@DisabledOnProvider("re")` skips suites and methods that need OSS-only admin commands, multi-DB, local sockets, or a full OSS cluster topology (ACL, HOTKEYS, CLIENT PAUSE, cluster setup/topology, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1abd3066655aee40d44db15158b99fd2bced0521. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->