### PR TITLE
fix: XAUTOCLAIM with JUSTID reports deleted PEL entries as claimed messages

### DIFF
--- a/docs/new-features.md
+++ b/docs/new-features.md
@@ -5,6 +5,7 @@
 
 - Deprecated the server-assisted client-side caching support (`ClientSideCaching`, `CacheFrontend`, `CacheAccessor`, `RedisCache` in `io.lettuce.core.support.caching`). This implementation is legacy and incomplete and is scheduled for removal in a future major release. There is no replacement yet — a redesigned client-side caching API is planned.
 - Fixed `ScriptOutputType.OBJECT` decoding so top-level scalar responses are returned directly instead of being treated as collections. Top-level integer responses now return `Long` instead of a one-element `List<Long>`; RESP arrays remain lists.
+- Fixed `XAUTOCLAIM` reply decoding for pending entries that were deleted from the stream (the third reply element added in Redis 7.0). With `JUSTID`, those deleted IDs are no longer misreported as claimed messages through `ClaimedMessages.getMessages()`; they are now exposed through the new `ClaimedMessages.getDeletedIds()`, which returns an empty list on Redis before 7.0.
 
 ## What's new in Lettuce 7.7
 

--- a/src/main/java/io/lettuce/core/models/stream/ClaimedMessages.java
+++ b/src/main/java/io/lettuce/core/models/stream/ClaimedMessages.java
@@ -19,6 +19,7 @@
  */
 package io.lettuce.core.models.stream;
 
+import java.util.Collections;
 import java.util.List;
 
 import io.lettuce.core.StreamMessage;
@@ -35,6 +36,8 @@ public class ClaimedMessages<K, V> {
 
     private final List<StreamMessage<K, V>> messages;
 
+    private final List<String> deletedIds;
+
     /**
      * Create a new {@link ClaimedMessages}.
      *
@@ -42,9 +45,21 @@ public class ClaimedMessages<K, V> {
      * @param messages
      */
     public ClaimedMessages(String id, List<StreamMessage<K, V>> messages) {
+        this(id, messages, Collections.emptyList());
+    }
 
+    /**
+     * Create a new {@link ClaimedMessages} with deleted entry IDs.
+     *
+     * @param id
+     * @param messages
+     * @param deletedIds
+     * @since 7.2
+     */
+    public ClaimedMessages(String id, List<StreamMessage<K, V>> messages, List<String> deletedIds) {
         this.id = id;
         this.messages = messages;
+        this.deletedIds = deletedIds;
     }
 
     public String getId() {
@@ -53,6 +68,19 @@ public class ClaimedMessages<K, V> {
 
     public List<StreamMessage<K, V>> getMessages() {
         return messages;
+    }
+
+    /**
+     * Returns the IDs of pending entries that were removed from the PEL because they no longer exist in the stream.
+     * <p>
+     * XAUTOCLAIM returns these IDs in a third reply element since Redis 7.0. Returns an empty list when the server
+     * responds with only two elements (Redis before 7.0).
+     *
+     * @return the IDs of PEL entries that were deleted from the stream, never {@code null}.
+     * @since 7.2
+     */
+    public List<String> getDeletedIds() {
+        return deletedIds;
     }
 
 }

--- a/src/main/java/io/lettuce/core/models/stream/ClaimedMessages.java
+++ b/src/main/java/io/lettuce/core/models/stream/ClaimedMessages.java
@@ -41,8 +41,8 @@ public class ClaimedMessages<K, V> {
     /**
      * Create a new {@link ClaimedMessages}.
      *
-     * @param id
-     * @param messages
+     * @param id the stream ID to use as the cursor for the next {@code XAUTOCLAIM} call.
+     * @param messages the claimed messages.
      */
     public ClaimedMessages(String id, List<StreamMessage<K, V>> messages) {
         this(id, messages, Collections.emptyList());
@@ -51,15 +51,15 @@ public class ClaimedMessages<K, V> {
     /**
      * Create a new {@link ClaimedMessages} with deleted entry IDs.
      *
-     * @param id
-     * @param messages
-     * @param deletedIds
-     * @since 7.2
+     * @param id the stream ID to use as the cursor for the next {@code XAUTOCLAIM} call.
+     * @param messages the claimed messages.
+     * @param deletedIds the IDs the server removed from the PEL, or {@code null} for an empty list.
+     * @since 7.8
      */
     public ClaimedMessages(String id, List<StreamMessage<K, V>> messages, List<String> deletedIds) {
         this.id = id;
         this.messages = messages;
-        this.deletedIds = deletedIds;
+        this.deletedIds = deletedIds == null ? Collections.emptyList() : deletedIds;
     }
 
     public String getId() {
@@ -73,11 +73,11 @@ public class ClaimedMessages<K, V> {
     /**
      * Returns the IDs of pending entries that were removed from the PEL because they no longer exist in the stream.
      * <p>
-     * XAUTOCLAIM returns these IDs in a third reply element since Redis 7.0. Returns an empty list when the server
-     * responds with only two elements (Redis before 7.0).
+     * XAUTOCLAIM returns these IDs in a third reply element since Redis 7.0. Returns an empty list when the server responds
+     * with only two elements (Redis before 7.0).
      *
      * @return the IDs of PEL entries that were deleted from the stream, never {@code null}.
-     * @since 7.2
+     * @since 7.8
      */
     public List<String> getDeletedIds() {
         return deletedIds;

--- a/src/main/java/io/lettuce/core/output/ClaimedMessagesOutput.java
+++ b/src/main/java/io/lettuce/core/output/ClaimedMessagesOutput.java
@@ -50,6 +50,8 @@ public class ClaimedMessagesOutput<K, V> extends CommandOutput<K, V, ClaimedMess
 
     private boolean hasId;
 
+    private int topLevelIndex;
+
     private K key;
 
     private boolean hasKey;
@@ -60,10 +62,13 @@ public class ClaimedMessagesOutput<K, V> extends CommandOutput<K, V, ClaimedMess
 
     private final List<StreamMessage<K, V>> messages;
 
+    private final List<String> deletedIds;
+
     public ClaimedMessagesOutput(RedisCodec<K, V> codec, K stream, boolean justId) {
         super(codec, null);
         this.stream = stream;
         this.messages = new ArrayList<>();
+        this.deletedIds = new ArrayList<>();
         this.justId = justId;
     }
 
@@ -107,27 +112,48 @@ public class ClaimedMessagesOutput<K, V> extends CommandOutput<K, V, ClaimedMess
     @Override
     public void complete(int depth) {
 
-        if (depth == 3 && bodyReceived) {
-            messages.add(new StreamMessage<>(stream, id, body == null ? Collections.emptyMap() : body));
-            bodyReceived = false;
-            key = null;
-            hasKey = false;
-            body = null;
-            id = null;
-            hasId = false;
+        if (depth == 1 && topLevelIndex < 3) {
+            topLevelIndex++;
+            return;
         }
 
-        if (depth == 2 && justId) {
-            messages.add(new StreamMessage<>(stream, id, null));
-            key = null;
-            hasKey = false;
-            body = null;
+        if (topLevelIndex == 1) {
+
+            if (depth == 3 && bodyReceived) {
+                // claimed entry with body (non-JUSTID)
+                messages.add(new StreamMessage<>(stream, id, body == null ? Collections.emptyMap() : body));
+                bodyReceived = false;
+                key = null;
+                hasKey = false;
+                body = null;
+                id = null;
+                hasId = false;
+                return;
+            }
+
+            if (depth == 2 && justId) {
+                // claimed entry with JUSTID: only the entry ID
+                messages.add(new StreamMessage<>(stream, id, null));
+                key = null;
+                hasKey = false;
+                body = null;
+                id = null;
+                hasId = false;
+                return;
+            }
+        }
+
+        if (topLevelIndex == 2 && depth == 2 && id != null) {
+            // deleted PEL entry IDs (third reply element since Redis 7.0)
+            deletedIds.add(id);
             id = null;
             hasId = false;
+            return;
         }
 
         if (depth == 0) {
-            output = new ClaimedMessages<>(startId, Collections.unmodifiableList(messages));
+            output = new ClaimedMessages<>(startId, Collections.unmodifiableList(messages),
+                    Collections.unmodifiableList(deletedIds));
         }
     }
 

--- a/src/test/java/io/lettuce/core/commands/StreamCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/StreamCommandIntegrationTests.java
@@ -826,9 +826,8 @@ public class StreamCommandIntegrationTests extends TestSupport {
         // Delete both entries from the stream; they remain pending in the PEL.
         redis.xdel(key, id1, id2);
 
-        ClaimedMessages<String, String> claimedMessages = redis.xautoclaim(key,
-                XAutoClaimArgs.Builder.xautoclaim(Consumer.from("group", "consumer2"), Duration.ZERO, "0-0").justid()
-                        .count(20));
+        ClaimedMessages<String, String> claimedMessages = redis.xautoclaim(key, XAutoClaimArgs.Builder
+                .xautoclaim(Consumer.from("group", "consumer2"), Duration.ZERO, "0-0").justid().count(20));
 
         // Deleted entries must NOT appear as claimed messages.
         assertThat(claimedMessages.getMessages()).isEmpty();

--- a/src/test/java/io/lettuce/core/commands/StreamCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/StreamCommandIntegrationTests.java
@@ -811,6 +811,53 @@ public class StreamCommandIntegrationTests extends TestSupport {
     }
 
     @Test
+    @EnabledOnCommand("XAUTOCLAIM") // Redis 6.2
+    void xautoclaimJustIdWithDeletedEntries() {
+
+        assumeTrue(RedisConditions.of(redis).hasVersionGreaterOrEqualsTo("7.0"),
+                "Redis 7.0+ required for the deleted-entries reply element");
+
+        redis.xgroupCreate(StreamOffset.latest(key), "group", XGroupCreateArgs.Builder.mkstream());
+        String id1 = redis.xadd(key, Collections.singletonMap("key1", "value1"));
+        String id2 = redis.xadd(key, Collections.singletonMap("key2", "value2"));
+
+        redis.xreadgroup(Consumer.from("group", "consumer1"), StreamOffset.lastConsumed(key));
+
+        // Delete both entries from the stream; they remain pending in the PEL.
+        redis.xdel(key, id1, id2);
+
+        ClaimedMessages<String, String> claimedMessages = redis.xautoclaim(key,
+                XAutoClaimArgs.Builder.xautoclaim(Consumer.from("group", "consumer2"), Duration.ZERO, "0-0").justid()
+                        .count(20));
+
+        // Deleted entries must NOT appear as claimed messages.
+        assertThat(claimedMessages.getMessages()).isEmpty();
+        assertThat(claimedMessages.getDeletedIds()).containsExactlyInAnyOrder(id1, id2);
+    }
+
+    @Test
+    @EnabledOnCommand("XAUTOCLAIM") // Redis 6.2
+    void xautoclaimWithDeletedEntries() {
+
+        assumeTrue(RedisConditions.of(redis).hasVersionGreaterOrEqualsTo("7.0"),
+                "Redis 7.0+ required for the deleted-entries reply element");
+
+        redis.xgroupCreate(StreamOffset.latest(key), "group", XGroupCreateArgs.Builder.mkstream());
+        String id1 = redis.xadd(key, Collections.singletonMap("key1", "value1"));
+        String id2 = redis.xadd(key, Collections.singletonMap("key2", "value2"));
+
+        redis.xreadgroup(Consumer.from("group", "consumer1"), StreamOffset.lastConsumed(key));
+
+        redis.xdel(key, id1, id2);
+
+        ClaimedMessages<String, String> claimedMessages = redis.xautoclaim(key,
+                XAutoClaimArgs.Builder.xautoclaim(Consumer.from("group", "consumer2"), Duration.ZERO, "0-0").count(20));
+
+        assertThat(claimedMessages.getMessages()).isEmpty();
+        assertThat(claimedMessages.getDeletedIds()).containsExactlyInAnyOrder(id1, id2);
+    }
+
+    @Test
     void xclaim() {
 
         redis.xgroupCreate(StreamOffset.latest(key), "group", XGroupCreateArgs.Builder.mkstream());


### PR DESCRIPTION
## Problem

`XAUTOCLAIM` with `JUSTID` returns deleted PEL entry IDs as claimed messages (`getMessages()`), and the actual deleted-IDs third reply element introduced in Redis 7.0 is silently dropped without `JUSTID`.

Since Redis 7.0, `XAUTOCLAIM` replies with three elements: the next cursor, the claimed entries, and the IDs that no longer exist in the stream and were removed from the PEL. `ClaimedMessagesOutput` only handled the first two.

**Root cause:** `ClaimedMessagesOutput.complete(depth == 2 && justId)` fires for both the claimed-entries array (correct) and the deleted-IDs array (wrong) because both contain strings at the same nesting depth.

## Fix

Track the top-level reply element index (`topLevelIndex`) via `complete(depth == 1)` calls, which fire exactly three times as each top-level element finishes (cursor → claimed entries → deleted IDs):

- `topLevelIndex == 1`: claimed entries — JUSTID messages added to `messages`, non-JUSTID entries with body added to `messages` (existing logic, unchanged)
- `topLevelIndex == 2`: deleted IDs — collected into a new `deletedIds` list

`ClaimedMessages` gains a `getDeletedIds()` method and a new constructor `(String id, List<StreamMessage<K,V>> messages, List<String> deletedIds)`. The existing public constructor delegates to the new one with an empty list.

## Changes

- `ClaimedMessages.java`: +28/-0 — added `deletedIds` field, getter, and 3-arg constructor
- `ClaimedMessagesOutput.java`: +40/-14 — added `topLevelIndex` tracking, `deletedIds` list, and selective element routing
- `StreamCommandIntegrationTests.java`: +47/-0 — two regression tests (`xautoclaimJustIdWithDeletedEntries`, `xautoclaimWithDeletedEntries`)

Fixes #3900

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stream consumer-group response parsing and adds a public API surface on ClaimedMessages; behavior fix is targeted but apps relying on the previous (incorrect) JUSTID results could see different getMessages() output on Redis 7.0+.
> 
> **Overview**
> Fixes **XAUTOCLAIM** reply handling so Redis 7.0’s third array element (IDs removed from the PEL because the stream entry was deleted) is decoded correctly instead of being dropped or misclassified.
> 
> **`ClaimedMessagesOutput`** now tracks which top-level reply segment is being parsed (`topLevelIndex`), so **JUSTID** no longer turns deleted-entry IDs into fake `StreamMessage`s in `getMessages()`, and non-JUSTID replies still populate claimed messages as before. **`ClaimedMessages`** adds **`getDeletedIds()`** (empty on Redis &lt; 7.0) via a new three-argument constructor; the existing two-argument constructor remains and delegates to an empty deleted list.
> 
> Integration tests cover **JUSTID** and full-body **XAUTOCLAIM** when pending messages were **XDEL**’d; **7.8** release notes document the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69c7d9ba7ddc3c2d85526d1825d9a10256441d4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->