### PR TITLE
Fix XAUTOCLAIM decoding of deleted PEL entries and expose the deleted ids

### DIFF
--- a/docs/new-features.md
+++ b/docs/new-features.md
@@ -5,6 +5,7 @@
 
 - Deprecated the server-assisted client-side caching support (`ClientSideCaching`, `CacheFrontend`, `CacheAccessor`, `RedisCache` in `io.lettuce.core.support.caching`). This implementation is legacy and incomplete and is scheduled for removal in a future major release. There is no replacement yet — a redesigned client-side caching API is planned.
 - Fixed `ScriptOutputType.OBJECT` decoding so top-level scalar responses are returned directly instead of being treated as collections. Top-level integer responses now return `Long` instead of a one-element `List<Long>`; RESP arrays remain lists.
+- Fixed [`XAUTOCLAIM`](https://redis.io/docs/latest/commands/xautoclaim/) decoding so the ids that Redis 7.0 and later report as removed from the Pending Entries List are no longer returned as claimed messages when `JUSTID` is used. These ids are now available through `ClaimedMessages.getDeletedIds()`.
 
 ## What's new in Lettuce 7.7
 

--- a/src/main/java/io/lettuce/core/models/stream/ClaimedMessages.java
+++ b/src/main/java/io/lettuce/core/models/stream/ClaimedMessages.java
@@ -19,6 +19,7 @@
  */
 package io.lettuce.core.models.stream;
 
+import java.util.Collections;
 import java.util.List;
 
 import io.lettuce.core.StreamMessage;
@@ -27,6 +28,7 @@ import io.lettuce.core.StreamMessage;
  * Value object representing the claimed messages reported through {@code XAUTOCLAIM}.
  *
  * @author dengliming
+ * @author big-cir
  * @since 6.1
  */
 public class ClaimedMessages<K, V> {
@@ -35,16 +37,32 @@ public class ClaimedMessages<K, V> {
 
     private final List<StreamMessage<K, V>> messages;
 
+    private final List<String> deletedIds;
+
     /**
-     * Create a new {@link ClaimedMessages}.
+     * Create a new {@link ClaimedMessages} without deleted message ids.
      *
      * @param id
      * @param messages
      */
     public ClaimedMessages(String id, List<StreamMessage<K, V>> messages) {
+        this(id, messages, Collections.emptyList());
+    }
+
+    /**
+     * Create a new {@link ClaimedMessages}.
+     *
+     * @param id
+     * @param messages
+     * @param deletedIds message ids that no longer exist in the stream and were removed from the Pending Entries List. May be
+     *        {@code null} in which case an empty list is used.
+     * @since 7.8
+     */
+    public ClaimedMessages(String id, List<StreamMessage<K, V>> messages, List<String> deletedIds) {
 
         this.id = id;
         this.messages = messages;
+        this.deletedIds = deletedIds == null ? Collections.emptyList() : deletedIds;
     }
 
     public String getId() {
@@ -53,6 +71,18 @@ public class ClaimedMessages<K, V> {
 
     public List<StreamMessage<K, V>> getMessages() {
         return messages;
+    }
+
+    /**
+     * Message ids that were reported by the server as no longer existing in the stream. Redis removes these from the Pending
+     * Entries List instead of claiming them. Empty when running against Redis versions before 7.0 as these do not report the
+     * deleted ids.
+     *
+     * @return the deleted message ids, never {@code null}.
+     * @since 7.8
+     */
+    public List<String> getDeletedIds() {
+        return deletedIds;
     }
 
 }

--- a/src/main/java/io/lettuce/core/output/ClaimedMessagesOutput.java
+++ b/src/main/java/io/lettuce/core/output/ClaimedMessagesOutput.java
@@ -75,10 +75,13 @@ public class ClaimedMessagesOutput<K, V> extends CommandOutput<K, V, ClaimedMess
 
     private final List<StreamMessage<K, V>> messages;
 
+    private final List<String> deletedIds;
+
     public ClaimedMessagesOutput(RedisCodec<K, V> codec, K stream, boolean justId) {
         super(codec, null);
         this.stream = stream;
         this.messages = new ArrayList<>();
+        this.deletedIds = new ArrayList<>();
         this.justId = justId;
     }
 
@@ -91,6 +94,7 @@ public class ClaimedMessagesOutput<K, V> extends CommandOutput<K, V, ClaimedMess
         }
 
         if (topLevelElement == DELETED_IDS) {
+            deletedIds.add(decodeString(bytes));
             return;
         }
 
@@ -154,7 +158,8 @@ public class ClaimedMessagesOutput<K, V> extends CommandOutput<K, V, ClaimedMess
         }
 
         if (depth == 0) {
-            output = new ClaimedMessages<>(startId, Collections.unmodifiableList(messages));
+            output = new ClaimedMessages<>(startId, Collections.unmodifiableList(messages),
+                    Collections.unmodifiableList(deletedIds));
         }
     }
 

--- a/src/main/java/io/lettuce/core/output/ClaimedMessagesOutput.java
+++ b/src/main/java/io/lettuce/core/output/ClaimedMessagesOutput.java
@@ -36,13 +36,28 @@ import io.lettuce.core.models.stream.ClaimedMessages;
  * @param <K> Key type.
  * @param <V> Value type.
  * @author dengliming
+ * @author big-cir
  * @since 6.1
  */
 public class ClaimedMessagesOutput<K, V> extends CommandOutput<K, V, ClaimedMessages<K, V>> {
 
+    /**
+     * Top-level reply elements of {@code XAUTOCLAIM}: the cursor, the claimed entries and, since Redis 7.0, the ids that were
+     * removed from the Pending Entries List because they no longer exist in the stream. Each element completes at depth one, so
+     * the index tells apart values that share a nesting depth: claimed entry ids reported through {@code JUSTID} and deleted
+     * ids both arrive as strings completing at depth two.
+     */
+    private static final int CURSOR = 0;
+
+    private static final int CLAIMED_ENTRIES = 1;
+
+    private static final int DELETED_IDS = 2;
+
     private final boolean justId;
 
     private final K stream;
+
+    private int topLevelElement = CURSOR;
 
     private String startId;
 
@@ -69,8 +84,13 @@ public class ClaimedMessagesOutput<K, V> extends CommandOutput<K, V, ClaimedMess
 
     @Override
     public void set(ByteBuffer bytes) {
-        if (startId == null) {
+
+        if (topLevelElement == CURSOR) {
             startId = decodeString(bytes);
+            return;
+        }
+
+        if (topLevelElement == DELETED_IDS) {
             return;
         }
 
@@ -107,23 +127,30 @@ public class ClaimedMessagesOutput<K, V> extends CommandOutput<K, V, ClaimedMess
     @Override
     public void complete(int depth) {
 
-        if (depth == 3 && bodyReceived) {
-            messages.add(new StreamMessage<>(stream, id, body == null ? Collections.emptyMap() : body));
-            bodyReceived = false;
-            key = null;
-            hasKey = false;
-            body = null;
-            id = null;
-            hasId = false;
+        if (topLevelElement == CLAIMED_ENTRIES) {
+
+            if (depth == 3 && bodyReceived) {
+                messages.add(new StreamMessage<>(stream, id, body == null ? Collections.emptyMap() : body));
+                bodyReceived = false;
+                key = null;
+                hasKey = false;
+                body = null;
+                id = null;
+                hasId = false;
+            }
+
+            if (depth == 2 && justId) {
+                messages.add(new StreamMessage<>(stream, id, null));
+                key = null;
+                hasKey = false;
+                body = null;
+                id = null;
+                hasId = false;
+            }
         }
 
-        if (depth == 2 && justId) {
-            messages.add(new StreamMessage<>(stream, id, null));
-            key = null;
-            hasKey = false;
-            body = null;
-            id = null;
-            hasId = false;
+        if (depth == 1) {
+            topLevelElement++;
         }
 
         if (depth == 0) {

--- a/src/test/java/io/lettuce/core/commands/StreamCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/StreamCommandIntegrationTests.java
@@ -60,6 +60,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  *
  * @author Mark Paluch
  * @author dengliming
+ * @author big-cir
  */
 @ExtendWith(LettuceExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -808,6 +809,50 @@ public class StreamCommandIntegrationTests extends TestSupport {
         assertThat(message.getBody()).isNull();
         assertThat(message.getStream()).isEqualTo(key);
         assertThat(message.getId()).isEqualTo(id1);
+    }
+
+    // XAUTOCLAIM reports ids that no longer exist in the stream in a third reply element - Redis 7.0
+
+    private void assumeDeletedIdsReply() {
+        assumeTrue(RedisConditions.of(redis).hasVersionGreaterOrEqualsTo("7.0"),
+                "Redis 7.0+ required for the XAUTOCLAIM deleted ids reply element");
+    }
+
+    @Test
+    @EnabledOnCommand("XAUTOCLAIM") // Redis 6.2
+    void xautoclaimWithDeletedEntries() {
+        assumeDeletedIdsReply();
+
+        redis.xgroupCreate(StreamOffset.latest(key), "group", XGroupCreateArgs.Builder.mkstream());
+        String id1 = redis.xadd(key, Collections.singletonMap("key1", "value1"));
+        String id2 = redis.xadd(key, Collections.singletonMap("key2", "value2"));
+
+        redis.xreadgroup(Consumer.from("group", "consumer1"), StreamOffset.lastConsumed(key));
+        redis.xdel(key, id1);
+
+        ClaimedMessages<String, String> claimedMessages = redis.xautoclaim(key,
+                XAutoClaimArgs.Builder.xautoclaim(Consumer.from("group", "consumer2"), Duration.ZERO, "0"));
+
+        assertThat(claimedMessages.getMessages()).hasSize(1);
+        assertThat(claimedMessages.getMessages().get(0).getId()).isEqualTo(id2);
+    }
+
+    @Test
+    @EnabledOnCommand("XAUTOCLAIM") // Redis 6.2
+    void xautoclaimJustIdWithDeletedEntries() {
+        assumeDeletedIdsReply();
+
+        redis.xgroupCreate(StreamOffset.latest(key), "group", XGroupCreateArgs.Builder.mkstream());
+        String id1 = redis.xadd(key, Collections.singletonMap("key1", "value1"));
+        String id2 = redis.xadd(key, Collections.singletonMap("key2", "value2"));
+
+        redis.xreadgroup(Consumer.from("group", "consumer1"), StreamOffset.lastConsumed(key));
+        redis.xdel(key, id1, id2);
+
+        ClaimedMessages<String, String> claimedMessages = redis.xautoclaim(key,
+                XAutoClaimArgs.Builder.xautoclaim(Consumer.from("group", "consumer2"), Duration.ZERO, "0").justid());
+
+        assertThat(claimedMessages.getMessages()).isEmpty();
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/commands/StreamCommandIntegrationTests.java
+++ b/src/test/java/io/lettuce/core/commands/StreamCommandIntegrationTests.java
@@ -833,6 +833,7 @@ public class StreamCommandIntegrationTests extends TestSupport {
         ClaimedMessages<String, String> claimedMessages = redis.xautoclaim(key,
                 XAutoClaimArgs.Builder.xautoclaim(Consumer.from("group", "consumer2"), Duration.ZERO, "0"));
 
+        assertThat(claimedMessages.getDeletedIds()).containsExactly(id1);
         assertThat(claimedMessages.getMessages()).hasSize(1);
         assertThat(claimedMessages.getMessages().get(0).getId()).isEqualTo(id2);
     }
@@ -853,6 +854,7 @@ public class StreamCommandIntegrationTests extends TestSupport {
                 XAutoClaimArgs.Builder.xautoclaim(Consumer.from("group", "consumer2"), Duration.ZERO, "0").justid());
 
         assertThat(claimedMessages.getMessages()).isEmpty();
+        assertThat(claimedMessages.getDeletedIds()).containsExactly(id1, id2);
     }
 
     @Test

--- a/src/test/java/io/lettuce/core/output/ClaimedMessagesOutputUnitTests.java
+++ b/src/test/java/io/lettuce/core/output/ClaimedMessagesOutputUnitTests.java
@@ -60,6 +60,7 @@ class ClaimedMessagesOutputUnitTests {
         ClaimedMessages<String, String> claimed = sut.get();
 
         assertThat(claimed.getId()).isEqualTo("0-0");
+        assertThat(claimed.getDeletedIds()).containsExactly("1234-2", "1234-3");
         assertThat(claimed.getMessages()).hasSize(1);
 
         StreamMessage<String, String> message = claimed.getMessages().get(0);
@@ -91,6 +92,7 @@ class ClaimedMessagesOutputUnitTests {
         ClaimedMessages<String, String> claimed = sut.get();
 
         assertThat(claimed.getId()).isEqualTo("0-0");
+        assertThat(claimed.getDeletedIds()).containsExactly("1234-2", "1234-3");
         assertThat(claimed.getMessages()).hasSize(1);
         assertThat(claimed.getMessages().get(0).getId()).isEqualTo("1234-1");
         assertThat(claimed.getMessages().get(0).getBody()).isNull();
@@ -118,6 +120,7 @@ class ClaimedMessagesOutputUnitTests {
 
         assertThat(claimed.getId()).isEqualTo("0-0");
         assertThat(claimed.getMessages()).isEmpty();
+        assertThat(claimed.getDeletedIds()).containsExactly("1234-1", "1234-2");
     }
 
     @Test
@@ -145,6 +148,7 @@ class ClaimedMessagesOutputUnitTests {
         ClaimedMessages<String, String> claimed = sut.get();
 
         assertThat(claimed.getId()).isEqualTo("0-0");
+        assertThat(claimed.getDeletedIds()).isEmpty();
         assertThat(claimed.getMessages()).hasSize(1);
         assertThat(claimed.getMessages().get(0).getBody()).containsEntry("key", "value");
     }

--- a/src/test/java/io/lettuce/core/output/ClaimedMessagesOutputUnitTests.java
+++ b/src/test/java/io/lettuce/core/output/ClaimedMessagesOutputUnitTests.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026-Present, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ */
+package io.lettuce.core.output;
+
+import static io.lettuce.TestTags.UNIT_TEST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.lettuce.core.StreamMessage;
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.models.stream.ClaimedMessages;
+
+/**
+ * Unit tests for {@link ClaimedMessagesOutput}.
+ * <p>
+ * The call sequences replay actual {@code XAUTOCLAIM} replies. Redis 7.0 and later reply with three top-level elements (cursor,
+ * claimed entries, deleted ids), Redis 6.2 replies with two. The nesting is identical under RESP2 and RESP3.
+ *
+ * @author big-cir
+ */
+@Tag(UNIT_TEST)
+class ClaimedMessagesOutputUnitTests {
+
+    @Test
+    void shouldDecodeClaimedEntries() {
+
+        ClaimedMessagesOutput<String, String> sut = new ClaimedMessagesOutput<>(StringCodec.UTF8, "stream-key", false);
+
+        sut.multi(3);
+        sut.set(buffer("0-0"));
+        sut.complete(1);
+        sut.multi(1);
+        sut.multi(2);
+        sut.set(buffer("1234-1"));
+        sut.complete(3);
+        sut.multi(2);
+        sut.set(buffer("key"));
+        sut.complete(4);
+        sut.set(buffer("value"));
+        sut.complete(4);
+        sut.complete(3);
+        sut.complete(2);
+        sut.complete(1);
+        sut.multi(2);
+        sut.set(buffer("1234-2"));
+        sut.complete(2);
+        sut.set(buffer("1234-3"));
+        sut.complete(2);
+        sut.complete(1);
+        sut.complete(0);
+
+        ClaimedMessages<String, String> claimed = sut.get();
+
+        assertThat(claimed.getId()).isEqualTo("0-0");
+        assertThat(claimed.getMessages()).hasSize(1);
+
+        StreamMessage<String, String> message = claimed.getMessages().get(0);
+        assertThat(message.getStream()).isEqualTo("stream-key");
+        assertThat(message.getId()).isEqualTo("1234-1");
+        assertThat(message.getBody()).hasSize(1).containsEntry("key", "value");
+    }
+
+    @Test
+    void shouldDecodeClaimedIdsWithJustId() {
+
+        ClaimedMessagesOutput<String, String> sut = new ClaimedMessagesOutput<>(StringCodec.UTF8, "stream-key", true);
+
+        sut.multi(3);
+        sut.set(buffer("0-0"));
+        sut.complete(1);
+        sut.multi(1);
+        sut.set(buffer("1234-1"));
+        sut.complete(2);
+        sut.complete(1);
+        sut.multi(2);
+        sut.set(buffer("1234-2"));
+        sut.complete(2);
+        sut.set(buffer("1234-3"));
+        sut.complete(2);
+        sut.complete(1);
+        sut.complete(0);
+
+        ClaimedMessages<String, String> claimed = sut.get();
+
+        assertThat(claimed.getId()).isEqualTo("0-0");
+        assertThat(claimed.getMessages()).hasSize(1);
+        assertThat(claimed.getMessages().get(0).getId()).isEqualTo("1234-1");
+        assertThat(claimed.getMessages().get(0).getBody()).isNull();
+    }
+
+    @Test
+    void shouldNotReportDeletedIdsAsClaimedMessagesWithJustId() {
+
+        ClaimedMessagesOutput<String, String> sut = new ClaimedMessagesOutput<>(StringCodec.UTF8, "stream-key", true);
+
+        sut.multi(3);
+        sut.set(buffer("0-0"));
+        sut.complete(1);
+        sut.multi(0);
+        sut.complete(1);
+        sut.multi(2);
+        sut.set(buffer("1234-1"));
+        sut.complete(2);
+        sut.set(buffer("1234-2"));
+        sut.complete(2);
+        sut.complete(1);
+        sut.complete(0);
+
+        ClaimedMessages<String, String> claimed = sut.get();
+
+        assertThat(claimed.getId()).isEqualTo("0-0");
+        assertThat(claimed.getMessages()).isEmpty();
+    }
+
+    @Test
+    void shouldDecodeReplyWithoutDeletedIdsElement() {
+
+        ClaimedMessagesOutput<String, String> sut = new ClaimedMessagesOutput<>(StringCodec.UTF8, "stream-key", false);
+
+        sut.multi(2);
+        sut.set(buffer("0-0"));
+        sut.complete(1);
+        sut.multi(1);
+        sut.multi(2);
+        sut.set(buffer("1234-1"));
+        sut.complete(3);
+        sut.multi(2);
+        sut.set(buffer("key"));
+        sut.complete(4);
+        sut.set(buffer("value"));
+        sut.complete(4);
+        sut.complete(3);
+        sut.complete(2);
+        sut.complete(1);
+        sut.complete(0);
+
+        ClaimedMessages<String, String> claimed = sut.get();
+
+        assertThat(claimed.getId()).isEqualTo("0-0");
+        assertThat(claimed.getMessages()).hasSize(1);
+        assertThat(claimed.getMessages().get(0).getBody()).containsEntry("key", "value");
+    }
+
+    private static ByteBuffer buffer(String value) {
+        return ByteBuffer.wrap(value.getBytes());
+    }
+
+}


### PR DESCRIPTION
Since Redis 7.0 `XAUTOCLAIM` replies with three top-level elements: the next cursor, the claimed entries, and the ids that no longer exist in the stream and were therefore removed from the Pending Entries List. `ClaimedMessagesOutput` handled only the first two and branched on nesting depth alone. Claimed entry ids reported through `JUSTID` and deleted ids both arrive as strings that complete at depth two, so the decoder could not tell them apart: a `JUSTID` reply reported the deleted ids as claimed messages, and a reply without `JUSTID` dropped them.

With two pending entries deleted by `XDEL`, the server replies:

```
127.0.0.1:6379> XAUTOCLAIM s g c2 0 0 JUSTID
1) "0-0"
2) (empty array)
3) 1) "1787564443438-0"
   2) "1787564443439-0"
```

Before this change Lettuce turned those two ids into claimed messages:

```
[JUSTID] cursor   = 0-0
[JUSTID] messages = [StreamMessage[s:1787564443438-0]null, StreamMessage[s:1787564443439-0]null]
```

No exception was raised, so callers processed messages that no longer exist and counted them as claimed. `JUSTID` is the mode cleanup jobs tend to use, since it leaves the delivery counter untouched.

### How the reply is decoded

To avoid guessing at the nesting, I recorded the decoder calls by dispatching `XAUTOCLAIM` with a `CommandOutput` that logs `multi`, `set` and `complete`. The shape is identical under RESP2 and RESP3, and every top-level element completes at depth one:

```
multi(3)
  set("0-0")               complete(1)     cursor
  multi(1)  ...entries...  complete(1)     claimed entries
  multi(2)  ...ids...      complete(1)     deleted ids
complete(0)
```

The fix tracks the index of the top-level element being decoded, so the cursor, the claimed entries and the deleted ids are routed separately and the `JUSTID` branch fires only while the claimed entries are read.

### Deleted ids

They are collected and exposed through `ClaimedMessages.getDeletedIds()`. The existing two-argument constructor delegates to a new one, and a reply with only two elements yields an empty list, so Redis 6.2 keeps working unchanged.

The change is split into two commits: the first fixes the decoding without touching public API, the second adds the accessor. If exposing the deleted ids should stay out of scope for now, dropping the second commit leaves the fix intact.

### Testing

`ClaimedMessagesOutputUnitTests` replays the recorded call sequences without a server, including a two-element reply. Two integration tests were added to the base stream test class and gated on Redis 7.0, so the RESP2, cluster, reactive and transactional overloads pick them up.

Reverting only the decoder change fails three of the four unit tests, the `JUSTID` one with:

```
Expecting empty but was: [StreamMessage[stream-key:1234-1]null, StreamMessage[stream-key:1234-2]null]
```

Verified locally against Redis 8.2 on JDK 17: the new unit tests, the API consistency suite (222 tests, no interface changes), and `StreamCommandIntegrationTests#xautoclaim*` together with its RESP2 overload. I have no JDK 8 available locally, so the CI matrix will have to confirm that toolchain.

Fixes #3900

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/lettuce-io/lettuce-core/blob/main/.github/CONTRIBUTING.md).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request. Reported as #3900.
- [x] You applied code formatting rules using the `mvn formatter:format` target. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stream consumer-group decoding semantics for XAUTOCLAIM on Redis 7.0+; behavior fix may surprise code that relied on bogus JUSTID “claimed” messages, but existing two-arg ClaimedMessages usage remains compatible.
> 
> **Overview**
> Fixes **XAUTOCLAIM** response handling for Redis 7.0+, where the reply has three top-level parts (cursor, claimed entries, and ids removed from the PEL because the stream entries were deleted). The decoder used nesting depth only, so **JUSTID** mode wrongly treated deleted ids as claimed `StreamMessage`s with null bodies—silent data corruption for typical PEL cleanup jobs.
> 
> **`ClaimedMessagesOutput`** now tracks which top-level segment is being parsed so cursor, claimed entries, and deleted ids are routed separately; **JUSTID** handling runs only in the claimed-entries segment. Two-element replies (Redis 6.2) still decode as before.
> 
> **`ClaimedMessages`** gains **`getDeletedIds()`** (and a delegating 3-arg constructor) so callers can see which pending ids Redis dropped from the PEL. Release notes and unit/integration tests cover the decoder and Redis 7.0+ behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59dc1c788ad8c25c8523085f9fcb2568e3c3b04d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->