### PR TITLE
Bump Netty to 4.2.17.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <micrometer.version>1.14.2</micrometer.version>
         <micrometer-tracing.version>1.2.4</micrometer-tracing.version>
         <mockito.version>4.9.0</mockito.version>
-        <netty.version>4.2.13.Final</netty.version>
+        <netty.version>4.2.17.Final</netty.version>
         <openwebbeans.version>2.0.27</openwebbeans.version>
         <reactor.version>3.6.6</reactor.version>
         <rxjava.version>1.3.8</rxjava.version>


### PR DESCRIPTION
Upgrades the pinned Netty version from `4.2.13.Final` to `4.2.17.Final` to pick up the transitive-dependency security fixes reported in #3888. The version flows through the `netty-bom`, so this single property change updates every Netty artifact Lettuce consumes.

## Key Decisions & Assumptions
- Chose `4.2.17.Final` (latest) rather than the minimum `4.2.16.Final` from the issue: it covers all listed CVEs and also resolves an `AsciiString.cached()` performance regression present in earlier builds.
- Stays within the same 4.2.x minor line already in use since Lettuce 7.0, so no Netty API or event-loop model migration is involved.
- `netty-tcnative` is intentionally left at `2.0.65.Final` — it uses Netty's separate 2.0.x versioning, is optional, and is not governed by the BOM.

## Notes
- Addresses CVE-2026-45674, -44249, -45416, -47691, -50010, -73508, -45536, -45673 (#3888).
- Runtime-dependency change: the CVEs are transitive and won't surface at compile time, so the full test matrix should be run to confirm no behavioral regression.
- At release time, add a corresponding row to the Netty version-mapping table in `docs/compatibility-roadmap.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Patch-level bump of the core I/O stack (Netty 4.2.x) used for all Redis connections; no API migration, but runtime behavior could still change.
> 
> **Overview**
> Bumps `${netty.version}` from `4.2.13.Final` to `4.2.17.Final`. That property drives the imported `netty-bom`, so every Netty artifact Lettuce consumes (including native epoll/io_uring test deps) moves together.
> 
> Stays on the existing 4.2.x line. `netty-tcnative` is unchanged at `2.0.65.Final`. Intended to address the transitive CVEs in #3888 and an `AsciiString.cached()` regression in earlier 4.2 builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95a7c731850d13aa97df60908cecb0ec5c671919. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->